### PR TITLE
Run artifacts upload in dry-run mode outside of Codebuild

### DIFF
--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -76,12 +76,18 @@ function build::common::upload_artifacts() {
   local -r buildidentifier=$4
   local -r githash=$5
   local -r latesttag=$6
+  local -r dry_run=$7
 
-  # Upload artifacts to s3 
-  # 1. To proper path on s3 with buildId-githash
-  # 2. Latest path to indicate the latest build, with --delete option to delete stale files in the dest path
-  aws s3 sync "$artifactspath" "$artifactsbucket"/"$projectpath"/"$buildidentifier"-"$githash"/artifacts --acl public-read
-  aws s3 sync "$artifactspath" "$artifactsbucket"/"$projectpath"/"$latesttag" --delete --acl public-read
+  if [ "$dry_run" = "true" ]; then
+    aws s3 cp "$artifactspath" s3://"$artifactsbucket"/"$projectpath"/"$buildidentifier"-"$githash"/artifacts --recursive --dryrun
+    aws s3 cp "$artifactspath" s3://"$artifactsbucket"/"$projectpath"/latest --recursive --dryrun
+  else
+    # Upload artifacts to s3 
+    # 1. To proper path on s3 with buildId-githash
+    # 2. Latest path to indicate the latest build, with --delete option to delete stale files in the dest path
+    aws s3 sync "$artifactspath" "$artifactsbucket"/"$projectpath"/"$buildidentifier"-"$githash"/artifacts --acl public-read
+    aws s3 sync "$artifactspath" "$artifactsbucket"/"$projectpath"/"$latesttag" --delete --acl public-read
+  fi
 }
 
 function build::gather_licenses() {

--- a/build/lib/upload_artifacts.sh
+++ b/build/lib/upload_artifacts.sh
@@ -24,9 +24,9 @@ PROJECT_PATH="${3? Specify third argument - project path}"
 BUILD_IDENTIFIER="${4? Specify fourth argument - build identifier}"
 GIT_HASH="${5?Specify fifth argument - git hash of the tar builds}"
 LATEST_TAG="${6?Specify sixth argument - folder name corresponding to latest build}"
-
+UPLOAD_DRY_RUN="${7?Specify seventh argument - Dry run upload}"
 
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 source "${SCRIPT_ROOT}/common.sh"
 
-build::common::upload_artifacts $SRC_TAR_PATH $ARTIFACTS_BUCKET $PROJECT_PATH $BUILD_IDENTIFIER $GIT_HASH $LATEST_TAG
+build::common::upload_artifacts $SRC_TAR_PATH $ARTIFACTS_BUCKET $PROJECT_PATH $BUILD_IDENTIFIER $GIT_HASH $LATEST_TAG $UPLOAD_DRY_RUN

--- a/build/update-attribution-files/create_pr.sh
+++ b/build/update-attribution-files/create_pr.sh
@@ -18,7 +18,7 @@ set -o pipefail
 set -x
 
 if [[ -z "$JOB_TYPE" ]]; then
-    return 0
+    exit 0
 fi
 
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"


### PR DESCRIPTION
Run artifacts upload in dry run mode locally and in presubmits to validate upload S3 paths.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
