### PR TITLE
Install additional yum packages as root

### DIFF
--- a/projects/kubernetes-sigs/image-builder/build/setup_bottlerocket.sh
+++ b/projects/kubernetes-sigs/image-builder/build/setup_bottlerocket.sh
@@ -25,6 +25,7 @@ CARGO_HOME="${2?Specify second argument - Root directory for Cargo installation}
 MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 RUSTUP_HOME=$MAKE_ROOT/_output/rustup
 BOTTLEROCKET_ROOT_JSON_URL="https://cache.bottlerocket.aws/root.json"
+CODEBUILD_CI="${CODEBUILD_CI:-false}"
 
 mkdir -p $BOTTLEROCKET_DOWNLOAD_PATH
 mkdir -p $CARGO_HOME
@@ -40,10 +41,10 @@ envsubst '$BOTTLEROCKET_ROOT_JSON_PATH' \
 curl $BOTTLEROCKET_ROOT_JSON_URL -o $BOTTLEROCKET_ROOT_JSON_PATH
 sha512sum -c $BOTTLEROCKET_DOWNLOAD_PATH/bottlerocket-root-json-checksum
 
-# On AL2, the Cargo build system requires the openssl-devel package
+# On Linux, the Cargo build system requires the openssl-devel package
 # for installing OpenSSL libraries and the pkgconfig utility to 
 # locate these headers/libs
-if [ "$(uname)" = "Linux" ]; then
+if [ "$CODEBUILD_CI" = "false" ] && [ "$(uname)" = "Linux" ]; then
     yum install -y openssl-devel pkgconfig
 fi
 

--- a/projects/kubernetes-sigs/image-builder/buildspecs/build-1-20-ubuntu-ova.yml
+++ b/projects/kubernetes-sigs/image-builder/buildspecs/build-1-20-ubuntu-ova.yml
@@ -13,6 +13,14 @@ env:
     VSPHERE_CONNECTION_DATA: "vsphere_ci_beta_connection:vsphere_connection_data"
 
 phases:
+  # On AL2, the Cargo build system requires the openssl-devel package
+  # for installing OpenSSL libraries and the pkgconfig utility to 
+  # locate these headers/libs
+  install:
+    run-as: root
+    commands:
+      - yum install -y openssl-devel pkgconfig
+
   pre_build:
     commands:
       - git config --global credential.helper '!aws codecommit credential-helper $@'

--- a/projects/kubernetes-sigs/image-builder/buildspecs/build-1-21-ubuntu-ova.yml
+++ b/projects/kubernetes-sigs/image-builder/buildspecs/build-1-21-ubuntu-ova.yml
@@ -13,6 +13,14 @@ env:
     VSPHERE_CONNECTION_DATA: "vsphere_ci_beta_connection:vsphere_connection_data"
 
 phases:
+  # On AL2, the Cargo build system requires the openssl-devel package
+  # for installing OpenSSL libraries and the pkgconfig utility to 
+  # locate these headers/libs
+  install:
+    run-as: root
+    commands:
+      - yum install -y openssl-devel pkgconfig
+
   pre_build:
     commands:
       - git config --global credential.helper '!aws codecommit credential-helper $@'


### PR DESCRIPTION
In Codebuild, OVA builds are run as the user `imagebuilder`, so `yum install`s should be done as root prior to kicking off builds.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
