### PR TITLE
Update Bottlerocket OVA links

### DIFF
--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_OVA_RELEASES
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_OVA_RELEASES
@@ -1,4 +1,4 @@
 1-20:
-    uri: https://bottlerocket-eks-anywhere.s3.us-west-2.amazonaws.com/bottlerocket-vmware-k8s-1.20-x86_64-v1.2.0.ova
+    uri: https://bottlerocket-eks-anywhere.s3.us-west-2.amazonaws.com/bottlerocket-vmware-k8s-1.20-x86_64-v1.3.0.ova
 1-21:
-    uri: https://bottlerocket-eks-anywhere.s3.us-west-2.amazonaws.com/bottlerocket-vmware-k8s-1.21-x86_64-v1.2.0.ova
+    uri: https://bottlerocket-eks-anywhere.s3.us-west-2.amazonaws.com/bottlerocket-vmware-k8s-1.21-x86_64-v1.3.0.ova


### PR DESCRIPTION
Bumping up Bottlerocket OVA links to latest release with CVE patches. The OVAs were downloaded using the instructions provided [here](https://github.com/aws/eks-anywhere/blob/main/docs/content/en/docs/reference/artifacts.md#bottlerocket).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
