### PR TITLE
Install QEMU during build setup

### DIFF
--- a/build/lib/setup.sh
+++ b/build/lib/setup.sh
@@ -4,6 +4,8 @@ set -x
 set -e
 set -o pipefail
 
+source /docker.sh 
+
 CODEBUILD_CI="${CODEBUILD_CI:-false}"
 GIT_CONFIG_SCOPE="--global"
 if [[ "$CODEBUILD_CI" = "true" ]] && [[ "$CODEBUILD_BUILD_ID" =~ "aws-staging-bundle-build" ]]; then
@@ -17,3 +19,7 @@ fi
 mv config/docker-ecr-config.json /root/.docker/config.json
 git config ${GIT_CONFIG_SCOPE} credential.helper '!aws codecommit credential-helper $@'
 git config ${GIT_CONFIG_SCOPE} credential.UseHttpPath true
+
+start::dockerd
+wait::for::dockerd
+docker run --privileged --rm public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0 --install aarch64

--- a/projects/kubernetes-sigs/kind/buildspec.yml
+++ b/projects/kubernetes-sigs/kind/buildspec.yml
@@ -4,7 +4,6 @@ phases:
   pre_build:
     commands:
     - ./build/lib/setup.sh
-    - /docker.sh
 
   build:
     commands:

--- a/release/staging-build.yml
+++ b/release/staging-build.yml
@@ -22,7 +22,6 @@ phases:
     run-as: root
     commands:
     - ./build/lib/setup.sh
-    - /docker.sh
 
   build:
     run-as: root


### PR DESCRIPTION
This PR adds a flag to the setup script to setup QEMU cross-platform emulation support. This will enable ARM64 builds for certain projects in CodeBuild.
/hold

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
