### PR TITLE
Check if docker machine or cluster is paused before reconciling

### DIFF
--- a/projects/kubernetes-sigs/cluster-api/patches/0027-capd-do-not-reconcile-machine-if-cluster-or-machine-is-paused.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0027-capd-do-not-reconcile-machine-if-cluster-or-machine-is-paused.patch
@@ -1,0 +1,39 @@
+From 44191af2995999d466c70d9e81c43d25df37ee1d Mon Sep 17 00:00:00 2001
+From: Stefan Bueringer <sbueringer@gmail.com>
+Date: Fri, 9 Apr 2021 18:33:36 +0200
+Subject: [PATCH] capd: do not reconcile machine if cluster or machine is
+ paused
+
+cr: https://code.amazon.com/reviews/CR-57112885
+---
+ .../docker/controllers/dockermachine_controller.go         | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/test/infrastructure/docker/controllers/dockermachine_controller.go b/test/infrastructure/docker/controllers/dockermachine_controller.go
+index ec86cd02c..e09fd046a 100644
+--- a/test/infrastructure/docker/controllers/dockermachine_controller.go
++++ b/test/infrastructure/docker/controllers/dockermachine_controller.go
+@@ -30,6 +30,7 @@ import (
+ 	infrav1 "sigs.k8s.io/cluster-api/test/infrastructure/docker/api/v1alpha3"
+ 	"sigs.k8s.io/cluster-api/test/infrastructure/docker/docker"
+ 	"sigs.k8s.io/cluster-api/util"
++	"sigs.k8s.io/cluster-api/util/annotations"
+ 	"sigs.k8s.io/cluster-api/util/conditions"
+ 	"sigs.k8s.io/cluster-api/util/patch"
+ 	"sigs.k8s.io/cluster-api/util/predicates"
+@@ -96,6 +97,12 @@ func (r *DockerMachineReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, re
+ 
+ 	log = log.WithValues("cluster", cluster.Name)
+ 
++	// Return early if the object or Cluster is paused.
++	if annotations.IsPaused(cluster, dockerMachine) {
++		log.Info("Reconciliation is paused for this object")
++		return ctrl.Result{}, nil
++	}
++
+ 	// Fetch the Docker Cluster.
+ 	dockerCluster := &infrav1.DockerCluster{}
+ 	dockerClusterName := client.ObjectKey{
+-- 
+2.30.1
+


### PR DESCRIPTION
All CAPI and CAPV controllers check for the paused annotation on the object
or if the cluster is paused before reconciling. This check was added in the capd
docker machine controller in v0.4: https://github.com/kubernetes-sigs/cluster-api/pull/4453/commits/ec3492800174af48377566ef100feb9cef12aec8
This commit backports the upstream commit to our fork for v0.3

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
