### PR TITLE
Run local registry container in detached mode

### DIFF
--- a/projects/kubernetes-sigs/kind/buildspec.yml
+++ b/projects/kubernetes-sigs/kind/buildspec.yml
@@ -4,7 +4,7 @@ phases:
   pre_build:
     commands:
     - ./build/lib/setup.sh
-    - docker run --rm registry:2
+    - docker run -d --rm registry:2
 
   build:
     commands:


### PR DESCRIPTION
If run in the foreground, we won't get back to the Codebuild shell context.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
