### PR TITLE
Automated cherry pick of #60: bump to latest eks-d release

### DIFF
--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -1,13 +1,13 @@
 1-18:
-  number: 10
+  number: 11
   kubeVersion: v1.18.20
 1-19:
-  number: 9
+  number: 10
   kubeVersion: v1.19.13
 1-20:
-  number: 6
+  number: 7
   kubeVersion: v1.20.7
 1-21:
-  number: 4
+  number: 5
   kubeVersion: v1.21.2
 latest: 1-21


### PR DESCRIPTION
Cherry pick of #60 on release-0.1.

#60: bump to latest eks-d release

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note

```