### PR TITLE
move adding users/groups to container image to common

### DIFF
--- a/build/lib/docker/linux/useradd/Dockerfile
+++ b/build/lib/docker/linux/useradd/Dockerfile
@@ -1,0 +1,19 @@
+ARG BASE_IMAGE 
+ARG BUILDER_IMAGE
+
+FROM $BASE_IMAGE as base
+
+FROM $BUILDER_IMAGE as builder
+
+RUN yum install -y shadow-utils
+
+ARG IMAGE_USERADD_USER_NAME
+ARG IMAGE_USERADD_USER_ID
+
+COPY --from=base /etc/group /etc/group
+COPY --from=base /etc/passwd /etc/passwd
+RUN groupadd -r ${IMAGE_USERADD_USER_NAME} && \
+    useradd -r -g ${IMAGE_USERADD_USER_NAME} -u ${IMAGE_USERADD_USER_ID} ${IMAGE_USERADD_USER_NAME}
+
+FROM scratch
+COPY --from=builder /etc/group /etc/passwd ./etc/

--- a/projects/fluxcd/helm-controller/Makefile
+++ b/projects/fluxcd/helm-controller/Makefile
@@ -13,11 +13,14 @@ FIX_LICENSES_XEIPUUV_TARGET=$(REPO)/vendor/github.com/xeipuuv/gojsonpointer/LICE
 FIX_LICENSES_API_LICENSE_TARGET=$(REPO)/vendor/github.com/fluxcd/helm-controller/api/LICENSE
 
 BASE_IMAGE_NAME=eks-distro-minimal-base
+IMAGE_USERADD_USER_NAME=controller
 
 include $(BASE_DIRECTORY)/Common.mk
 
 
 $(GATHER_LICENSES_TARGETS): $(FIX_LICENSES_XEIPUUV_TARGET) $(FIX_LICENSES_API_LICENSE_TARGET)
+
+$(call IMAGE_TARGETS_FOR_NAME, helm-controller): helm-controller-useradd/images/export
 
 .PHONY: local-images
 local-images: helm-controller/images/amd64

--- a/projects/fluxcd/helm-controller/docker/linux/Dockerfile
+++ b/projects/fluxcd/helm-controller/docker/linux/Dockerfile
@@ -1,24 +1,10 @@
 ARG BASE_IMAGE # https://gallery.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base
-ARG BUILDER_IMAGE
-
-FROM $BASE_IMAGE as base
-
-FROM $BUILDER_IMAGE as builder
-
-COPY --from=base /etc/group /etc/group
-COPY --from=base /etc/passwd /etc/passwd
-RUN yum install -y shadow-utils && \
-    groupadd -r controller && \
-    useradd -r -g controller controller
-
 FROM $BASE_IMAGE
 
 ARG TARGETARCH
 ARG TARGETOS
 
-COPY --from=builder /etc/group /etc/group
-COPY --from=builder /etc/passwd /etc/passwd
-
+COPY _output/files/helm-controller /
 COPY _output/bin/helm-controller/$TARGETOS-$TARGETARCH/helm-controller /usr/local/bin/helm-controller
 COPY _output/LICENSES /LICENSES
 COPY ATTRIBUTION.txt /ATTRIBUTION.txt

--- a/projects/fluxcd/kustomize-controller/Makefile
+++ b/projects/fluxcd/kustomize-controller/Makefile
@@ -13,11 +13,14 @@ FIX_LICENSES_MOZILLA_TARGET=$(REPO)/vendor/go.mozilla.org/gopgagent/LICENSE.txt
 FIX_LICENSES_API_LICENSE_TARGET=$(REPO)/vendor/github.com/fluxcd/kustomize-controller/api/LICENSE
 
 BASE_IMAGE_NAME=eks-distro-minimal-base-git
+IMAGE_USERADD_USER_NAME=controller
 
 include $(BASE_DIRECTORY)/Common.mk
 
 
 $(GATHER_LICENSES_TARGETS): $(FIX_LICENSES_MOZILLA_TARGET) $(FIX_LICENSES_API_LICENSE_TARGET)
+
+$(call IMAGE_TARGETS_FOR_NAME, kustomize-controller): kustomize-controller-useradd/images/export
 
 .PHONY: local-images
 local-images: kustomize-controller/images/amd64

--- a/projects/fluxcd/kustomize-controller/docker/linux/Dockerfile
+++ b/projects/fluxcd/kustomize-controller/docker/linux/Dockerfile
@@ -1,25 +1,10 @@
 ARG BASE_IMAGE # https://gallery.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-git
-ARG BUILDER_IMAGE
-
-FROM $BASE_IMAGE as base
-
-FROM $BUILDER_IMAGE as builder
-
-COPY --from=base /etc/group /etc/group
-COPY --from=base /etc/passwd /etc/passwd
-RUN yum install -y shadow-utils && \
-    groupadd -r controller && \
-    useradd -r -g controller controller
-
-
 FROM $BASE_IMAGE
 
 ARG TARGETARCH
 ARG TARGETOS
 
