### PR TITLE
Adding rolloutCiliumPods to true

### DIFF
--- a/projects/cilium/cilium/manifests/cilium-eksa.yaml
+++ b/projects/cilium/cilium/manifests/cilium-eksa.yaml
@@ -5,6 +5,7 @@ ipam:
 identityAllocationMode: "crd"
 prometheus:
   enabled: true
+rollOutCiliumPods: true
 tunnel: "geneve"
 image:
   repository: "public.ecr.aws/isovalent/cilium"


### PR DESCRIPTION
*Description of changes:*
rolloutCiliumPods will monitor the `cilium-config` config map which holds the Cilium configuration and will rollout cilium agent pods when there is a new change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
