### PR TITLE
Add packer log to list of expected artifacts

### DIFF
--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -57,6 +57,7 @@ s3-artifacts: $(FINAL_UBUNTU_OVA_PATH) $(FINAL_BOTTLEROCKET_OVA_PATH)
 $(FAKE_UBUNTU_OVA_PATH):
 	@mkdir -p $(@D)
 	touch $@
+	touch $(ARTIFACTS_PATH)/packer.log
 
 $(FINAL_UBUNTU_OVA_PATH):
 	mv $(IMAGE_BUILDER_DIR)/output/*.ova $@

--- a/projects/kubernetes-sigs/image-builder/expected_artifacts
+++ b/projects/kubernetes-sigs/image-builder/expected_artifacts
@@ -9,6 +9,7 @@ SHA512SUM.sha512
 bottlerocket.ova
 bottlerocket.ova.sha256
 bottlerocket.ova.sha512
+packer.log
 ubuntu.ova
 ubuntu.ova.sha256
 ubuntu.ova.sha512


### PR DESCRIPTION
Packer logging is enabled and the log file is also uploaded to S3, and is one of the expected artifacts.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