-COPY --from=builder /etc/group /etc/group
-COPY --from=builder /etc/passwd /etc/passwd
-
+COPY _output/files/kustomize-controller /
 COPY _output/bin/kustomize-controller/$TARGETOS-$TARGETARCH/kustomize-controller /usr/local/bin/kustomize-controller
 COPY _output/LICENSES /LICENSES
 COPY ATTRIBUTION.txt /ATTRIBUTION.txt

--- a/projects/fluxcd/notification-controller/Makefile
+++ b/projects/fluxcd/notification-controller/Makefile
@@ -13,11 +13,14 @@ FIX_LICENSES_API_LICENSE_TARGET=$(REPO)/vendor/github.com/fluxcd/notification-co
 FIX_LICENSES_K0KUBUN_TARGET=$(REPO)/vendor/github.com/k0kubun/pp/LICENSE.txt
 
 BASE_IMAGE_NAME=eks-distro-minimal-base
+IMAGE_USERADD_USER_NAME=controller
 
 include $(BASE_DIRECTORY)/Common.mk
 
 
 $(GATHER_LICENSES_TARGETS): $(FIX_LICENSES_K0KUBUN_TARGET) $(FIX_LICENSES_API_LICENSE_TARGET)
+
+$(call IMAGE_TARGETS_FOR_NAME, notification-controller): notification-controller-useradd/images/export
 
 .PHONY: local-images
 local-images: notification-controller/images/amd64

--- a/projects/fluxcd/notification-controller/docker/linux/Dockerfile
+++ b/projects/fluxcd/notification-controller/docker/linux/Dockerfile
@@ -1,24 +1,10 @@
 ARG BASE_IMAGE # https://gallery.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base
-ARG BUILDER_IMAGE
-
-FROM $BASE_IMAGE as base
-
-FROM $BUILDER_IMAGE as builder
-
-COPY --from=base /etc/group /etc/group
-COPY --from=base /etc/passwd /etc/passwd
-RUN yum install -y shadow-utils && \
-    groupadd -r controller && \
-    useradd -r -g controller controller
-
 FROM $BASE_IMAGE
 
 ARG TARGETARCH
 ARG TARGETOS
 
-COPY --from=builder /etc/group /etc/group
-COPY --from=builder /etc/passwd /etc/passwd
-
+COPY _output/files/notification-controller /
 COPY _output/bin/notification-controller/$TARGETOS-$TARGETARCH/notification-controller /usr/local/bin/notification-controller
 COPY _output/LICENSES /LICENSES
 COPY ATTRIBUTION.txt /ATTRIBUTION.txt

--- a/projects/fluxcd/source-controller/Makefile
+++ b/projects/fluxcd/source-controller/Makefile
@@ -14,6 +14,7 @@ FIX_LICENSES_XEIPUUV_TARGET=$(REPO)/vendor/github.com/xeipuuv/gojsonpointer/LICE
 FIX_LICENSES_API_LICENSE_TARGET=$(REPO)/vendor/github.com/fluxcd/source-controller/api/LICENSE
 LIBGIT2_LICENSES_TARGET=$(OUTPUT_DIR)/LICENSES/github.com/libgit2/libgit2/COPYING
 BASE_IMAGE_NAME?=eks-distro-minimal-base-git
+IMAGE_USERADD_USER_NAME=controller
 
 CGO_DEPS_TARGET=$(CGO_SOURCE)/linux-%/lib64/libgit2.so
 CGO_CREATE_BINARIES=true
@@ -30,6 +31,8 @@ $(CGO_SOURCE)/linux-%/usr/lib64/libgit2.so:
 	$(MAKE) binary-builder-deps/cgo/$* IMAGE_TARGET=deps IMAGE_OUTPUT=dest=$(CGO_SOURCE)/linux-$*
 
 $(GATHER_LICENSES_TARGETS): | $(FIX_LICENSES_XEIPUUV_TARGET) $(FIX_LICENSES_API_LICENSE_TARGET) $(LIBGIT2_LICENSES_TARGET)
+
+$(call IMAGE_TARGETS_FOR_NAME, source-controller): source-controller-useradd/images/export
 
 .PHONY: local-images
 local-images: source-controller/images/amd64

--- a/projects/fluxcd/source-controller/docker/linux/Dockerfile
+++ b/projects/fluxcd/source-controller/docker/linux/Dockerfile
@@ -1,25 +1,10 @@
 ARG BASE_IMAGE # https://gallery.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-git
-ARG BUILDER_IMAGE
-
-FROM $BASE_IMAGE as base
-
-FROM $BUILDER_IMAGE as builder
-
-COPY --from=base /etc/group /etc/group
-COPY --from=base /etc/passwd /etc/passwd
-RUN yum install -y shadow-utils && \
-    groupadd -r controller && \
-    useradd -r -g controller controller
-
-
 FROM $BASE_IMAGE
 
 ARG TARGETARCH
 ARG TARGETOS
 
-COPY --from=builder /etc/group /etc/group
-COPY --from=builder /etc/passwd /etc/passwd
-
+COPY _output/files/source-controller /
 COPY _output/bin/source-controller/$TARGETOS-$TARGETARCH/source-controller /usr/local/bin/source-controller
 COPY _output/LICENSES /LICENSES
 COPY ATTRIBUTION.txt /ATTRIBUTION.txt

