### PR TITLE
Add kubectl to collector image

### DIFF
--- a/projects/aws/eks-anywhere/Makefile
+++ b/projects/aws/eks-anywhere/Makefile
@@ -19,7 +19,7 @@ COLLECTOR_LATEST_IMAGE=$(IMAGE_REPO)/$(COLLECTOR_IMAGE_NAME):latest
 
 .PHONY: fetch-binaries
 fetch-binaries:
-    build/fetch_binaries.sh $(RELEASE_BRANCH) $(RELEASE) $(EKS_DISTRO_RELEASE_VERSION)
+	build/fetch_binaries.sh
 
 .PHONY: local-images
 local-images: fetch-binaries

--- a/projects/aws/eks-anywhere/Makefile
+++ b/projects/aws/eks-anywhere/Makefile
@@ -17,8 +17,12 @@ COLLECTOR_IMAGE_NAME=eks-anywhere-diagnostic-collector
 COLLECTOR_IMAGE=$(IMAGE_REPO)/$(COLLECTOR_IMAGE_NAME):$(IMAGE_TAG)
 COLLECTOR_LATEST_IMAGE=$(IMAGE_REPO)/$(COLLECTOR_IMAGE_NAME):latest
 
+.PHONY: fetch-binaries
+fetch-binaries:
+    build/fetch_binaries.sh $(RELEASE_BRANCH) $(RELEASE) $(EKS_DISTRO_RELEASE_VERSION)
+
 .PHONY: local-images
-local-images:
+local-images: fetch-binaries
 	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \
@@ -29,7 +33,7 @@ local-images:
 		--output type=oci,oci-mediatypes=true,\"name=$(COLLECTOR_IMAGE),$(COLLECTOR_LATEST_IMAGE)\",dest=/tmp/eksa-diagnostic-collector.tar
 
 .PHONY: images
-images:
+images: fetch-binaries
 	$(BUILD_LIB)/buildkit.sh \
 		build \
 		--frontend dockerfile.v0 \

--- a/projects/aws/eks-anywhere/build/fetch_binaries.sh
+++ b/projects/aws/eks-anywhere/build/fetch_binaries.sh
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 set -x
 set -o errexit
 set -o nounset
@@ -21,30 +22,8 @@ set -o pipefail
 MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 source "${MAKE_ROOT}/../../../build/lib/common.sh"
 
-OUTPUT_DIR="${MAKE_ROOT}/_output"
-EKS_A_DIAGNOSTIC_COLLECTOR_BINARY_DIR="${OUTPUT_DIR}/eks-a-diagnostic-collector-tools/binary"
-EKS_A_DIAGNOSTIC_COLLECTOR_TOOL_LICENSE_DIR="${OUTPUT_DIR}/eks-a-diagnostic-collector-tools/licenses"
-
-function unpack::tarballs(){
-  mkdir -p $OUTPUT_DIR
-  project="kubernetes"
-  base=$(basename $project)
-  mkdir $OUTPUT_DIR/$base
-  URL=$(build::eksd_releases::get_eksd_kubernetes_asset_url "kubernetes-client-linux-amd64.tar.gz")
-  curl -sSL "${URL}" -o $OUTPUT_DIR/tmp.tar.gz
-  tar xzf $OUTPUT_DIR/tmp.tar.gz -C $OUTPUT_DIR/$base
-}
-
-function copy::binaries::licenses(){
-  mkdir -p $EKS_A_DIAGNOSTIC_COLLECTOR_BINARY_DIR
-  mkdir -p $EKS_A_DIAGNOSTIC_COLLECTOR_TOOL_LICENSE_DIR
-  project="kubernetes/kubernetes"
-  binary="client/bin/kubectl"
-  license_prefix="KUBERNETES"
-  cp ./_output/$project/$binary $EKS_A_DIAGNOSTIC_COLLECTOR_BINARY_DIR/$(basename $binary)
-  cp ./_output/$project/ATTRIBUTION.txt $EKS_A_DIAGNOSTIC_COLLECTOR_TOOL_LICENSE_DIR/${license_prefix}_ATTRIBUTION.txt
-  cp -r ./_output/$project/LICENSES $EKS_A_DIAGNOSTIC_COLLECTOR_TOOL_LICENSE_DIR/${license_prefix}_LICENSES
-}
-
-unpack::tarballs
-copy::binaries::licenses
+mkdir -p kubernetes
+TARBALL="kubernetes-client-linux-amd64.tar.gz"
+URL=$(build::eksd_releases::get_eksd_kubernetes_asset_url $TARBALL)
+curl -sSL $URL -o ${TARBALL}
+tar xzf $TARBALL -C kubernetes

