### PR TITLE
Make buildspecs consistent, add artifacts upload target to filter

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -55,7 +55,7 @@ ifneq ($(RELEASE_BRANCH),)
 	# include release branch info in latest tag
 	LATEST_TAG:=$(GIT_TAG)-$(LATEST_TAG)
 else ifneq ($(and $(filter true,$(HAS_RELEASE_BRANCHES)), \
-	$(filter-out build release release-upload clean,$(MAKECMDGOALS))),)
+	$(filter-out build release upload-artifacts release-upload clean,$(MAKECMDGOALS))),)
 	# if project has release branches and not calling one of the above targets
 $(error When running targets for this project other than `build` or `release` a `RELEASE_BRANCH` is required)
 else ifeq ($(HAS_RELEASE_BRANCHES),true)

--- a/projects/fluxcd/helm-controller/buildspec.yml
+++ b/projects/fluxcd/helm-controller/buildspec.yml
@@ -9,6 +9,6 @@ phases:
     commands:
     - make release -C $PROJECT_PATH
 
-artifacts:
-  files:
-  - $PROJECT_PATH/$CODEBUILD_BUILD_NUMBER-$CODEBUILD_RESOLVED_SOURCE_VERSION/artifacts/*.gz
+  post_build:
+    commands:
+    - make upload-artifacts -C $PROJECT_PATH

--- a/projects/fluxcd/kustomize-controller/buildspec.yml
+++ b/projects/fluxcd/kustomize-controller/buildspec.yml
@@ -9,6 +9,6 @@ phases:
     commands:
     - make release -C $PROJECT_PATH
 
-artifacts:
-  files:
-  - $PROJECT_PATH/$CODEBUILD_BUILD_NUMBER-$CODEBUILD_RESOLVED_SOURCE_VERSION/artifacts/*.gz
+  post_build:
+    commands:
+    - make upload-artifacts -C $PROJECT_PATH

--- a/projects/fluxcd/notification-controller/buildspec.yml
+++ b/projects/fluxcd/notification-controller/buildspec.yml
@@ -9,6 +9,6 @@ phases:
     commands:
     - make release -C $PROJECT_PATH
 
-artifacts:
-  files:
-  - $PROJECT_PATH/$CODEBUILD_BUILD_NUMBER-$CODEBUILD_RESOLVED_SOURCE_VERSION/artifacts/*.gz
+  post_build:
+    commands:
+    - make upload-artifacts -C $PROJECT_PATH

--- a/projects/fluxcd/source-controller/buildspec.yml
+++ b/projects/fluxcd/source-controller/buildspec.yml
@@ -9,6 +9,6 @@ phases:
     commands:
     - make release -C $PROJECT_PATH
 
-artifacts:
-  files:
-  - $PROJECT_PATH/$CODEBUILD_BUILD_NUMBER-$CODEBUILD_RESOLVED_SOURCE_VERSION/artifacts/*.gz
+  post_build:
+    commands:
+    - make upload-artifacts -C $PROJECT_PATH

--- a/projects/jetstack/cert-manager/buildspec.yml
+++ b/projects/jetstack/cert-manager/buildspec.yml
@@ -9,6 +9,6 @@ phases:
     commands:
     - make release -C $PROJECT_PATH
 
-artifacts:
-  files:
-  - $PROJECT_PATH/$CODEBUILD_BUILD_NUMBER-$CODEBUILD_RESOLVED_SOURCE_VERSION/artifacts/*.gz
+  post_build:
+    commands:
+    - make upload-artifacts -C $PROJECT_PATH

--- a/projects/replicatedhq/troubleshoot/buildspec.yml
+++ b/projects/replicatedhq/troubleshoot/buildspec.yml
@@ -3,12 +3,12 @@ version: 0.2
 phases:
   pre_build:
     commands:
-      - ./build/lib/setup.sh
+    - ./build/lib/setup.sh
 
   build:
     commands:
-      - make release -C $PROJECT_PATH
+    - make release -C $PROJECT_PATH
 
   post_build:
     commands:
-      - make upload-artifacts -C $PROJECT_PATH
+    - make upload-artifacts -C $PROJECT_PATH


### PR DESCRIPTION
Fixes Codebuild looking for tarballs when uploading artifacts.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
