### PR TITLE
Removing policyEnforcement to be always

### DIFF
--- a/projects/cilium/cilium/manifests/cilium-eksa.yaml
+++ b/projects/cilium/cilium/manifests/cilium-eksa.yaml
@@ -6,7 +6,6 @@ identityAllocationMode: "crd"
 prometheus:
   enabled: true
 tunnel: "geneve"
-policyEnforcementMode: "always"
 image:
   repository: "public.ecr.aws/isovalent/cilium"
   tag: "v1.9.10-eksa.1"


### PR DESCRIPTION
*Description of changes:*
Changing Cilium policy enforcement to be "default" from "always".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
