### PR TITLE
Add capi patch for bottlerocket registry mirror support

### DIFF
--- a/projects/kubernetes-sigs/cluster-api/patches/0028-add-support-for-registry-mirror-for-bottlerocket.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0028-add-support-for-registry-mirror-for-bottlerocket.patch
@@ -1,0 +1,455 @@
+From 303a7ba3658bcd4829b998f76d30e41cd394e3ae Mon Sep 17 00:00:00 2001
+From: Abhinav Pandey <abhnvp@amazon.com>
+Date: Tue, 21 Sep 2021 08:29:47 -0700
+Subject: [PATCH] add support for registry mirror for bottlerocket
+
+Signed-off-by: Abhinav Pandey <abhnvp@amazon.com>
+---
+ api/v1alpha2/zz_generated.conversion.go       |  3 ++
+ ...strap.cluster.x-k8s.io_kubeadmconfigs.yaml | 48 +++++++++++++++++
+ ...uster.x-k8s.io_kubeadmconfigtemplates.yaml | 52 +++++++++++++++++++
+ .../controllers/kubeadmconfig_controller.go   |  9 ++++
+ .../internal/bottlerocket/bootstrap.go        | 19 +++++++
+ .../internal/bottlerocket/bottlerocket.go     | 20 +++++--
+ bootstrap/kubeadm/types/v1beta1/types.go      | 19 +++++++
+ .../types/v1beta1/zz_generated.deepcopy.go    | 17 ++++++
+ ...cluster.x-k8s.io_kubeadmcontrolplanes.yaml | 26 ++++++++++
+ 9 files changed, 209 insertions(+), 4 deletions(-)
+
+diff --git a/api/v1alpha2/zz_generated.conversion.go b/api/v1alpha2/zz_generated.conversion.go
+index 435282bf0..68299ede9 100644
+--- a/api/v1alpha2/zz_generated.conversion.go
++++ b/api/v1alpha2/zz_generated.conversion.go
+@@ -442,6 +442,7 @@ func autoConvert_v1alpha3_ClusterSpec_To_v1alpha2_ClusterSpec(in *v1alpha3.Clust
+ 	out.ClusterNetwork = (*ClusterNetwork)(unsafe.Pointer(in.ClusterNetwork))
+ 	// WARNING: in.ControlPlaneEndpoint requires manual conversion: does not exist in peer-type
+ 	// WARNING: in.ControlPlaneRef requires manual conversion: does not exist in peer-type
++	// WARNING: in.ManagedExternalEtcdRef requires manual conversion: does not exist in peer-type
+ 	out.InfrastructureRef = (*v1.ObjectReference)(unsafe.Pointer(in.InfrastructureRef))
+ 	return nil
+ }
+@@ -466,6 +467,8 @@ func autoConvert_v1alpha3_ClusterStatus_To_v1alpha2_ClusterStatus(in *v1alpha3.C
+ 	// WARNING: in.ControlPlaneReady requires manual conversion: does not exist in peer-type
+ 	// WARNING: in.Conditions requires manual conversion: does not exist in peer-type
+ 	// WARNING: in.ObservedGeneration requires manual conversion: does not exist in peer-type
++	// WARNING: in.ManagedExternalEtcdInitialized requires manual conversion: does not exist in peer-type
++	// WARNING: in.ManagedExternalEtcdReady requires manual conversion: does not exist in peer-type
+ 	return nil
+ }
+ 
+diff --git a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+index 8919ffc88..3b683e74f 100644
+--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
++++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
+@@ -349,6 +349,18 @@ spec:
+                           type: string
+                         type: array
+                     type: object
++                  registryMirror:
++                    description: RegistryMirror holds the image registry mirror information
++                      This is only for bottlerocket
++                    properties:
++                      caCert:
++                        description: CACert defines the CA cert for the registry mirror
++                        type: string
++                      endpoint:
++                        description: Endpoint defines the registry mirror endpoint
++                          to use for pulling images
++                        type: string
++                    type: object
+                   scheduler:
+                     description: Scheduler contains extra settings for the scheduler
+                       control plane component
+@@ -815,6 +827,18 @@ spec:
+                           type: string
+                         type: array
+                     type: object
++                  registryMirror:
++                    description: RegistryMirror holds the image registry mirror information
++                      This is only for bottlerocket
++                    properties:
++                      caCert:
++                        description: CACert defines the CA cert for the registry mirror
++                        type: string
++                      endpoint:
++                        description: Endpoint defines the registry mirror endpoint
++                          to use for pulling images
++                        type: string
++                    type: object
+                 type: object
+               ntp:
+                 description: NTP specifies NTP configuration
+@@ -1245,6 +1269,18 @@ spec:
+                           type: string
+                         type: array
+                     type: object
++                  registryMirror:
++                    description: RegistryMirror holds the image registry mirror information
++                      This is only for bottlerocket
++                    properties:
++                      caCert:
++                        description: CACert defines the CA cert for the registry mirror
++                        type: string
++                      endpoint:
++                        description: Endpoint defines the registry mirror endpoint
++                          to use for pulling images
++                        type: string
++                    type: object
+                   scheduler:
+                     description: Scheduler contains extra settings for the scheduler
+                       control plane component
+@@ -1814,6 +1850,18 @@ spec:
+                           type: string
+                         type: array
+                     type: object
++                  registryMirror:
++                    description: RegistryMirror holds the image registry mirror information
++                      This is only for bottlerocket
++                    properties:
++                      caCert:
++                        description: CACert defines the CA cert for the registry mirror
++                        type: string
++                      endpoint:
++                        description: Endpoint defines the registry mirror endpoint
++                          to use for pulling images
++                        type: string
++                    type: object
+                 type: object
+               mounts:
+                 description: Mounts specifies a list of mount points to be setup.
+diff --git a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+index 275a13d6b..389787970 100644
+--- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
++++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
+@@ -374,6 +374,19 @@ spec:
+                                   type: string
+                                 type: array
+                             type: object
++                          registryMirror:
++                            description: RegistryMirror holds the image registry mirror
++                              information This is only for bottlerocket
++                            properties:
++                              caCert:
++                                description: CACert defines the CA cert for the registry
++                                  mirror
++                                type: string
++                              endpoint:
++                                description: Endpoint defines the registry mirror
++                                  endpoint to use for pulling images
++                                type: string
++                            type: object
+                           scheduler:
+                             description: Scheduler contains extra settings for the
+                               scheduler control plane component
+@@ -868,6 +881,19 @@ spec:
+                                   type: string
+                                 type: array
+                             type: object
++                          registryMirror:
++                            description: RegistryMirror holds the image registry mirror
++                              information This is only for bottlerocket
++                            properties:
++                              caCert:
++                                description: CACert defines the CA cert for the registry
++                                  mirror
++                                type: string
++                              endpoint:
++                                description: Endpoint defines the registry mirror
++                                  endpoint to use for pulling images
++                                type: string
++                            type: object
+                         type: object
+                       ntp:
+                         description: NTP specifies NTP configuration
+@@ -1310,6 +1336,19 @@ spec:
+                                   type: string
+                                 type: array
+                             type: object
++                          registryMirror:
++                            description: RegistryMirror holds the image registry mirror
++                              information This is only for bottlerocket
++                            properties:
++                              caCert:
++                                description: CACert defines the CA cert for the registry
++                                  mirror
++                                type: string
++                              endpoint:
++                                description: Endpoint defines the registry mirror
++                                  endpoint to use for pulling images
++                                type: string
++                            type: object
+                           scheduler:
+                             description: Scheduler contains extra settings for the
+                               scheduler control plane component
+@@ -1914,6 +1953,19 @@ spec:
+                                   type: string
+                                 type: array
+                             type: object
++                          registryMirror:
++                            description: RegistryMirror holds the image registry mirror
++                              information This is only for bottlerocket
++                            properties:
++                              caCert:
++                                description: CACert defines the CA cert for the registry
++                                  mirror
++                                type: string
++                              endpoint:
++                                description: Endpoint defines the registry mirror
++                                  endpoint to use for pulling images
++                                type: string
++                            type: object
+                         type: object
+                       mounts:
+                         description: Mounts specifies a list of mount points to be
+diff --git a/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go b/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
+index 74e2fc5a4..4b1df9b08 100644
+--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
++++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
+@@ -436,6 +436,9 @@ func (r *KubeadmConfigReconciler) handleClusterNotInitialized(ctx context.Contex
+ 		if scope.Config.Spec.ClusterConfiguration.Proxy.HTTPSProxy != "" {
+ 			bottlerocketConfig.ProxyConfiguration = scope.Config.Spec.ClusterConfiguration.Proxy
+ 		}
++		if scope.Config.Spec.ClusterConfiguration.RegistryMirror.Endpoint != "" {
++			bottlerocketConfig.RegistryMirrorConfiguration = scope.Config.Spec.ClusterConfiguration.RegistryMirror
++		}
+ 	}
+ 
+ 	clusterdata, err := kubeadmv1beta1.ConfigurationToYAMLForVersion(scope.Config.Spec.ClusterConfiguration, scope.ConfigOwner.KubernetesVersion())
+@@ -578,6 +581,9 @@ func (r *KubeadmConfigReconciler) joinWorker(ctx context.Context, scope *Scope)
+ 		if scope.Config.Spec.JoinConfiguration.Proxy.HTTPSProxy != "" {
+ 			bottlerocketConfig.ProxyConfiguration = scope.Config.Spec.JoinConfiguration.Proxy
+ 		}
++		if scope.Config.Spec.JoinConfiguration.RegistryMirror.Endpoint != "" {
++			bottlerocketConfig.RegistryMirrorConfiguration = scope.Config.Spec.JoinConfiguration.RegistryMirror
++		}
+ 		cloudJoinData, err = bottlerocket.NewNode(cloudJoinInput, bottlerocketConfig)
+ 		if err != nil {
+ 			scope.Error(err, "Failed to create a worker bottlerocket join configuration")
+@@ -674,6 +680,9 @@ func (r *KubeadmConfigReconciler) joinControlplane(ctx context.Context, scope *S
+ 		if scope.Config.Spec.JoinConfiguration.Proxy.HTTPSProxy != "" {
+ 			bottlerocketConfig.ProxyConfiguration = scope.Config.Spec.JoinConfiguration.Proxy
+ 		}
++		if scope.Config.Spec.ClusterConfiguration.RegistryMirror.Endpoint != "" {
++			bottlerocketConfig.RegistryMirrorConfiguration = scope.Config.Spec.ClusterConfiguration.RegistryMirror
++		}
+ 		cloudJoinData, err = bottlerocket.NewJoinControlPlane(cloudJoinInput, bottlerocketConfig)
+ 		if err != nil {
+ 			scope.Error(err, "Failed to generate cloud init for bottlerocket bootstrap control plane")
+diff --git a/bootstrap/kubeadm/internal/bottlerocket/bootstrap.go b/bootstrap/kubeadm/internal/bottlerocket/bootstrap.go
+index e4be8d945..886af6d87 100644
+--- a/bootstrap/kubeadm/internal/bottlerocket/bootstrap.go
++++ b/bootstrap/kubeadm/internal/bottlerocket/bootstrap.go
+@@ -31,6 +31,17 @@ user-data = "{{.BootstrapContainerUserData}}"
+ https-proxy = "{{.HTTPSProxyEndpoint}}"
+ no-proxy = "{{.NoProxyEndpoints}}"
+ {{- end -}}
++`
++	registryMirrorTemplate = `{{ define "registryMirrorSettings" -}}
++[settings.container-registry.mirrors]
++"public.ecr.aws" = ["https://{{.RegistryMirrorEndpoint}}"]
++{{- end -}}
++`
++	registryMirrorCACertTemplate = `{{ define "registryMirrorCACertSettings" -}}
++[settings.pki.registry-mirror-ca]
++data = "{{.RegistryMirrorCACert}}"
++trusted=true
++{{- end -}}
+ `
+ 	bottlerocketNodeInitSettingsTemplate = `{{template "bootstrapHostContainerSettings" .}}
+ 
+@@ -41,5 +52,13 @@ no-proxy = "{{.NoProxyEndpoints}}"
+ {{- if (ne .HTTPSProxyEndpoint "")}}
+ {{template "networkInitSettings" .}}
+ {{- end -}}
++
++{{- if (ne .RegistryMirrorEndpoint "")}}
++{{template "registryMirrorSettings" .}}
++{{- end -}}
++
++{{- if (ne .RegistryMirrorCACert "")}}
++{{template "registryMirrorCACertSettings" .}}
++{{- end -}}
+ `
+ )
+diff --git a/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go b/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go
+index 6756741fb..15927ec20 100644
+--- a/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go
++++ b/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go
+@@ -22,9 +22,10 @@ const (
+ )
+ 
+ type BottlerocketConfig struct {
+-	Pause                 kubeadmv1beta1.Pause
+-	BottlerocketBootstrap kubeadmv1beta1.BottlerocketBootstrap
+-	ProxyConfiguration    kubeadmv1beta1.ProxyConfiguration
++	Pause                       kubeadmv1beta1.Pause
++	BottlerocketBootstrap       kubeadmv1beta1.BottlerocketBootstrap
++	ProxyConfiguration          kubeadmv1beta1.ProxyConfiguration
++	RegistryMirrorConfiguration kubeadmv1beta1.RegistryMirrorConfiguration
+ }
+ 
+ type BottlerocketSettingsInput struct {
+@@ -34,6 +35,8 @@ type BottlerocketSettingsInput struct {
+ 	PauseContainerSource       string
+ 	HTTPSProxyEndpoint         string
+ 	NoProxyEndpoints           []string
++	RegistryMirrorEndpoint     string
++	RegistryMirrorCACert       string
+ }
+ 
+ type HostPath struct {
+@@ -90,7 +93,12 @@ func generateNodeUserData(kind string, tpl string, data interface{}) ([]byte, er
+ 	if _, err := tm.Parse(networkInitTemplate); err != nil {
+ 		return nil, errors.Wrapf(err, "failed to parse networks %s template", kind)
+ 	}
+-
++	if _, err := tm.Parse(registryMirrorTemplate); err != nil {
++		return nil, errors.Wrapf(err, "failed to parse registry mirror %s template", kind)
++	}
++	if _, err := tm.Parse(registryMirrorCACertTemplate); err != nil {
++		return nil, errors.Wrapf(err, "failed to parse registry mirror ca cert %s template", kind)
++	}
+ 	t, err := tm.Parse(tpl)
+ 	if err != nil {
+ 		return nil, errors.Wrapf(err, "failed to parse %s template", kind)
+@@ -125,6 +133,10 @@ func getBottlerocketNodeUserData(bootstrapContainerUserData []byte, users []boot
+ 		PauseContainerSource:       fmt.Sprintf("%s:%s", config.Pause.ImageRepository, config.Pause.ImageTag),
+ 		HTTPSProxyEndpoint:         config.ProxyConfiguration.HTTPSProxy,
+ 		NoProxyEndpoints:           config.ProxyConfiguration.NoProxy,
++		RegistryMirrorEndpoint:     config.RegistryMirrorConfiguration.Endpoint,
++	}
++	if config.RegistryMirrorConfiguration.CACert != "" {
++		bottlerocketInput.RegistryMirrorCACert = base64.StdEncoding.EncodeToString([]byte(config.RegistryMirrorConfiguration.CACert))
+ 	}
+ 
+ 	bottlerocketNodeUserData, err := generateNodeUserData("InitBottlerocketNode", bottlerocketNodeInitSettingsTemplate, bottlerocketInput)
+diff --git a/bootstrap/kubeadm/types/v1beta1/types.go b/bootstrap/kubeadm/types/v1beta1/types.go
+index c098a3c5d..2fc6263c4 100644
+--- a/bootstrap/kubeadm/types/v1beta1/types.go
++++ b/bootstrap/kubeadm/types/v1beta1/types.go
+@@ -70,6 +70,11 @@ type ClusterConfiguration struct {
+ 	// +optional
+ 	Proxy ProxyConfiguration `json:"proxy,omitempty"`
+ 
++	// RegistryMirror holds the image registry mirror information
++	// This is only for bottlerocket
++	// +optional
++	RegistryMirror RegistryMirrorConfiguration `json:"registryMirror,omitempty"`
++
+ 	// Etcd holds configuration for etcd.
+ 	// NB: This value defaults to a Local (stacked) etcd
+ 	// +optional
+@@ -164,6 +169,15 @@ type ProxyConfiguration struct {
+ 	NoProxy []string `json:"noProxy,omitempty"`
+ }
+ 
++// RegistryMirrorConfiguration holds the settings for image registry mirror
++type RegistryMirrorConfiguration struct {
++	// Endpoint defines the registry mirror endpoint to use for pulling images
++	Endpoint string `json:"endpoint,omitempty"`
++
++	// CACert defines the CA cert for the registry mirror
++	CACert string `json:"caCert,omitempty"`
++}
++
+ // ControlPlaneComponent holds settings common to control plane component of the cluster
+ type ControlPlaneComponent struct {
+ 	// ExtraArgs is an extra set of flags to pass to the control plane component.
+@@ -380,6 +394,11 @@ type JoinConfiguration struct {
+ 	// +optional
+ 	Proxy ProxyConfiguration `json:"proxy,omitempty"`
+ 
++	// RegistryMirror holds the image registry mirror information
++	// This is only for bottlerocket
++	// +optional
++	RegistryMirror RegistryMirrorConfiguration `json:"registryMirror,omitempty"`
++
+ 	// NodeRegistration holds fields that relate to registering the new control-plane node to the cluster.
+ 	// When used in the context of control plane nodes, NodeRegistration should remain consistent
+ 	// across both InitConfiguration and JoinConfiguration
+diff --git a/bootstrap/kubeadm/types/v1beta1/zz_generated.deepcopy.go b/bootstrap/kubeadm/types/v1beta1/zz_generated.deepcopy.go
+index f88294f55..b28b8accb 100644
+--- a/bootstrap/kubeadm/types/v1beta1/zz_generated.deepcopy.go
++++ b/bootstrap/kubeadm/types/v1beta1/zz_generated.deepcopy.go
+@@ -164,6 +164,7 @@ func (in *ClusterConfiguration) DeepCopyInto(out *ClusterConfiguration) {
+ 	out.Pause = in.Pause
+ 	out.BottlerocketBootstrap = in.BottlerocketBootstrap
+ 	in.Proxy.DeepCopyInto(&out.Proxy)
++	out.RegistryMirror = in.RegistryMirror
+ 	in.Etcd.DeepCopyInto(&out.Etcd)
+ 	out.Networking = in.Networking
+ 	in.APIServer.DeepCopyInto(&out.APIServer)
+@@ -431,6 +432,7 @@ func (in *JoinConfiguration) DeepCopyInto(out *JoinConfiguration) {
+ 	out.Pause = in.Pause
+ 	out.BottlerocketBootstrap = in.BottlerocketBootstrap
+ 	in.Proxy.DeepCopyInto(&out.Proxy)
++	out.RegistryMirror = in.RegistryMirror
+ 	in.NodeRegistration.DeepCopyInto(&out.NodeRegistration)
+ 	in.Discovery.DeepCopyInto(&out.Discovery)
+ 	if in.ControlPlane != nil {
+@@ -586,3 +588,18 @@ func (in *ProxyConfiguration) DeepCopy() *ProxyConfiguration {
+ 	in.DeepCopyInto(out)
+ 	return out
+ }
++
++// DeepCopyInto is an autogenerated deepcopy function, copying the receiver, writing into out. in must be non-nil.
++func (in *RegistryMirrorConfiguration) DeepCopyInto(out *RegistryMirrorConfiguration) {
++	*out = *in
++}
++
++// DeepCopy is an autogenerated deepcopy function, copying the receiver, creating a new RegistryMirrorConfiguration.
++func (in *RegistryMirrorConfiguration) DeepCopy() *RegistryMirrorConfiguration {
++	if in == nil {
++		return nil
++	}
++	out := new(RegistryMirrorConfiguration)
++	in.DeepCopyInto(out)
++	return out
++}
+diff --git a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+index 0b137b987..2b6b9db8d 100644
+--- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
++++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
+@@ -433,6 +433,19 @@ spec:
+                               type: string
+                             type: array
+                         type: object
++                      registryMirror:
++                        description: RegistryMirror holds the image registry mirror
++                          information This is only for bottlerocket
++                        properties:
++                          caCert:
++                            description: CACert defines the CA cert for the registry
++                              mirror
++                            type: string
++                          endpoint:
++                            description: Endpoint defines the registry mirror endpoint
++                              to use for pulling images
++                            type: string
++                        type: object
+                       scheduler:
+                         description: Scheduler contains extra settings for the scheduler
+                           control plane component
+@@ -1024,6 +1037,19 @@ spec:
+                               type: string
+                             type: array
+                         type: object
++                      registryMirror:
++                        description: RegistryMirror holds the image registry mirror
++                          information This is only for bottlerocket
++                        properties:
++                          caCert:
++                            description: CACert defines the CA cert for the registry
++                              mirror
++                            type: string
++                          endpoint:
++                            description: Endpoint defines the registry mirror endpoint
++                              to use for pulling images
++                            type: string
++                        type: object
+                     type: object
+                   mounts:
+                     description: Mounts specifies a list of mount points to be setup.
+-- 
+2.24.3 (Apple Git-128)
+


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/98

*Description of changes:*
Add CAPI patch to allow registry mirror configuration for bottlerocket
This patch is added to resolve this issue:  https://github.com/aws/eks-anywhere/issues/98

I also noticed there were two `0026` patches so I renamed one of them to `0027`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
