### PR TITLE
eks-anywhere-test helm chart: Adds config and secret annotations

### DIFF
--- a/projects/aws/eks-anywhere-test/helm/eks-anywhere-test/templates/deployment.yaml
+++ b/projects/aws/eks-anywhere-test/helm/eks-anywhere-test/templates/deployment.yaml
@@ -11,6 +11,10 @@ spec:
       app: eks-anywhere-test
   template:
     metadata:
+      annotations:
+        # https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments
+        checksum/config: {{ include (print $.Template.BasePath "/config.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       labels:
         app: eks-anywhere-test
     spec:


### PR DESCRIPTION
These checksums cause the deployment to be redeployed when a config map
or secret changes during a helm upgrade.

https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
