### PR TITLE
eks-anywhere-test: use al2 base image with nginx

### DIFF
--- a/projects/aws/eks-anywhere-test/Makefile
+++ b/projects/aws/eks-anywhere-test/Makefile
@@ -7,9 +7,9 @@ AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output tex
 AWS_REGION=us-west-2
 
 MAKE_ROOT=$(shell cd "$(shell dirname "${BASH_SOURCE[0]}")" && pwd -P)
-BASE_REPO?=public.ecr.aws/nginx
-BASE_IMAGE_NAME?=nginx
-BASE_TAG?=$(shell cat $(MAKE_ROOT)/BASE_TAG_FILE)
+BASE_REPO?=public.ecr.aws/eks-distro-build-tooling
+BASE_IMAGE_NAME?=eks-distro-minimal-base-glibc
+BASE_TAG?=$(shell cat $(MAKE_ROOT)/../../../EKS_DISTRO_MINIMAL_BASE_GLIBC_TAG_FILE)
 BASE_IMAGE?=$(BASE_REPO)/$(BASE_IMAGE_NAME):$(BASE_TAG)
 
 IMAGE_REPO?=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
@@ -25,6 +25,7 @@ local-images:
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64 \
 		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
+		--opt build-arg:BUILDER_IMAGE=$(BASE_REPO)/$(BASE_IMAGE_NAME)-builder:$(BASE_TAG) \
 		--local dockerfile=./docker/linux/ \
 		--local context=. \
 		--output type=oci,oci-mediatypes=true,\"name=$(IMAGE),$(LATEST_IMAGE)\",dest=/tmp/$(COMPONENT).tar
@@ -36,6 +37,7 @@ images:
 		--frontend dockerfile.v0 \
 		--opt platform=linux/amd64 \
 		--opt build-arg:BASE_IMAGE=$(BASE_IMAGE) \
+		--opt build-arg:BUILDER_IMAGE=$(BASE_REPO)/$(BASE_IMAGE_NAME)-builder:$(BASE_TAG) \
 		--local dockerfile=./docker/linux/ \
 		--local context=. \
 		--output type=image,oci-mediatypes=true,\"name=$(IMAGE),$(LATEST_IMAGE)\",push=true

--- a/projects/aws/eks-anywhere-test/conf/entrypoint.sh
+++ b/projects/aws/eks-anywhere-test/conf/entrypoint.sh
@@ -39,3 +39,5 @@ echo '{"podname":"${POD_NAME}","nodename":"$NODE_NAME","foo":"$foo","bar":"$bar"
 ln -s /usr/share/nginx/txt/index.json /usr/share/nginx/html/index.json
 
 export -n foo bar
+
+exec "$@"

--- a/projects/aws/eks-anywhere-test/docker/linux/Dockerfile
+++ b/projects/aws/eks-anywhere-test/docker/linux/Dockerfile
@@ -13,10 +13,38 @@
 # limitations under the License.
 
 ARG BASE_IMAGE
+ARG BUILDER_IMAGE
+FROM $BUILDER_IMAGE as nginx-builder
+
+RUN set -x && \
+    amazon-linux-extras enable nginx1 && \
+    cp /etc/yum.repos.d/amzn2-extras.repo /newroot/etc/yum.repos.d/amzn2-extras.repo && \
+    # manually "install" systemd to avoid installing the entire dep tree
+    clean_install systemd true true && \
+    clean_install "nginx" && \
+    # remove unncessary utils and other binary deps that are not needed by nginx during runtime
+    remove_package "chkconfig gawk grep info make openssl p11-kit p11-kit-trust sed shadow-utils" && \
+    remove_package systemd true && \
+    cleanup "nginx"
+
+# envsubst is needed to generate the config, but it comes from the gettext package
+# which pulls in a number of deps, manually installing envsubt from the rpm
+RUN set -x && \
+    yumdownloader --destdir=/tmp/downloads gettext && \
+    cd /newroot && \
+    rpm2cpio /tmp/downloads/gettext*.rpm | cpio -idv ./usr/bin/envsubst
+
+
 FROM $BASE_IMAGE
+
+COPY --from=nginx-builder /newroot /
 
 WORKDIR /
 
 ADD conf/index.template /usr/share/nginx/index.template
 ADD conf/default.conf /etc/nginx/conf.d/
-ADD conf/test.sh /docker-entrypoint.d/99-test.sh
+ADD conf/entrypoint.sh /entrypoint.sh
+
+STOPSIGNAL SIGQUIT
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Switch alpine based upstream nginx image to a al2 based off the minimal-glibc image.  This follows a similar pattern as defined in the [readme](https://github.com/aws/eks-distro-build-tooling/tree/main/eks-distro-base#readme) in eks-distro-build-tooling.  We may move this base to build-tooling at some point.

Nginx depends on libssl which haproxy also depends on.  We dont have the haproxy image in yet, but we will when we update to the new capd version.  I will probably add a libssl variant to base both of these off of.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
