### PR TITLE
Verify that git tag exists before checkout

### DIFF
--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -257,3 +257,19 @@ function build::common::get_latest_eksa_asset_url() {
   echo "https://$(basename $artifact_bucket).s3-us-west-2.amazonaws.com/projects/$project/latest/$(basename $project)-linux-amd64-${git_tag}.tar.gz"
 
 }
+
+function build::common::wait_for_tag() {
+  local -r tag=$1
+  sleep_interval=20
+  for i in {1..60}; do
+    echo "Checking for tag ${tag}..."
+    git fetch --tags > /dev/null 2>&1
+    git rev-parse --verify --quiet "${tag}" && echo "Tag ${tag} exists!" && break
+    echo "Tag ${tag} does not exist!"
+    echo "Waiting for tag ${tag}..."
+    sleep $sleep_interval
+    if [ "$i" = "60" ]; then
+      exit 1
+    fi
+  done
+}

--- a/projects/brancz/kube-rbac-proxy/build/create_binaries.sh
+++ b/projects/brancz/kube-rbac-proxy/build/create_binaries.sh
@@ -42,6 +42,7 @@ function build::kube-rbac-proxy::binaries(){
   mkdir -p $BIN_PATH
   git clone $CLONE_URL $REPO
   cd $REPO
+  build::common::wait_for_tag $TAG
   git checkout $TAG
   build::common::use_go_version $GOLANG_VERSION
   go mod vendor

--- a/projects/fluxcd/flux2/build/create_binaries.sh
+++ b/projects/fluxcd/flux2/build/create_binaries.sh
@@ -70,6 +70,7 @@ function build::flux::binaries(){
   mkdir $KUSTOMIZE_BIN
   git clone $CLONE_URL $REPO
   cd $REPO
+  build::common::wait_for_tag $TAG
   git checkout $TAG
   git apply --verbose $MAKE_ROOT/patches/*
   build::install::kustomize

--- a/projects/fluxcd/helm-controller/build/create_binaries.sh
+++ b/projects/fluxcd/helm-controller/build/create_binaries.sh
@@ -62,6 +62,7 @@ function build::helm-controller::binaries(){
   mkdir -p $BIN_PATH
   git clone $CLONE_URL $REPO
   cd $REPO
+  build::common::wait_for_tag $TAG
   git checkout $TAG
   build::common::use_go_version $GOLANG_VERSION
   go mod vendor

--- a/projects/fluxcd/kustomize-controller/build/create_binaries.sh
+++ b/projects/fluxcd/kustomize-controller/build/create_binaries.sh
@@ -55,6 +55,7 @@ function build::kustomize-controller::binaries(){
   mkdir -p $BIN_FILES
   git clone $CLONE_URL $REPO
   cd $REPO
+  build::common::wait_for_tag $TAG
   git checkout $TAG
   cp config/kubeconfig ../$BIN_FILES/
   build::common::use_go_version $GOLANG_VERSION

--- a/projects/fluxcd/notification-controller/build/create_binaries.sh
+++ b/projects/fluxcd/notification-controller/build/create_binaries.sh
@@ -53,6 +53,7 @@ function build::notification-controller::binaries(){
   mkdir -p $BIN_PATH
   git clone $CLONE_URL $REPO
   cd $REPO
+  build::common::wait_for_tag $TAG
   git checkout $TAG
   build::common::use_go_version $GOLANG_VERSION
   go mod vendor

--- a/projects/fluxcd/source-controller/build/create_binaries.sh
+++ b/projects/fluxcd/source-controller/build/create_binaries.sh
@@ -75,6 +75,7 @@ function build::source-controller::binaries(){
   mkdir -p $BIN_PATH
   git clone $CLONE_URL $REPO
   cd $REPO
+  build::common::wait_for_tag $TAG
   git checkout $TAG
   build::common::use_go_version $GOLANG_VERSION
   go mod vendor

--- a/projects/jetstack/cert-manager/build/create_binaries.sh
+++ b/projects/jetstack/cert-manager/build/create_binaries.sh
@@ -58,6 +58,7 @@ function build::cert-manager::binaries(){
   mkdir -p $BIN_PATH
   git clone $CLONE_URL $REPO
   cd $REPO
+  build::common::wait_for_tag $TAG
   git checkout $TAG
   build::cert-manager::cherry_pick
   build::common::use_go_version $GOLANG_VERSION

--- a/projects/kubernetes-sigs/cluster-api-provider-aws/build/create_binaries.sh
+++ b/projects/kubernetes-sigs/cluster-api-provider-aws/build/create_binaries.sh
@@ -62,6 +62,7 @@ function build::cluster-api-provider-aws::binaries(){
   cd $REPO
   source ./hack/version.sh;
   LDFLAGS=$(version::ldflags)
+  build::common::wait_for_tag $TAG
   git checkout $TAG
   build::common::use_go_version $GOLANG_VERSION
   go mod vendor

--- a/projects/kubernetes-sigs/cluster-api-provider-vsphere/build/create_binaries.sh
+++ b/projects/kubernetes-sigs/cluster-api-provider-vsphere/build/create_binaries.sh
@@ -60,6 +60,7 @@ function build::cluster-api-provider-vsphere::binaries(){
   cd $REPO
   source ./hack/version.sh;
   LDFLAGS=$(version::ldflags)
+  build::common::wait_for_tag $TAG
   git checkout $TAG
   git apply --verbose $MAKE_ROOT/patches/*
   build::common::use_go_version $GOLANG_VERSION

--- a/projects/kubernetes-sigs/cluster-api/build/create_binaries.sh
+++ b/projects/kubernetes-sigs/cluster-api/build/create_binaries.sh
@@ -113,6 +113,7 @@ function build::cluster-api::binaries(){
   mkdir -p $BIN_PATH
   git clone $CLONE_URL $REPO
   cd $REPO
+  build::common::wait_for_tag $TAG
   git checkout $TAG
   git apply --verbose $MAKE_ROOT/patches/*
   build::common::use_go_version $GOLANG_VERSION

--- a/projects/kubernetes-sigs/cri-tools/build/create_binaries.sh
+++ b/projects/kubernetes-sigs/cri-tools/build/create_binaries.sh
@@ -44,6 +44,7 @@ function build::cri-tools::binaries(){
   git clone $CLONE_URL $REPO
   cd $REPO
   COMMIT=$(git rev-parse HEAD 2>/dev/null)
+  build::common::wait_for_tag $TAG
   git checkout $TAG
   build::common::use_go_version $GOLANG_VERSION
   build::cri-tools::build_binaries "linux/amd64"

--- a/projects/kubernetes-sigs/etcdadm/build/create_binaries.sh
+++ b/projects/kubernetes-sigs/etcdadm/build/create_binaries.sh
@@ -43,6 +43,7 @@ function build::etcdadm::binaries(){
   mkdir -p $BIN_PATH
   git clone $CLONE_URL $REPO
   cd $REPO
+  build::common::wait_for_tag $TAG
   git checkout $TAG
   git apply --verbose $MAKE_ROOT/patches/*
   build::common::use_go_version $GOLANG_VERSION

--- a/projects/kubernetes-sigs/kind/build/create_binaries.sh
+++ b/projects/kubernetes-sigs/kind/build/create_binaries.sh
@@ -59,6 +59,7 @@ function build::kind::binaries(){
   git clone $CLONE_URL $REPO
   cd $REPO
   COMMIT=$(git rev-parse HEAD 2>/dev/null)
+  build::common::wait_for_tag $TAG
   git checkout $TAG    
   git apply --verbose $MAKE_ROOT/patches/*
   build::common::use_go_version $GOLANG_VERSION

--- a/projects/kubernetes-sigs/vsphere-csi-driver/build/create_binaries.sh
+++ b/projects/kubernetes-sigs/vsphere-csi-driver/build/create_binaries.sh
@@ -45,6 +45,7 @@ function build::vsphere-csi-driver::binaries(){
   mkdir -p $BIN_FILES
   git clone $CLONE_URL $REPO
   cd $REPO
+  build::common::wait_for_tag $TAG
   git checkout $TAG
   cp pkg/apis/cnsoperator/config/cnsregistervolume_crd.yaml pkg/apis/cnsoperator/config/cnsfileaccessconfig_crd.yaml pkg/internal/cnsoperator/config/cnsfilevolumeclient_crd.yaml ../$BIN_FILES/
   build::common::use_go_version $GOLANG_VERSION

--- a/projects/kubernetes/cloud-provider-vsphere/build/create_binaries.sh
+++ b/projects/kubernetes/cloud-provider-vsphere/build/create_binaries.sh
@@ -65,6 +65,7 @@ function build::cloud-provider-vsphere::binaries(){
   rm -rf $REPO
   git clone $CLONE_URL $REPO
   cd $REPO
+  build::common::wait_for_tag $TAG
   git checkout $TAG
   build::common::use_go_version $GOLANG_VERSION
   go mod vendor

--- a/projects/mrajashree/etcdadm-bootstrap-provider/build/create_binaries.sh
+++ b/projects/mrajashree/etcdadm-bootstrap-provider/build/create_binaries.sh
@@ -65,6 +65,7 @@ function build::etcdadm-bootstrap-provider::binaries(){
   mkdir $KUSTOMIZE_BIN
   git clone $CLONE_URL $REPO
   cd $REPO
+  build::common::wait_for_tag $TAG
   git checkout $TAG
   build::install::kustomize
   build::common::use_go_version $GOLANG_VERSION

--- a/projects/mrajashree/etcdadm-controller/build/create_binaries.sh
+++ b/projects/mrajashree/etcdadm-controller/build/create_binaries.sh
@@ -69,6 +69,7 @@ function build::etcdadm-controller::binaries(){
   mkdir $KUSTOMIZE_BIN
   git clone $CLONE_URL $REPO
   cd $REPO
+  build::common::wait_for_tag $TAG
   git checkout $TAG
   build::install::kustomize
   build::common::use_go_version $GOLANG_VERSION

--- a/projects/plunder-app/kube-vip/build/create_binaries.sh
+++ b/projects/plunder-app/kube-vip/build/create_binaries.sh
@@ -50,6 +50,7 @@ function build::kube-vip::binaries(){
   mkdir -p $BIN_PATH
   git clone $CLONE_URL $REPO
   cd $REPO
+  build::common::wait_for_tag $TAG
   git checkout $TAG
   build::common::use_go_version $GOLANG_VERSION
   build::kube-vip::fix_licenses

--- a/projects/rancher/local-path-provisioner/build/create_binaries.sh
+++ b/projects/rancher/local-path-provisioner/build/create_binaries.sh
@@ -42,6 +42,7 @@ function build::local-path-provisioner::binaries(){
   mkdir -p $BIN_PATH
   git clone $CLONE_URL $REPO
   cd $REPO
+  build::common::wait_for_tag $TAG
   git checkout $TAG
   build::common::use_go_version $GOLANG_VERSION
   go mod vendor

--- a/projects/replicatedhq/troubleshoot/build/create_binaries.sh
+++ b/projects/replicatedhq/troubleshoot/build/create_binaries.sh
@@ -53,6 +53,7 @@ function build::troubleshoot::binaries(){
   mkdir -p $BIN_PATH
   git clone $CLONE_URL $REPO
   cd $REPO
+  build::common::wait_for_tag $TAG
   git checkout $TAG
   git apply --verbose $MAKE_ROOT/patches/*
   build::common::use_go_version $GOLANG_VERSION

--- a/projects/vmware/govmomi/build/create_binaries.sh
+++ b/projects/vmware/govmomi/build/create_binaries.sh
@@ -42,6 +42,7 @@ function build::govmomi::binaries(){
   mkdir -p $BIN_PATH
   git clone $CLONE_URL $REPO
   cd $REPO
+  build::common::wait_for_tag $TAG
   git checkout $TAG
   build::common::use_go_version $GOLANG_VERSION
   go mod vendor


### PR DESCRIPTION
This function makes the project build wait until the tag is available on Codecommit through the sync Cronjob.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
