### PR TITLE
image-builder: improve ova built stability

### DIFF
--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -61,10 +61,10 @@ RELEASE_TARGETS+=$(addprefix release-ova-bottlerocket-, $(SUPPORTED_K8S_VERSIONS
 # Kubeadm hardcodes the version of the pause image it pulls, even tho containerd config
 # overrides which image is actually used
 # Setting up this mapping so we can build the additional image into the image
-ADDITIONAL_PAUSE_1-18=3.2
-ADDITIONAL_PAUSE_1-19=3.2
-ADDITIONAL_PAUSE_1-20=3.2
-ADDITIONAL_PAUSE_1-21=3.4.1
+ADDITIONAL_PAUSE_1-18_FROM=1-18
+ADDITIONAL_PAUSE_1-19_FROM=1-18
+ADDITIONAL_PAUSE_1-20_FROM=1-19
+ADDITIONAL_PAUSE_1-21_FROM=1-20
 
 .PHONY: setup-ami-share
 setup-ami-share:
@@ -104,7 +104,7 @@ upload-artifacts-%:
 
 .PHONY: setup-packer-configs-%
 setup-packer-configs-%:
-	build/setup_packer_configs.sh $* $(ARTIFACTS_BUCKET) $(OVA_PATH) $(ADDITIONAL_PAUSE_$*)
+	build/setup_packer_configs.sh $* $(ARTIFACTS_BUCKET) $(OVA_PATH) $(ADDITIONAL_PAUSE_$*_FROM)
 
 .PHONY: build-ami-ubuntu-2004-%
 build-ami-ubuntu-2004-%: setup-ami-share deps-ami setup-packer-configs-%

--- a/projects/kubernetes-sigs/image-builder/packer/config/additional_components.json.tmpl
+++ b/projects/kubernetes-sigs/image-builder/packer/config/additional_components.json.tmpl
@@ -1,5 +1,5 @@
 {
-    "additional_registry_images": "true",
-    "additional_registry_images_list": "$ADDITIONAL_PAUSE_IMAGE",
+    "additional_url_images": "true",
+    "additional_url_images_list": "$ADDITIONAL_PAUSE_IMAGE",
     "load_additional_components": "true"
 }

--- a/projects/kubernetes-sigs/image-builder/packer/config/validate_goss_inline_vars.json.tmpl
+++ b/projects/kubernetes-sigs/image-builder/packer/config/validate_goss_inline_vars.json.tmpl
@@ -14,7 +14,6 @@
 	"kubernetes_deb_version":"",
 	"kubernetes_rpm_version":"",
 	"kubernetes_source_type":"http",
-	"kubernetes_version":"$KUBERNETES_FULL_VERSION",
 	"pause_image": "$PAUSE_IMAGE"
 
 }

--- a/projects/kubernetes-sigs/image-builder/patches/0007-additional-eks-specific-goss-validations.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0007-additional-eks-specific-goss-validations.patch
@@ -25,7 +25,7 @@ index 2d6e8d5e..08d50743 100644
          "kubernetes_rpm_version": "{{ split (user `kubernetes_rpm_version`) \"-\" 0 }}",
          "kubernetes_source_type": "{{user `kubernetes_source_type`}}",
 -        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}"
-+        "kubernetes_version": "{{user `kubernetes_full_version` | replace \"v\" \"\" 1}}",
++        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}",
 +        "etcdadm_version": "{{ user `etcdadm_version` }}",
 +        "etcd_version": "{{ user `etcd_version` }}",
 +        "etcd_sha256": "{{ user `etcd_sha256` }}",
@@ -150,7 +150,7 @@ index 8742dbf3..eba70712 100644
          "kubernetes_rpm_version": "{{ split (user `kubernetes_rpm_version`) \"-\" 0  }}",
          "kubernetes_source_type": "{{user `kubernetes_source_type`}}",
 -        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}"
-+        "kubernetes_version": "{{user `kubernetes_full_version` | replace \"v\" \"\" 1}}",
++        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}",
 +        "etcdadm_version": "{{ user `etcdadm_version` }}",
 +        "etcd_version": "{{ user `etcd_version` }}",
 +        "etcd_sha256": "{{ user `etcd_sha256` }}",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Use pause.tar to pull in previous version pause image to make kubeadm init happy instead of pulling from ecr which will sometimes timeout on ssl handshake
- Use crictl sha256 file that now exists instead of generating it to avoid crictl building while image-builder and breaking checksum validation
- Fix goss validation due to change in version on kube binaries in latest eks-d releases

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
