### PR TITLE
create-pr: handle dry-run with multiple changes

### DIFF
--- a/build/update-attribution-files/create_pr.sh
+++ b/build/update-attribution-files/create_pr.sh
@@ -57,7 +57,7 @@ function pr:create()
         return 0
     fi
 
-    git checkout -b $pr_branch
+    git checkout -B $pr_branch
     git commit -m "$commit_message" || true
 
     if [ "$JOB_TYPE" != "periodic" ]; then


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

From time to time the vsphere-provider presubmit will fail due to the dry run of attribution generation.  This is due to the branch already existing when trying to create it.  This changes to use -B which will create or reset.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
