### PR TITLE
Fix proxy template for bottlerocket bootstrap

### DIFF
--- a/projects/kubernetes-sigs/cluster-api/patches/0029-Fix-proxy-template-for-bottlerocket-bootstrap.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0029-Fix-proxy-template-for-bottlerocket-bootstrap.patch
@@ -1,0 +1,71 @@
+From 0ece5d5257b69ddde37aa27bb83c79b41a516d3f Mon Sep 17 00:00:00 2001
+From: Rajashree Mandaogane <mandaor@amazon.com>
+Date: Thu, 30 Sep 2021 14:04:36 -0700
+Subject: [PATCH] Fix proxy template for bottlerocket bootstrap
+
+Bottlerocket expects no-proxy setting to be a comma-separated list
+of strings. The proxy template was parsing the input no-proxy list
+and converting it to a string. This commit changes the template to
+get the desired format.
+
+Current generated value of no-proxy: "[localhost 127.0.0.1]"
+New generated value for no-proxy: ["localhost", "127.0.0.1"]
+
+cr: https://code.amazon.com/reviews/CR-58004615
+---
+ bootstrap/kubeadm/internal/bottlerocket/bootstrap.go    | 2 +-
+ bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go | 9 +++++++--
+ 2 files changed, 8 insertions(+), 3 deletions(-)
+
+diff --git a/bootstrap/kubeadm/internal/bottlerocket/bootstrap.go b/bootstrap/kubeadm/internal/bottlerocket/bootstrap.go
+index 886af6d87..4e1de77db 100644
+--- a/bootstrap/kubeadm/internal/bottlerocket/bootstrap.go
++++ b/bootstrap/kubeadm/internal/bottlerocket/bootstrap.go
+@@ -29,7 +29,7 @@ user-data = "{{.BootstrapContainerUserData}}"
+ 	networkInitTemplate = `{{ define "networkInitSettings" -}}
+ [settings.network]
+ https-proxy = "{{.HTTPSProxyEndpoint}}"
+-no-proxy = "{{.NoProxyEndpoints}}"
++no-proxy = [{{stringsJoin .NoProxyEndpoints "," }}]
+ {{- end -}}
+ `
+ 	registryMirrorTemplate = `{{ define "registryMirrorSettings" -}}
+diff --git a/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go b/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go
+index 15927ec20..7ce8e37d5 100644
+--- a/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go
++++ b/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go
+@@ -4,6 +4,7 @@ import (
+ 	"bytes"
+ 	"encoding/base64"
+ 	"fmt"
++	"strconv"
+ 	"strings"
+ 	"text/template"
+ 
+@@ -80,7 +81,7 @@ func generateAdminContainerUserData(kind string, tpl string, data interface{}) (
+ }
+ 
+ func generateNodeUserData(kind string, tpl string, data interface{}) ([]byte, error) {
+-	tm := template.New(kind)
++	tm := template.New(kind).Funcs(template.FuncMap{"stringsJoin": strings.Join})
+ 	if _, err := tm.Parse(bootstrapHostContainerTemplate); err != nil {
+ 		return nil, errors.Wrapf(err, "failed to parse hostContainer %s template", kind)
+ 	}
+@@ -132,9 +133,13 @@ func getBottlerocketNodeUserData(bootstrapContainerUserData []byte, users []boot
+ 		BootstrapContainerSource:   fmt.Sprintf("%s:%s", config.BottlerocketBootstrap.ImageRepository, config.BottlerocketBootstrap.ImageTag),
+ 		PauseContainerSource:       fmt.Sprintf("%s:%s", config.Pause.ImageRepository, config.Pause.ImageTag),
+ 		HTTPSProxyEndpoint:         config.ProxyConfiguration.HTTPSProxy,
+-		NoProxyEndpoints:           config.ProxyConfiguration.NoProxy,
+ 		RegistryMirrorEndpoint:     config.RegistryMirrorConfiguration.Endpoint,
+ 	}
++	if len(config.ProxyConfiguration.NoProxy) > 0 {
++		for _, noProxy := range config.ProxyConfiguration.NoProxy {
++			bottlerocketInput.NoProxyEndpoints = append(bottlerocketInput.NoProxyEndpoints, strconv.Quote(noProxy))
++		}
++	}
+ 	if config.RegistryMirrorConfiguration.CACert != "" {
+ 		bottlerocketInput.RegistryMirrorCACert = base64.StdEncoding.EncodeToString([]byte(config.RegistryMirrorConfiguration.CACert))
+ 	}
+-- 
+2.30.1
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bottlerocket expects no-proxy setting to be a comma-separated list
of strings. The proxy template was parsing the input no-proxy list
and converting it to a string. This commit changes the template to
get the desired format.

Current generated value of no-proxy: "[localhost 127.0.0.1]"
New generated value for no-proxy: ["localhost", "127.0.0.1"]

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
