### PR TITLE
Fix filepath for mounted SSH key secret

### DIFF
--- a/build/update-attribution-files/create_pr.sh
+++ b/build/update-attribution-files/create_pr.sh
@@ -51,7 +51,7 @@ if [ "$FILES_ADDED" = "" ]; then
 fi
 
 git commit -m "$COMMIT_MESSAGE"
-ssh-agent bash -c 'ssh-add /secrets/ssh-secrets/ssh-privatekey; ssh -o StrictHostKeyChecking=no git@github.com; git fetch upstream; git rebase -Xtheirs upstream/main; git push -u origin $PR_BRANCH -f'
+ssh-agent bash -c 'ssh-add /secrets/ssh-secrets/ssh-key; ssh -o StrictHostKeyChecking=no git@github.com; git fetch upstream; git rebase -Xtheirs upstream/main; git push -u origin $PR_BRANCH -f'
 
 gh auth login --with-token < /secrets/github-secrets/token
 


### PR DESCRIPTION
This corresponds to the secret key in the postsubmits cluster.
[Reference](https://github.com/aws/eks-distro-build-tooling/blob/main/pr-scripts/create_pr.sh#L95)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
