### PR TITLE
Converting from string to base 8 integer

### DIFF
--- a/projects/aws/bottlerocket-bootstrap/pkg/utils/userdata.go
+++ b/projects/aws/bottlerocket-bootstrap/pkg/utils/userdata.go
@@ -52,7 +52,7 @@ func WriteUserDataFiles(userData *UserData) error {
 		if file.Permissions == "" {
 			file.Permissions = "0640"
 		}
-		perm, err := strconv.Atoi(file.Permissions)
+		perm, err := strconv.ParseInt(file.Permissions, 8, 64)
 		if err != nil {
 			return errors.Wrap(err, "Error converting string to int for permissions")
 		}


### PR DESCRIPTION
*Description of changes:*
Changes to convert file permissions as an octal integer. Originally we were converting to base 10 which assigned the wrong permissions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
