### PR TITLE
Copy top-level manifests folder when pushing to S3

### DIFF
--- a/projects/cilium/cilium/build/create_manifests.sh
+++ b/projects/cilium/cilium/build/create_manifests.sh
@@ -42,4 +42,4 @@ function build::cilium::manifests(){
 build::install::helm
 build::cilium::manifests
 
-cp -rf _output/manifests/cilium $ARTIFACTS_PATH
+cp -rf _output/manifests $ARTIFACTS_PATH

--- a/projects/cilium/cilium/expected_artifacts
+++ b/projects/cilium/cilium/expected_artifacts
@@ -1,1 +1,1 @@
-cilium/$GIT_TAG/cilium.yaml
+manifests/cilium/$GIT_TAG/cilium.yaml


### PR DESCRIPTION
Path is `projects/cilium/cilium/latest/manifests/cilium...`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
