### PR TITLE
Add githash to expected artifacts

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -6,6 +6,7 @@ MAKEFLAGS+=--no-builtin-rules --warn-undefined-variables
 RELEASE_BRANCH?=
 RELEASE_ENVIRONMENT?=development
 ARTIFACT_BUCKET?=my-s3-bucket
+GIT_HASH=$(shell git rev-parse HEAD)
 
 COMPONENT=$(REPO_OWNER)/$(REPO)
 ifdef CODEBUILD_SRC_DIR
@@ -146,14 +147,14 @@ attribution: $(ATTRIBUTION_TARGET)
 tarballs: ## Create tarballs by calling build/lib/simple_create_tarballs.sh unless SIMPLE_CREATE_TARBALLS=false, then calls build/create_tarballs.sh from project directory
 tarballs: $(GATHER_LICENSES_TARGET) $(OUTPUT_DIR)/ATTRIBUTION.txt
 ifeq ($(SIMPLE_CREATE_TARBALLS),true)
-	$(BASE_DIRECTORY)/build/lib/simple_create_tarballs.sh $(TAR_FILE_PREFIX) $(MAKE_ROOT)/$(OUTPUT_BIN_DIR) $(GIT_TAG) "$(BINARY_PLATFORMS)" $(ARTIFACTS_PATH)
+	$(BASE_DIRECTORY)/build/lib/simple_create_tarballs.sh $(TAR_FILE_PREFIX) $(MAKE_ROOT)/$(OUTPUT_BIN_DIR) $(GIT_TAG) "$(BINARY_PLATFORMS)" $(ARTIFACTS_PATH) $(GIT_HASH)
 else
 	build/create_tarballs.sh $(REPO) $(GIT_TAG) $(RELEASE_BRANCH)
 endif
 
 .PHONY: upload-artifacts
 upload-artifacts: s3-artifacts
-	$(BASE_DIRECTORY)/build/lib/upload_artifacts.sh $(ARTIFACTS_PATH) $(ARTIFACTS_BUCKET) $(PROJECT_PATH) $(CODEBUILD_BUILD_NUMBER) $(CODEBUILD_RESOLVED_SOURCE_VERSION)
+	$(BASE_DIRECTORY)/build/lib/upload_artifacts.sh $(ARTIFACTS_PATH) $(ARTIFACTS_BUCKET) $(PROJECT_PATH) $(CODEBUILD_BUILD_NUMBER) $(GIT_HASH)
 
 
 ##@ Checksum Targets

--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -76,8 +76,6 @@ function build::common::upload_artifacts() {
   local -r buildidentifier=$4
   local -r githash=$5
 
-  echo "$githash" >> "$artifactspath"/githash
-
   # Upload artifacts to s3 
   # 1. To proper path on s3 with buildId-githash
   # 2. Latest path to indicate the latest build, with --delete option to delete stale files in the dest path

--- a/build/lib/simple_create_binaries.sh
+++ b/build/lib/simple_create_binaries.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+set -x
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/build/lib/simple_create_tarballs.sh
+++ b/build/lib/simple_create_tarballs.sh
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -x
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -22,6 +23,7 @@ OUTPUT_BIN_DIR="$2"
 TAG="$3"
 BINARY_PLATFORMS="$4"
 TAR_PATH="$5"
+GIT_HASH="$6"
 
 LICENSES_PATH="_output/LICENSES"
 ATTRIBUTION_PATH="_output/ATTRIBUTION.txt"
@@ -43,6 +45,7 @@ function build::simple::tarball() {
     cp $ATTRIBUTION_PATH ${OUTPUT_BIN_DIR}/${OS}-${ARCH}/ 
     build::common::create_tarball ${TAR_PATH}/${TAR_FILE} ${OUTPUT_BIN_DIR}/${OS}-${ARCH} .
   done
+  echo $GIT_HASH > $TAR_PATH/githash
 }
 
 build::simple::tarball

--- a/projects/brancz/kube-rbac-proxy/expected_artifacts
+++ b/projects/brancz/kube-rbac-proxy/expected_artifacts
@@ -4,6 +4,7 @@ SHA256SUM.sha512
 SHA512SUM
 SHA512SUM.sha256
 SHA512SUM.sha512
+githash
 kube-rbac-proxy-linux-amd64-$GIT_TAG.tar.gz
 kube-rbac-proxy-linux-amd64-$GIT_TAG.tar.gz.sha256
 kube-rbac-proxy-linux-amd64-$GIT_TAG.tar.gz.sha512

--- a/projects/rancher/local-path-provisioner/expected_artifacts
+++ b/projects/rancher/local-path-provisioner/expected_artifacts
@@ -4,6 +4,7 @@ SHA256SUM.sha512
 SHA512SUM
 SHA512SUM.sha256
 SHA512SUM.sha512
+githash
 local-path-provisioner-linux-amd64-$GIT_TAG.tar.gz
 local-path-provisioner-linux-amd64-$GIT_TAG.tar.gz.sha256
 local-path-provisioner-linux-amd64-$GIT_TAG.tar.gz.sha512


### PR DESCRIPTION
This file is created in Codebuild, no reason why we shouldn't generalize it. This way we can maintain same set of artifacts locally, on Prow and on Codebuild as well.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
