### PR TITLE
Fix target for attribution generation

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -143,9 +143,9 @@ $(ATTRIBUTION_TARGET): $(GATHER_LICENSES_TARGET)
 gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGET) which gathers all licenses
 gather-licenses: $(GATHER_LICENSES_TARGET)
 
-.PHONY: attribution
-attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
-attribution: $(ATTRIBUTION_TARGET)
+.PHONY: generate-attribution
+generate-attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+generate-attribution: $(ATTRIBUTION_TARGET)
 
 ##@ Tarball Targets
 
@@ -216,7 +216,7 @@ validate-checksums: $(BINARY_TARGET)
 ##@ Build Targets
 
 .PHONY: build
-build: ## Called via prow presubmit, calls `binaries gather-licenses clean-repo local-images attribution checksums` by default
+build: ## Called via prow presubmit, calls `binaries gather-licenses clean-repo local-images generate-attribution checksums` by default
 build: FAKE_ARM_IMAGES_FOR_VALIDATION=true
 build: $(BINARY_TARGET) validate-checksums $(GATHER_LICENSES_TARGET) local-images $(ATTRIBUTION_TARGET)
 


### PR DESCRIPTION
Changing all attribution targets to `generate-attribution`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
