### PR TITLE
Remove year from license verbiage

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -39,6 +39,5 @@ reviewers:
 - sostheim
 - taneyland
 - TerryHowe
-- ttashi
 - vignesh-goutham
 - vivek-koppuru

--- a/projects/aws/eks-anywhere/build/create_attribution.sh
+++ b/projects/aws/eks-anywhere/build/create_attribution.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/brancz/kube-rbac-proxy/build/create_attribution.sh
+++ b/projects/brancz/kube-rbac-proxy/build/create_attribution.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/fluxcd/flux2/build/create_attribution.sh
+++ b/projects/fluxcd/flux2/build/create_attribution.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/fluxcd/helm-controller/build/create_attribution.sh
+++ b/projects/fluxcd/helm-controller/build/create_attribution.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/fluxcd/kustomize-controller/build/create_attribution.sh
+++ b/projects/fluxcd/kustomize-controller/build/create_attribution.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/fluxcd/notification-controller/build/create_attribution.sh
+++ b/projects/fluxcd/notification-controller/build/create_attribution.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/fluxcd/source-controller/build/create_attribution.sh
+++ b/projects/fluxcd/source-controller/build/create_attribution.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/jetstack/cert-manager/build/create_attribution.sh
+++ b/projects/jetstack/cert-manager/build/create_attribution.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/kubernetes-sigs/cluster-api-provider-aws/build/create_attribution.sh
+++ b/projects/kubernetes-sigs/cluster-api-provider-aws/build/create_attribution.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/kubernetes-sigs/cluster-api-provider-vsphere/build/create_attribution.sh
+++ b/projects/kubernetes-sigs/cluster-api-provider-vsphere/build/create_attribution.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/kubernetes-sigs/cluster-api/build/create_attribution.sh
+++ b/projects/kubernetes-sigs/cluster-api/build/create_attribution.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/kubernetes-sigs/cri-tools/build/create_attribution.sh
+++ b/projects/kubernetes-sigs/cri-tools/build/create_attribution.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/kubernetes-sigs/etcdadm/build/create_attribution.sh
+++ b/projects/kubernetes-sigs/etcdadm/build/create_attribution.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/kubernetes-sigs/kind/build/build-kind-base-image.sh
+++ b/projects/kubernetes-sigs/kind/build/build-kind-base-image.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/kubernetes-sigs/kind/build/build-kind-node-image.sh
+++ b/projects/kubernetes-sigs/kind/build/build-kind-node-image.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/kubernetes-sigs/kind/build/build-kindnetd-image.sh
+++ b/projects/kubernetes-sigs/kind/build/build-kindnetd-image.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/kubernetes-sigs/kind/build/create_attribution.sh
+++ b/projects/kubernetes-sigs/kind/build/create_attribution.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/kubernetes-sigs/kind/images/base/kubeadm-override.sh
+++ b/projects/kubernetes-sigs/kind/images/base/kubeadm-override.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/kubernetes-sigs/kind/images/k8s.io/kubernetes/build/download-images.sh
+++ b/projects/kubernetes-sigs/kind/images/k8s.io/kubernetes/build/download-images.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/kubernetes-sigs/kind/images/k8s.io/kubernetes/build/run.sh
+++ b/projects/kubernetes-sigs/kind/images/k8s.io/kubernetes/build/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/kubernetes-sigs/kind/images/k8s.io/kubernetes/hack/print-workspace-status.sh
+++ b/projects/kubernetes-sigs/kind/images/k8s.io/kubernetes/hack/print-workspace-status.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/kubernetes-sigs/vsphere-csi-driver/build/create_attribution.sh
+++ b/projects/kubernetes-sigs/vsphere-csi-driver/build/create_attribution.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/kubernetes/cloud-provider-vsphere/build/create_attribution.sh
+++ b/projects/kubernetes/cloud-provider-vsphere/build/create_attribution.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/mrajashree/etcdadm-bootstrap-provider/build/create_attribution.sh
+++ b/projects/mrajashree/etcdadm-bootstrap-provider/build/create_attribution.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/mrajashree/etcdadm-controller/build/create_attribution.sh
+++ b/projects/mrajashree/etcdadm-controller/build/create_attribution.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/plunder-app/kube-vip/build/create_attribution.sh
+++ b/projects/plunder-app/kube-vip/build/create_attribution.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/rancher/local-path-provisioner/build/create_attribution.sh
+++ b/projects/rancher/local-path-provisioner/build/create_attribution.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/projects/vmware/govmomi/build/create_attribution.sh
+++ b/projects/vmware/govmomi/build/create_attribution.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Amazon.com Inc. or its affiliates. All Rights Reserved.
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Remove year from license header on files.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
