### PR TITLE
kind: use proper etcdadm arch binary

### DIFF
--- a/projects/kubernetes-sigs/kind/build/build-kind-node-image.sh
+++ b/projects/kubernetes-sigs/kind/build/build-kind-node-image.sh
@@ -159,7 +159,7 @@ function build::kind::load_images(){
 
 
 function build::kind::download_additional_components() {
-    OUTPUT_FOLDER="$MAKE_ROOT/_output/$EKSD_RELEASE_BRANCH/dependencies"
+    OUTPUT_FOLDER="$MAKE_ROOT/_output/$EKSD_RELEASE_BRANCH/dependencies/linux-$ARCH"
 
     declare -A URLS=([$(build::eksd_releases::get_eksd_kubernetes_asset_url kubernetes-client-linux-$ARCH.tar.gz $EKSD_RELEASE_BRANCH $ARCH)]="kubernetes"
                   [$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET 'kubernetes-sigs/etcdadm' $ARCH)]="etcdadm"
@@ -186,8 +186,8 @@ function build::kind::download_additional_components() {
     done
     
     # Download etcd tarball to be placed in etcdadm cache directory to avoid downloading at runtime
-    ETCD_HTTP_SOURCE=$(build::eksd_releases::get_eksd_component_url "etcd" $EKSD_RELEASE_BRANCH)
-    ETCD_VERSION=$(build::eksd_releases::get_eksd_component_version "etcd" $EKSD_RELEASE_BRANCH)
+    ETCD_HTTP_SOURCE=$(build::eksd_releases::get_eksd_component_url "etcd" $EKSD_RELEASE_BRANCH $ARCH)
+    ETCD_VERSION=$(build::eksd_releases::get_eksd_component_version "etcd" $EKSD_RELEASE_BRANCH $ARCH)
     FOLDER="$OUTPUT_FOLDER/cache/etcdadm/etcd/$ETCD_VERSION"
     mkdir -p $FOLDER
     curl -sSL $ETCD_HTTP_SOURCE -o $FOLDER/etcd-$ETCD_VERSION-linux-$ARCH.tar.gz

--- a/projects/kubernetes-sigs/kind/images/node/Dockerfile
+++ b/projects/kubernetes-sigs/kind/images/node/Dockerfile
@@ -8,6 +8,9 @@ FROM $BUILDER_IMAGE-arm64 AS builder-arm64
 ARG TARGETARCH
 FROM builder-${TARGETARCH} AS builder
 
+ARG TARGETOS
+ARG TARGETARCH
+
 ARG IMAGE_REPO
 ARG AL2_HELPER_IMAGE
 ARG LOCAL_PATH_PROVISONER_IMAGE_TAG
@@ -29,10 +32,9 @@ RUN sed -i "s,$PAUSE_IMAGE_TAG,$PAUSE_IMAGE_TAG_OVERRIDE," /etc/containerd/confi
 RUN sed -i "s,image: $KINDNETD_IMAGE_TAG,image: $KIND_KINDNETD_RELEASE_OVERRIDE," /kind/manifests/default-cni.yaml
 
 # Add licenses/attribution + etcdadm + etcd tarball
-COPY LICENSES /LICENSES
-COPY etcdadm/etcdadm \
-     /usr/bin/
-COPY cache/etcdadm /var/cache/etcdadm
+COPY $TARGETOS-$TARGETARCH/LICENSES /LICENSES
+COPY $TARGETOS-$TARGETARCH/etcdadm/etcdadm /usr/bin/
+COPY $TARGETOS-$TARGETARCH/cache/etcdadm /var/cache/etcdadm
 
 # AL2 doesn't setup the ip6tables alternative the same as ubuntu
 # since kind's entrypoint assumes this adding the alternative


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
e2e presubmits are currently failing because the etcdadm binary in the amd64 kind image is actually the arm64 binary...

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