--- a/projects/jetstack/cert-manager/Makefile
+++ b/projects/jetstack/cert-manager/Makefile
@@ -20,6 +20,13 @@ SOURCE_PATTERNS=./cmd/acmesolver ./cmd/cainjector ./cmd/controller ./cmd/webhook
 
 include $(BASE_DIRECTORY)/Common.mk
 
+$(call IMAGE_TARGETS_FOR_NAME, cert-manager-acmesolver): cert-manager-acmesolver-useradd/images/export
+$(call IMAGE_TARGETS_FOR_NAME, cert-manager-cainjector): cert-manager-cainjector-useradd/images/export
+$(call IMAGE_TARGETS_FOR_NAME, cert-manager-acmesolver): cert-manager-controller-useradd/images/export
+
+cert-manager-acmesolver-useradd/images/export: IMAGE_USERADD_USER_NAME=acmesolver
+cert-manager-cainjector-useradd/images/export: IMAGE_USERADD_USER_NAME=cainjector
+cert-manager-controller-useradd/images/export: IMAGE_USERADD_USER_NAME=cert-manager
 
 .PHONY: local-images
 local-images: cert-manager-acmesolver/images/amd64 cert-manager-cainjector/images/amd64 cert-manager-controller/images/amd64 cert-manager-webhook/images/amd64

--- a/projects/jetstack/cert-manager/docker/linux/cert-manager-acmesolver/Dockerfile
+++ b/projects/jetstack/cert-manager/docker/linux/cert-manager-acmesolver/Dockerfile
@@ -1,22 +1,10 @@
 ARG BASE_IMAGE # https://gallery.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base
-ARG BUILDER_IMAGE
-
-FROM $BASE_IMAGE as base
-
-FROM $BUILDER_IMAGE as builder
-
-COPY --from=base /etc/group /etc/group
-COPY --from=base /etc/passwd /etc/passwd
-RUN yum install -y shadow-utils && \
-    useradd -r -u 1000 acmesolver
-
 FROM $BASE_IMAGE
 
 ARG TARGETARCH
 ARG TARGETOS
 
-COPY --from=builder /etc/group /etc/group
-COPY --from=builder /etc/passwd /etc/passwd
+COPY _output/files/cert-manager-acmesolver /
 COPY _output/bin/cert-manager/$TARGETOS-$TARGETARCH/cert-manager-acmesolver /usr/bin/acmesolver
 COPY _output/LICENSES /LICENSES
 COPY ATTRIBUTION.txt /ATTRIBUTION.txt

--- a/projects/jetstack/cert-manager/docker/linux/cert-manager-cainjector/Dockerfile
+++ b/projects/jetstack/cert-manager/docker/linux/cert-manager-cainjector/Dockerfile
@@ -1,22 +1,10 @@
 ARG BASE_IMAGE # https://gallery.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base
-ARG BUILDER_IMAGE
-
-FROM $BASE_IMAGE as base
-
-FROM $BUILDER_IMAGE as builder
-
-COPY --from=base /etc/group /etc/group
-COPY --from=base /etc/passwd /etc/passwd
-RUN yum install -y shadow-utils && \
-    useradd -r -u 1000 cainjector
-
 FROM $BASE_IMAGE
 
 ARG TARGETARCH
 ARG TARGETOS
 
-COPY --from=builder /etc/group /etc/group
-COPY --from=builder /etc/passwd /etc/passwd
+COPY _output/files/cert-manager-cainjector /
 COPY _output/bin/cert-manager/$TARGETOS-$TARGETARCH/cert-manager-cainjector /usr/bin/cainjector
 COPY _output/LICENSES /LICENSES
 COPY ATTRIBUTION.txt /ATTRIBUTION.txt

--- a/projects/jetstack/cert-manager/docker/linux/cert-manager-controller/Dockerfile
+++ b/projects/jetstack/cert-manager/docker/linux/cert-manager-controller/Dockerfile
@@ -1,22 +1,10 @@
 ARG BASE_IMAGE # https://gallery.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base
-ARG BUILDER_IMAGE
-
-FROM $BASE_IMAGE as base
-
-FROM $BUILDER_IMAGE as builder
-
-COPY --from=base /etc/group /etc/group
-COPY --from=base /etc/passwd /etc/passwd
-RUN yum install -y shadow-utils && \
-    useradd -r -u 1000 cert-manager
-
 FROM $BASE_IMAGE
 
 ARG TARGETARCH
 ARG TARGETOS
 
-COPY --from=builder /etc/group /etc/group
-COPY --from=builder /etc/passwd /etc/passwd
+COPY _output/files/cert-manager-controller /
 COPY _output/bin/cert-manager/$TARGETOS-$TARGETARCH/cert-manager-controller /usr/bin/cert-manager
 COPY _output/LICENSES /LICENSES
 COPY ATTRIBUTION.txt /ATTRIBUTION.txt


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There are a few container images where we add new users.  This standardizes that to a common target in Common.mk.  This should also help with reproducibility of container images using the buildkitd inline cache option.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
