### PR TITLE
Update CLI repo tag

### DIFF
--- a/projects/aws/eks-anywhere/GIT_COMMIT
+++ b/projects/aws/eks-anywhere/GIT_COMMIT
@@ -1,0 +1,1 @@
+2ce1dd9a94e4e7013fc9ac5f1eeef00a54ce2cf2

--- a/projects/aws/eks-anywhere/GIT_TAG
+++ b/projects/aws/eks-anywhere/GIT_TAG
@@ -1,1 +1,1 @@
-1f123ffd32ab330d3b256c6a8fa14ae3fe94b6c2
+v0.5.0

--- a/projects/aws/eks-anywhere/Makefile
+++ b/projects/aws/eks-anywhere/Makefile
@@ -2,6 +2,7 @@ BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
 BUILD_LIB=$(BASE_DIRECTORY)/build/lib
 ARTIFACTS_BUCKET?=my-s3-bucket
 GIT_TAG=$(shell cat GIT_TAG)
+GIT_COMMIT=$(shell cat GIT_COMMIT)
 GOLANG_VERSION?="1.16"
 
 REPO=eks-anywhere
@@ -56,7 +57,7 @@ upload-artifacts:
 
 .PHONY: binaries
 binaries:
-	build/create_binaries.sh $(REPO) $(CLONE_URL) $(GIT_TAG) $(GOLANG_VERSION) $(BINARY_NAME) $(IMAGE_REPO) $(IMAGE_TAG)
+	build/create_binaries.sh $(REPO) $(CLONE_URL) $(GIT_COMMIT) $(GOLANG_VERSION) $(BINARY_NAME) $(IMAGE_REPO) $(IMAGE_TAG)
 
 .PHONY: generate-attribution
 generate-attribution:


### PR DESCRIPTION
Use v0.5.0 tag for EKS-A CLI builds.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
