### PR TITLE
Remove redundant yum package installation

### DIFF
--- a/projects/cilium/cilium/build/create_manifests.sh
+++ b/projects/cilium/cilium/build/create_manifests.sh
@@ -27,8 +27,6 @@ HELM_BIN="${MAKE_ROOT}/_output/helm-bin"
 function build::install::helm(){
   mkdir -p $HELM_BIN
   export PATH=$HELM_BIN:$PATH
-  # TODO: install on builder base to avoid limitting this to linux machines for building
-  yum install -y openssl
   curl -s https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | HELM_INSTALL_DIR=$HELM_BIN bash
 }
 

--- a/projects/fluxcd/source-controller/build/install_deps.sh
+++ b/projects/fluxcd/source-controller/build/install_deps.sh
@@ -36,5 +36,3 @@ $BUILD_LIB/buildkit.sh build \
   --local context=. \
   --progress plain \
   --output type=local,dest=/
-
-yum install pkgconfig -y

--- a/projects/kubernetes-sigs/image-builder/build/setup_bottlerocket.sh
+++ b/projects/kubernetes-sigs/image-builder/build/setup_bottlerocket.sh
@@ -42,10 +42,9 @@ curl $BOTTLEROCKET_ROOT_JSON_URL -o $BOTTLEROCKET_ROOT_JSON_PATH
 sha512sum -c $BOTTLEROCKET_DOWNLOAD_PATH/bottlerocket-root-json-checksum
 
 # On Linux, the Cargo build system requires the openssl-devel package
-# for installing OpenSSL libraries and the pkgconfig utility to 
-# locate these headers/libs
+# for installing OpenSSL libraries
 if [ "$CODEBUILD_CI" = "false" ] && [ "$(uname)" = "Linux" ]; then
-    yum install -y openssl-devel pkgconfig
+    yum install -y openssl-devel
 fi
 
 # This code installs the Rust toolchain manager called rustup along

--- a/projects/kubernetes-sigs/image-builder/buildspecs/build-1-20-ubuntu-ova.yml
+++ b/projects/kubernetes-sigs/image-builder/buildspecs/build-1-20-ubuntu-ova.yml
@@ -14,12 +14,11 @@ env:
 
 phases:
   # On AL2, the Cargo build system requires the openssl-devel package
-  # for installing OpenSSL libraries and the pkgconfig utility to 
-  # locate these headers/libs
+  # for installing OpenSSL headers/libraries
   install:
     run-as: root
     commands:
-      - yum install -y openssl-devel pkgconfig
+      - yum install -y openssl-devel
 
   pre_build:
     commands:

--- a/projects/kubernetes-sigs/image-builder/buildspecs/build-1-21-ubuntu-ova.yml
+++ b/projects/kubernetes-sigs/image-builder/buildspecs/build-1-21-ubuntu-ova.yml
@@ -14,12 +14,11 @@ env:
 
 phases:
   # On AL2, the Cargo build system requires the openssl-devel package
-  # for installing OpenSSL libraries and the pkgconfig utility to 
-  # locate these headers/libs
+  # for installing OpenSSL headers/libraries
   install:
     run-as: root
     commands:
-      - yum install -y openssl-devel pkgconfig
+      - yum install -y openssl-devel
 
   pre_build:
     commands:


### PR DESCRIPTION
Removing yum installs of packages that are already on the builder-base image.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
