### PR TITLE
Override image component for Bottlerocket bootstrap image

### DIFF
--- a/projects/aws/bottlerocket-bootstrap/Makefile
+++ b/projects/aws/bottlerocket-bootstrap/Makefile
@@ -6,6 +6,7 @@ REPO=bottlerocket-bootstrap
 REPO_OWNER=aws
 
 BASE_IMAGE_NAME?=eks-distro-base
+IMAGE_COMPONENT=bottlerocket-bootstrap
 
 LICENSE_PACKAGE_FILTER?=.
 BINARY_TARGET_FILES=bottlerocket-bootstrap


### PR DESCRIPTION
The image name is just `bottlerocket-bootstrap`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
