### PR TITLE
Enable prometheus metrics on Cilium

### DIFF
--- a/projects/cilium/cilium/build/create_manifests.sh
+++ b/projects/cilium/cilium/build/create_manifests.sh
@@ -35,7 +35,7 @@ function build::install::helm(){
 function build::cilium::manifests(){
   mkdir -p _output/manifests/cilium/$TAG
   helm repo add cilium https://helm.cilium.io
-  helm template cilium cilium/cilium --version $HELM_REPO_VERSION --namespace kube-system --set prometheus.enabled=true -f manifests/cilium-eksa.yaml > _output/manifests/cilium/${TAG}/cilium.yaml
+  helm template cilium cilium/cilium --version $HELM_REPO_VERSION --namespace kube-system -f manifests/cilium-eksa.yaml > _output/manifests/cilium/${TAG}/cilium.yaml
 }
 
 build::install::helm

--- a/projects/cilium/cilium/manifests/cilium-eksa.yaml
+++ b/projects/cilium/cilium/manifests/cilium-eksa.yaml
@@ -3,6 +3,8 @@ cni:
 ipam:
   mode: "kubernetes"
 identityAllocationMode: "crd"
+prometheus:
+  enabled: true
 tunnel: "geneve"
 image:
   repository: "public.ecr.aws/isovalent/cilium"
@@ -11,3 +13,5 @@ operator:
   image:
     repository: "public.ecr.aws/isovalent/operator"
     tag: "v1.9.10-eksa.1"
+  prometheus:
+    enabled: true


### PR DESCRIPTION
*Issue #, if available:*
Issue [#400](https://github.com/aws/eks-anywhere/issues/400)

*Description of changes:*
This change sets the prometheus value to true on the helm chart for Cilium deployments. This will help users scrape Cilium metrics with their Prometheus servers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
