### PR TITLE
Fix script root var assignment when uploading artifacts

### DIFF
--- a/build/lib/upload_artifacts.sh
+++ b/build/lib/upload_artifacts.sh
@@ -25,7 +25,7 @@ BUILD_IDENTIFIER="${4? Specify fourth argument - build identifier}"
 GIT_HASH="${5?Specify fifth argument - git hash of the tar builds}"
 
 
-MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
-source "${MAKE_ROOT}/../../../build/lib/common.sh"
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_ROOT}/common.sh"
 
 build::common::upload_artifacts $SRC_TAR_PATH $ARTIFACTS_BUCKET $PROJECT_PATH $BUILD_IDENTIFIER $GIT_HASH


### PR DESCRIPTION
Fixes issues with this script not being able to find the `common.sh` script.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