--- a/projects/aws/eks-anywhere/build/fetch_binaries.sh
+++ b/projects/aws/eks-anywhere/build/fetch_binaries.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -x
+set -o errexit
+set -o nounset
+set -o pipefail
+
+MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+source "${MAKE_ROOT}/../../../build/lib/common.sh"
+
+OUTPUT_DIR="${MAKE_ROOT}/_output"
+EKS_A_DIAGNOSTIC_COLLECTOR_BINARY_DIR="${OUTPUT_DIR}/eks-a-diagnostic-collector-tools/binary"
+EKS_A_DIAGNOSTIC_COLLECTOR_TOOL_LICENSE_DIR="${OUTPUT_DIR}/eks-a-diagnostic-collector-tools/licenses"
+
+function unpack::tarballs(){
+  mkdir -p $OUTPUT_DIR
+  project="kubernetes"
+  base=$(basename $project)
+  mkdir $OUTPUT_DIR/$base
+  URL=$(build::eksd_releases::get_eksd_kubernetes_asset_url "kubernetes-client-linux-amd64.tar.gz")
+  curl -sSL "${URL}" -o $OUTPUT_DIR/tmp.tar.gz
+  tar xzf $OUTPUT_DIR/tmp.tar.gz -C $OUTPUT_DIR/$base
+}
+
+function copy::binaries::licenses(){
+  mkdir -p $EKS_A_DIAGNOSTIC_COLLECTOR_BINARY_DIR
+  mkdir -p $EKS_A_DIAGNOSTIC_COLLECTOR_TOOL_LICENSE_DIR
+  project="kubernetes/kubernetes"
+  binary="client/bin/kubectl"
+  license_prefix="KUBERNETES"
+  cp ./_output/$project/$binary $EKS_A_DIAGNOSTIC_COLLECTOR_BINARY_DIR/$(basename $binary)
+  cp ./_output/$project/ATTRIBUTION.txt $EKS_A_DIAGNOSTIC_COLLECTOR_TOOL_LICENSE_DIR/${license_prefix}_ATTRIBUTION.txt
+  cp -r ./_output/$project/LICENSES $EKS_A_DIAGNOSTIC_COLLECTOR_TOOL_LICENSE_DIR/${license_prefix}_LICENSES
+}
+
+unpack::tarballs
+copy::binaries::licenses

--- a/projects/aws/eks-anywhere/docker/linux/Dockerfile
+++ b/projects/aws/eks-anywhere/docker/linux/Dockerfile
@@ -5,12 +5,6 @@ RUN yum install tar -y && \
     yum clean all && \
     rm -rf /var/cache/yum
 
-WORKDIR /
-
-ARG EKS_A_DIAGNOSTIC_COLLECTOR_BINARY_DIR=/eks-a-diagnostic-collector-tools/binary
-ARG EKS_A_DIAGNOSTIC_COLLECTOR_TOOL_LICENSE_DIR=/eks-a-diagnostic-collector-tools/licenses
-
-COPY ./_output/eks-a-diagnostic-collector-tools/binary $EKS_A_DIAGNOSTIC_COLLECTOR_BINARY_DIR
-COPY ./_output/eks-a-diagnostic-collector-tools/licenses $EKS_A_DIAGNOSTIC_COLLECTOR_TOOL_LICENSE_DIR
-
-ENV PATH="${EKS_A_DIAGNOSTIC_COLLECTOR_BINARY_DIR}:${PATH}"
+COPY kubernetes/kubernetes/client/bin/kubectl /usr/local/bin/kubectl
+COPY kubernetes/kubernetes/ATTRIBUTION.txt /KUBERNETES_ATTRIBUTION.txt
+COPY kubernetes/kubernetes/LICENSES /KUBERNETES_LICENSES

--- a/projects/aws/eks-anywhere/docker/linux/Dockerfile
+++ b/projects/aws/eks-anywhere/docker/linux/Dockerfile
@@ -12,3 +12,5 @@ ARG EKS_A_DIAGNOSTIC_COLLECTOR_TOOL_LICENSE_DIR=/eks-a-diagnostic-collector-tool
 
 COPY ./_output/eks-a-diagnostic-collector-tools/binary $EKS_A_DIAGNOSTIC_COLLECTOR_BINARY_DIR
 COPY ./_output/eks-a-diagnostic-collector-tools/licenses $EKS_A_DIAGNOSTIC_COLLECTOR_TOOL_LICENSE_DIR
+
+ENV PATH="${EKS_A_DIAGNOSTIC_COLLECTOR_BINARY_DIR}:${PATH}"

--- a/projects/aws/eks-anywhere/docker/linux/Dockerfile
+++ b/projects/aws/eks-anywhere/docker/linux/Dockerfile
@@ -2,4 +2,13 @@ ARG BASE_IMAGE # https://gallery.ecr.aws/eks-distro-build-tooling/eks-distro-bas
 FROM $BASE_IMAGE
 
 RUN yum install tar -y && \
-    yum clean all
+    yum clean all && \
+    rm -rf /var/cache/yum
+
+WORKDIR /
+
+ARG EKS_A_DIAGNOSTIC_COLLECTOR_BINARY_DIR=/eks-a-diagnostic-collector-tools/binary
+ARG EKS_A_DIAGNOSTIC_COLLECTOR_TOOL_LICENSE_DIR=/eks-a-diagnostic-collector-tools/licenses
+
+COPY ./_output/eks-a-diagnostic-collector-tools/binary $EKS_A_DIAGNOSTIC_COLLECTOR_BINARY_DIR
+COPY ./_output/eks-a-diagnostic-collector-tools/licenses $EKS_A_DIAGNOSTIC_COLLECTOR_TOOL_LICENSE_DIR


### PR DESCRIPTION
part of https://github.com/aws/eks-anywhere/issues/239

*Description of changes:*

Add `kubectl` binary to the eksa-diagnostic-collector image. 

This will allow us to use [`run`](https://troubleshoot.sh/docs/collect/run/) collectors for Troubleshoot to execute `kubectl` commands, specifically toward the goal of `describe`'ing our CRDs for analysis.
