### PR TITLE
work around codebuild gopath shennanigans by pre-installing controlle…

### DIFF
--- a/projects/replicatedhq/troubleshoot/build/create_binaries.sh
+++ b/projects/replicatedhq/troubleshoot/build/create_binaries.sh
@@ -33,6 +33,7 @@ function build::troubleshoot::build_binaries(){
   platform=${1}
   OS="$(cut -d '/' -f1 <<< ${platform})"
   ARCH="$(cut -d '/' -f2 <<< ${platform})"
+  go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0
   make support-bundle
   mkdir -p ../${BIN_PATH}/${OS}-${ARCH}/
   mv bin/* ../${BIN_PATH}/${OS}-${ARCH}/

--- a/projects/replicatedhq/troubleshoot/build/create_binaries.sh
+++ b/projects/replicatedhq/troubleshoot/build/create_binaries.sh
@@ -33,7 +33,6 @@ function build::troubleshoot::build_binaries(){
   platform=${1}
   OS="$(cut -d '/' -f1 <<< ${platform})"
   ARCH="$(cut -d '/' -f2 <<< ${platform})"
-  echo $GOPATH
   export PATH=$PATH:$(go env GOPATH)/bin
   go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0
   go get k8s.io/code-generator/cmd/client-gen@kubernetes-1.18.0

--- a/projects/replicatedhq/troubleshoot/build/create_binaries.sh
+++ b/projects/replicatedhq/troubleshoot/build/create_binaries.sh
@@ -33,6 +33,8 @@ function build::troubleshoot::build_binaries(){
   platform=${1}
   OS="$(cut -d '/' -f1 <<< ${platform})"
   ARCH="$(cut -d '/' -f2 <<< ${platform})"
+  echo $GOPATH
+  export PATH=$PATH:$(go env GOPATH)/bin
   go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0
   make support-bundle
   mkdir -p ../${BIN_PATH}/${OS}-${ARCH}/

--- a/projects/replicatedhq/troubleshoot/build/create_binaries.sh
+++ b/projects/replicatedhq/troubleshoot/build/create_binaries.sh
@@ -36,6 +36,7 @@ function build::troubleshoot::build_binaries(){
   echo $GOPATH
   export PATH=$PATH:$(go env GOPATH)/bin
   go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0
+  go get k8s.io/code-generator/cmd/client-gen@kubernetes-1.18.0
   make support-bundle
   mkdir -p ../${BIN_PATH}/${OS}-${ARCH}/
   mv bin/* ../${BIN_PATH}/${OS}-${ARCH}/


### PR DESCRIPTION
…r gen, rather than allowing troubleshoot makefile to do it and set the gopath incorrectly

So, we call `make support-bundle` in order to build the support bundle binaries.

In the [troubleshoot `Makefile` target `support-bundle`](https://github.com/replicatedhq/troubleshoot/blob/master/Makefile), they check for the presence of `controller-gen` and `client-gen` using `which`; if they don't exist in the path, they'll install them and then call them based on the gopath. However, because of the way codebuild structures the gopath for sub-modules, this isn't going to work correctly. So, we instead pre-install them and ensure that the top-level codebuild gopath/bin dir is on the path before calling `make support-bundle`.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
