### PR TITLE
Use prod ECR registry in READMEs

### DIFF
--- a/projects/aws/eks-anywhere-build-tooling/README.md
+++ b/projects/aws/eks-anywhere-build-tooling/README.md
@@ -4,4 +4,4 @@
 
 The EKS-A CLI tools image is packaged with the executables that are invoked by the `eks-a` command-line tool, such as `clusterctl`, `kubectl`, `kind`, `flux`, `govc`, etc. This image serves as the runtime environment when using the CLI, but customers can choose to use their own local binaries by setting the flag `MR_TOOLS_DISABLED` to `true`.
 
-You can find the latest version of this image [on ECR Public Gallery](https://gallery.ecr.aws/l0g8r8j6/eks-anywhere-cli-tools).
+You can find the latest version of this image [on ECR Public Gallery](https://gallery.ecr.aws/eks-anywhere/cli-tools).

--- a/projects/brancz/kube-rbac-proxy/README.md
+++ b/projects/brancz/kube-rbac-proxy/README.md
@@ -6,4 +6,4 @@ The [kube-rbac-proxy](https://github.com/brancz/kube-rbac-proxy) is an HTTP prox
 
 A `kube-rbac-proxy` sidecar container is injected by Cluster API Kubeadm manager when provisioning the Kubernetes controlplane.
 
-You can find the latest version of this image [on ECR Public Gallery](https://gallery.ecr.aws/l0g8r8j6/brancz/kube-rbac-proxy).
+You can find the latest version of this image [on ECR Public Gallery](https://gallery.ecr.aws/eks-anywhere/brancz/kube-rbac-proxy).

--- a/projects/fluxcd/helm-controller/README.md
+++ b/projects/fluxcd/helm-controller/README.md
@@ -16,4 +16,4 @@ Some of the features of the Helm controller are:
 * Reports Helm release statuses
 * Built-in Kustomize compatible Helm post renderer, providing support for strategic merge, JSON 6902 and images patches
 
-You can find the latest version of this image [on ECR Public Gallery](https://gallery.ecr.aws/l0g8r8j6/fluxcd/helm-controller).
+You can find the latest version of this image [on ECR Public Gallery](https://gallery.ecr.aws/eks-anywhere/fluxcd/helm-controller).

--- a/projects/fluxcd/kustomize-controller/README.md
+++ b/projects/fluxcd/kustomize-controller/README.md
@@ -19,4 +19,4 @@ Some of the features of the Kustomize controller are:
 * Runs `Kustomizations` in a specific order, taking into account the depends-on relationship 
 * Notifies whenever a `Kustomization` status changes
 
-You can find the latest version of this image [on ECR Public Gallery](https://gallery.ecr.aws/l0g8r8j6/fluxcd/kustomize-controller).
+You can find the latest version of this image [on ECR Public Gallery](https://gallery.ecr.aws/eks-anywhere/fluxcd/kustomize-controller).

--- a/projects/fluxcd/notification-controller/README.md
+++ b/projects/fluxcd/notification-controller/README.md
@@ -4,4 +4,4 @@
 
 The [notification-controller](https://github.com/fluxcd/notification-controller) is a Kubernetes operator specialized in handling inbound and outbound events. The controller exposes an HTTP endpoint for receiving events from other controllers. It can be configured with Kubernetes custom resources such as `Alert`, `Event`,`Provider` and `Receiver` to define how events are processed and where to dispatch them.
 
-You can find the latest version of this image [on ECR Public Gallery](https://gallery.ecr.aws/l0g8r8j6/fluxcd/notification-controller).
+You can find the latest version of this image [on ECR Public Gallery](https://gallery.ecr.aws/eks-anywhere/fluxcd/notification-controller).

--- a/projects/fluxcd/source-controller/README.md
+++ b/projects/fluxcd/source-controller/README.md
@@ -16,4 +16,4 @@ Some of the features of the Source controller are:
 * Notifies interested third-parties of source changes and availability (status conditions, events, hooks)
 * Reacts to Git push and Helm chart upload events
 
-You can find the latest version of this image [on ECR Public Gallery](https://gallery.ecr.aws/l0g8r8j6/fluxcd/source-controller).
+You can find the latest version of this image [on ECR Public Gallery](https://gallery.ecr.aws/eks-anywhere/fluxcd/source-controller).

--- a/projects/jetstack/cert-manager/README.md
+++ b/projects/jetstack/cert-manager/README.md
@@ -13,7 +13,7 @@ In addition, cert-manager supports requesting certificates from ACME servers, in
 
 You can find the latest versions of these images on ECR Public Gallery.
 
-[ACME Solver](https://gallery.ecr.aws/l0g8r8j6/jetstack/cert-manager-acmesolver) | 
-[cert-manager Controller](https://gallery.ecr.aws/l0g8r8j6/jetstack/cert-manager-controller) | 
-[CA injector](https://gallery.ecr.aws/l0g8r8j6/jetstack/cert-manager-cainjector) | 
-[cert-manager Webhook Server](https://gallery.ecr.aws/l0g8r8j6/jetstack/cert-manager-webhook)
+[ACME Solver](https://gallery.ecr.aws/eks-anywhere/jetstack/cert-manager-acmesolver) | 
+[cert-manager Controller](https://gallery.ecr.aws/eks-anywhere/jetstack/cert-manager-controller) | 
+[CA injector](https://gallery.ecr.aws/eks-anywhere/jetstack/cert-manager-cainjector) | 
+[cert-manager Webhook Server](https://gallery.ecr.aws/eks-anywhere/jetstack/cert-manager-webhook)

--- a/projects/kubernetes-sigs/cluster-api-provider-aws/README.md
+++ b/projects/kubernetes-sigs/cluster-api-provider-aws/README.md
@@ -16,7 +16,7 @@ Cluster API Provider AWS controller images are used in the Provider confgiration
 
 You can find the latest versions of these images on ECR Public Gallery.
 
-[Cluster API AWS Controller](https://gallery.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api-provider-aws/cluster-api-aws-controller) | 
-[Cluster API EKS Bootstrap Controller](https://gallery.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api-provider-aws/eks-bootstrap-controller) | 
-[Cluster API EKS Controlplane Controller](https://gallery.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api-provider-aws/eks-control-plane-controller)
+[Cluster API AWS Controller](https://gallery.ecr.aws/eks-anywhere/kubernetes-sigs/cluster-api-provider-aws/cluster-api-aws-controller) | 
+[Cluster API EKS Bootstrap Controller](https://gallery.ecr.aws/eks-anywhere/kubernetes-sigs/cluster-api-provider-aws/eks-bootstrap-controller) | 
+[Cluster API EKS Controlplane Controller](https://gallery.ecr.aws/eks-anywhere/kubernetes-sigs/cluster-api-provider-aws/eks-control-plane-controller)
 

--- a/projects/kubernetes-sigs/cluster-api-provider-vsphere/README.md
+++ b/projects/kubernetes-sigs/cluster-api-provider-vsphere/README.md
@@ -12,4 +12,4 @@ Some of the features of Cluster API Provider vSphere include:
 
 The Cluster API Provider vSphere controller image is used in the Provider confgiration to bootstrap the vSphere Infrastructure Provider in the EKS-A CLI.
 
-You can find the latest version of this image [on ECR Public Gallery](https://gallery.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api-provider-vsphere/release/manager).
+You can find the latest version of this image [on ECR Public Gallery](https://gallery.ecr.aws/eks-anywhere/kubernetes-sigs/cluster-api-provider-vsphere/release/manager).

--- a/projects/kubernetes-sigs/cluster-api/README.md
+++ b/projects/kubernetes-sigs/cluster-api/README.md
@@ -8,6 +8,6 @@ The `eks-a` CLI uses Cluster API to generate configurations for various infrasur
 
 You can find the latest versions of these images on ECR Public Gallery.
 
-[Cluster API Controller](https://gallery.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api/cluster-api-controller) | 
-[Cluster API Kubeadm Bootstrap Controller](https://gallery.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller) | 
-[Cluster API Kubeadm Controlplane Controller](https://gallery.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller)
+[Cluster API Controller](https://gallery.ecr.aws/eks-anywhere/kubernetes-sigs/cluster-api/cluster-api-controller) | 
+[Cluster API Kubeadm Bootstrap Controller](https://gallery.ecr.aws/eks-anywhere/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller) | 
+[Cluster API Kubeadm Controlplane Controller](https://gallery.ecr.aws/eks-anywhere/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller)

--- a/projects/kubernetes-sigs/kind/README.md
+++ b/projects/kubernetes-sigs/kind/README.md
@@ -21,4 +21,4 @@ Kind also implements its own standard CNI/cluster networking configuration in th
 
 You can find the latest versions of these images on ECR Public Gallery.
 
-[Node](https://gallery.ecr.aws/l0g8r8j6/kubernetes-sigs/kind/node) | [HA Proxy](https://gallery.ecr.aws/l0g8r8j6/kubernetes-sigs/kind/haproxy) | [Kindnetd](https://gallery.ecr.aws/l0g8r8j6/kubernetes-sigs/kind/kindnetd)
+[Node](https://gallery.ecr.aws/eks-anywhere/kubernetes-sigs/kind/node) | [HA Proxy](https://gallery.ecr.aws/eks-anywhere/kubernetes-sigs/kind/haproxy) | [Kindnetd](https://gallery.ecr.aws/eks-anywhere/kubernetes-sigs/kind/kindnetd)

--- a/projects/kubernetes-sigs/vsphere-csi-driver/README.md
+++ b/projects/kubernetes-sigs/vsphere-csi-driver/README.md
@@ -10,4 +10,4 @@ In Kubernetes, CNS provides a volume driver that has two sub-components – the 
 
 You can find the latest versions of these images on ECR Public Gallery.
 
-[CSI driver](https://gallery.ecr.aws/l0g8r8j6/kubernetes-sigs/vsphere-csi-driver/csi/driver) | [CSI syncer](https://gallery.ecr.aws/l0g8r8j6/kubernetes-sigs/vsphere-csi-driver/csi/syncer)
+[CSI driver](https://gallery.ecr.aws/eks-anywhere/kubernetes-sigs/vsphere-csi-driver/csi/driver) | [CSI syncer](https://gallery.ecr.aws/eks-anywhere/kubernetes-sigs/vsphere-csi-driver/csi/syncer)

--- a/projects/kubernetes/cloud-provider-vsphere/README.md
+++ b/projects/kubernetes/cloud-provider-vsphere/README.md
@@ -4,4 +4,4 @@
 
 [Cloud Provider vSphere](https://github.com/kubernetes/cloud-provider-vsphere) defines the vSphere-specific implementation of the Kubernetes controller-manager. The Cloud Provider Interface (CPI) allows customers to run Kubernetes clusters on vSphere infrastructure. It replaces the Kubernetes Controller Manager for only the cloud-specific control loops. The CPI integration connects to vCenter Server and maps information about the infrastructure, such as VMs, disks, and so on, back to the Kubernetes API.
 
-You can find the latest version of this image [on ECR Public Gallery](https://gallery.ecr.aws/l0g8r8j6/kubernetes/cloud-provider-vsphere/cpi/manager).
+You can find the latest version of this image [on ECR Public Gallery](https://gallery.ecr.aws/eks-anywhere/kubernetes/cloud-provider-vsphere/cpi/manager).

--- a/projects/plunder-app/kube-vip/README.md
+++ b/projects/plunder-app/kube-vip/README.md
@@ -6,4 +6,4 @@ The [kube-vip project](https://github.com/plunder-app/kube-vip) provides High-Av
 
 In EKS-A, kube-vip offers HA and load-balancing services for Kubernetes clusters on vSphere infrastructure.
 
-You can find the latest version of this image [on ECR Public Gallery](https://gallery.ecr.aws/l0g8r8j6/plunder-app/kube-vip).
+You can find the latest version of this image [on ECR Public Gallery](https://gallery.ecr.aws/eks-anywhere/plunder-app/kube-vip).

--- a/projects/rancher/local-path-provisioner/README.md
+++ b/projects/rancher/local-path-provisioner/README.md
@@ -4,4 +4,4 @@
 
 [Local Path Provisioner](https://github.com/rancher/local-path-provisioner) provides a way for the Kubernetes users to utilize the local storage in each node. Based on the user configuration, the Local Path Provisioner will create `hostPath`-based persistent volume on the node automatically. It utilizes the features introduced by Kubernetes Local Persistent Volume feature, but makes it a simpler solution than the built-in `local` volume feature in Kubernetes. Its advantage over the Local PV feature is its ability to perform dynamic provisioning of volumes using `hostPath`.
 
-You can find the latest version of this image [on ECR Public Gallery](https://gallery.ecr.aws/l0g8r8j6/rancher/local-path-provisioner).
+You can find the latest version of this image [on ECR Public Gallery](https://gallery.ecr.aws/eks-anywhere/rancher/local-path-provisioner).


### PR DESCRIPTION
Update all READMEs to reference the prod public ECR registry.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
