### PR TITLE
Override image component for diagnostic collector

### DIFF
--- a/projects/aws/eks-anywhere/Makefile
+++ b/projects/aws/eks-anywhere/Makefile
@@ -8,6 +8,7 @@ BASE_IMAGE_NAME?=eks-distro-base
 
 HAS_S3_ARTIFACTS=false
 SIMPLE_CREATE_BINARIES=false
+IMAGE_COMPONENT=eks-anywhere-diagnostic-collector
 
 
 include $(BASE_DIRECTORY)/Common.mk


### PR DESCRIPTION
This overrides the default name we set using the org and repository name.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
