### PR TITLE
Generate GOTK components manifest and upload to S3

### DIFF
--- a/projects/fluxcd/flux2/Makefile
+++ b/projects/fluxcd/flux2/Makefile
@@ -13,13 +13,17 @@ else
 	CLONE_URL?=https://github.com/$(COMPONENT).git
 endif
 
+AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
+AWS_REGION=us-west-2
+IMAGE_REPO=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
+
 .PHONY: upload-artifacts
 upload-artifacts:
 	build/upload_artifacts.sh $(TAR_PATH) $(ARTIFACTS_BUCKET) $(PROJECT_PATH) $(CODEBUILD_BUILD_NUMBER) $(CODEBUILD_RESOLVED_SOURCE_VERSION)
 
 .PHONY: create-binaries
 create-binaries:
-	build/create_binaries.sh $(REPO) $(CLONE_URL) $(GIT_TAG) $(GOLANG_VERSION)
+	build/create_binaries.sh $(REPO) $(CLONE_URL) $(GIT_TAG) $(GOLANG_VERSION) $(IMAGE_REPO)
 
 .PHONY: fetch-binaries
 fetch-binaries:

--- a/projects/fluxcd/flux2/build/create_binaries.sh
+++ b/projects/fluxcd/flux2/build/create_binaries.sh
@@ -23,6 +23,7 @@ REPO="${1?Specify first argument - repository name}"
 CLONE_URL="${2?Specify second argument - git clone endpoint}"
 TAG="${3?Specify third argument - git version tag}"
 GOLANG_VERSION="${4?Specify fourth argument - golang version}"
+IMAGE_REPO="${5?Specify fifth argument - ecr image repo}"
 BIN_ROOT="_output/bin"
 BIN_PATH=$BIN_ROOT/$REPO
 
@@ -47,6 +48,23 @@ function build::flux::create_binaries(){
   mv bin/* ../${BIN_PATH}/${OS}-${ARCH}/
 }
 
+function build::flux::create_manifests(){
+  mkdir -p ../_output/manifests/gotk/$TAG
+  FLUX_PATH="$MAKE_ROOT/$BIN_PATH/linux-amd64/flux"
+  $FLUX_PATH install --export > gotk-components.yaml
+  images=(
+    helm-controller
+    kustomize-controller
+    notification-controller
+    source-controller
+  )
+  for image in "${images[@]}"; do
+    sed -i "s,ghcr.io/fluxcd/$image:.*,$IMAGE_REPO/fluxcd/$image:latest," gotk-components.yaml
+  done
+
+  cp gotk-components.yaml "../_output/manifests/gotk/$TAG"
+}
+
 function build::flux::binaries(){
   mkdir -p $BIN_PATH
   mkdir $KUSTOMIZE_BIN
@@ -58,6 +76,7 @@ function build::flux::binaries(){
   build::common::use_go_version $GOLANG_VERSION
   go mod vendor
   build::flux::create_binaries "linux/amd64"
+  build::flux::create_manifests
   build::gather_licenses $MAKE_ROOT/_output "./cmd/flux"
   cd ..
   rm -rf $REPO

--- a/projects/fluxcd/flux2/build/create_tarballs.sh
+++ b/projects/fluxcd/flux2/build/create_tarballs.sh
@@ -24,6 +24,7 @@ TAG="${2?Specify second argument - git version tag}"
 TAR_PATH="${3?Specify third argument - tarball output path}"
 BIN_ROOT="_output/bin"
 LICENSES_PATH="_output/LICENSES"
+MANIFESTS_PATH="_output/manifests"
 
 MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 source "${MAKE_ROOT}/../../../build/lib/common.sh"
@@ -37,6 +38,7 @@ function build::flux::create_tarball() {
   cp -rf $LICENSES_PATH $BIN_ROOT/$REPO/${OS}-${ARCH}/
   cp ATTRIBUTION.txt $BIN_ROOT/$REPO/${OS}-${ARCH}/
   build::common::create_tarball ${TAR_PATH}/${TAR_FILE} $BIN_ROOT/$REPO/${OS}-${ARCH} .
+  cp -rf $MANIFESTS_PATH/ ${TAR_PATH}/
 }
 
 function build::flux::tarball() {


### PR DESCRIPTION
Closes https://github.com/aws/eks-anywhere/issues/402
To eliminate dependency on Github for Flux CRDs, we should generat ehe GitOps ToolKit CRD manifest matching the same version as the Flux version and upload it to S3. We can consume the same from the CLI.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
