### PR TITLE
Add support for cipher suites in etcdadm

### DIFF
--- a/projects/kubernetes-sigs/etcdadm/CHECKSUMS
+++ b/projects/kubernetes-sigs/etcdadm/CHECKSUMS
@@ -1,2 +1,2 @@
-4d6834668338ab2d280e5e1328b9dea49acc17cc49de0d04b95241bba6c59a97  _output/bin/etcdadm/linux-amd64/etcdadm
-dfed80a70a594025d4ae1fe8cd4d130e034330d165299d12f2bb3e8c16ea7f48  _output/bin/etcdadm/linux-arm64/etcdadm
+97c5ebe4ae132cd2fcb86bc145d21acf9827b7816644c5e8e996283342abb1ce  _output/bin/etcdadm/linux-amd64/etcdadm
+36a7402508776994090f5cab62f19f02efc33c342566ddb31c808d8c84926a61  _output/bin/etcdadm/linux-arm64/etcdadm

--- a/projects/kubernetes-sigs/etcdadm/patches/0011-Add-support-for-cipher-suites.patch
+++ b/projects/kubernetes-sigs/etcdadm/patches/0011-Add-support-for-cipher-suites.patch
@@ -1,0 +1,105 @@
+From 3cbeef92a04c2d09bca28dfbd005080246781196 Mon Sep 17 00:00:00 2001
+From: Vivek Koppuru <koppv@amazon.com>
+Date: Wed, 1 Dec 2021 15:51:57 -0800
+Subject: [PATCH] Add support for cipher-suites
+
+---
+ apis/config.go         | 4 ++++
+ cmd/init.go            | 1 +
+ cmd/join.go            | 1 +
+ constants/constants.go | 2 ++
+ service/diff.go        | 3 ++-
+ service/unit.go        | 4 +++-
+ 6 files changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/apis/config.go b/apis/config.go
+index b530110d..7de11c5d 100644
+--- a/apis/config.go
++++ b/apis/config.go
+@@ -95,6 +95,10 @@ type EtcdAdmConfig struct {
+ 	InitSystem InitSystem
+ 
+ 	Endpoint string
++
++	// CipherSuites is a list of supported TLS cipher suites, mapping to the --cipher-suites flag.
++	// Default is empty, which means that they will be auto-populated by Go.
++	CipherSuites []string
+ }
+ 
+ // InitSystem represents the different types of init system
+diff --git a/cmd/init.go b/cmd/init.go
+index 835b6c00..2fe20179 100644
+--- a/cmd/init.go
++++ b/cmd/init.go
+@@ -52,6 +52,7 @@ func init() {
+ 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.ImageRepository, "image-repository", constants.DefaultImageRepository, "image repository when using kubelet init system")
+ 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.DataDir, "data-dir", constants.DefaultDataDir, "etcd data directory")
+ 	initCmd.PersistentFlags().StringVar(&etcdAdmConfig.PodSpecDir, "podspec-dir", constants.DefaultPodSpecDir, "kubelet podspec directory")
++	initCmd.PersistentFlags().StringSliceVar(&etcdAdmConfig.CipherSuites, "cipher-suites", etcdAdmConfig.CipherSuites, "optional list of supported TLS cipher suites between server/client and peers, can be multiple comma separated TLS cipher suites")
+ 
+ 	runner.registerPhasesAsSubcommands(initCmd)
+ }
+diff --git a/cmd/join.go b/cmd/join.go
+index 1be6c6af..97843998 100644
+--- a/cmd/join.go
++++ b/cmd/join.go
+@@ -51,6 +51,7 @@ func init() {
+ 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.ImageRepository, "image-repository", constants.DefaultImageRepository, "image repository when using kubelet init system")
+ 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.DataDir, "data-dir", constants.DefaultDataDir, "etcd data directory")
+ 	joinCmd.PersistentFlags().StringVar(&etcdAdmConfig.PodSpecDir, "podspec-dir", constants.DefaultPodSpecDir, "kubelet podspec directory")
++	joinCmd.PersistentFlags().StringSliceVar(&etcdAdmConfig.CipherSuites, "cipher-suites", etcdAdmConfig.CipherSuites, "optional list of supported TLS cipher suites between server/client and peers, can be multiple comma separated TLS cipher suites")
+ 
+ 	runner.registerPhasesAsSubcommands(joinCmd)
+ }
+diff --git a/constants/constants.go b/constants/constants.go
+index e5f6be80..cc8daca1 100644
+--- a/constants/constants.go
++++ b/constants/constants.go
+@@ -134,6 +134,8 @@ ETCD_CERT_FILE={{ .CertFile }}
+ ETCD_KEY_FILE={{ .KeyFile }}
+ ETCD_TRUSTED_CA_FILE={{ .TrustedCAFile }}
+ 
++ETCD_CIPHER_SUITES={{ StringsJoin .CipherSuites "," }}
++
+ # Other
+ ETCD_DATA_DIR={{ .DataDir }}
+ ETCD_STRICT_RECONFIG_CHECK=true
+diff --git a/service/diff.go b/service/diff.go
+index 9bcf2e1a..3874c9f3 100644
+--- a/service/diff.go
++++ b/service/diff.go
+@@ -98,7 +98,8 @@ func DiffVersion(cfg *apis.EtcdAdmConfig) (string, error) {
+ }
+ 
+ func desiredEnvironment(cfg *apis.EtcdAdmConfig) (map[string]string, error) {
+-	t := template.Must(template.New("environment").Parse(constants.EnvFileTemplate))
++	t := template.Must(template.New("environment").Funcs(template.FuncMap{"StringsJoin": strings.Join}).
++		Parse(constants.EnvFileTemplate))
+ 	var b bytes.Buffer
+ 	t.Execute(&b, cfg)
+ 	return makeEnvironment(&b)
+diff --git a/service/unit.go b/service/unit.go
+index f06e73b6..8beaaadd 100644
+--- a/service/unit.go
++++ b/service/unit.go
+@@ -22,6 +22,7 @@ import (
+ 	"html/template"
+ 	"os"
+ 	"path/filepath"
++	"strings"
+ 
+ 	"sigs.k8s.io/etcdadm/apis"
+ 	"sigs.k8s.io/etcdadm/constants"
+@@ -54,7 +55,8 @@ func WriteEnvironmentFile(cfg *apis.EtcdAdmConfig) error {
+ 
+ // BuildEnvironment returns the environment variables corresponding to the desired configuration
+ func BuildEnvironment(cfg *apis.EtcdAdmConfig) ([]byte, error) {
+-	t := template.Must(template.New("environment").Parse(constants.EnvFileTemplate))
++	t := template.Must(template.New("environment").Funcs(template.FuncMap{"StringsJoin": strings.Join}).
++		Parse(constants.EnvFileTemplate))
+ 
+ 	var b bytes.Buffer
+ 
+-- 
+2.27.0
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added support for `--cipher-suites` flag for etcdadm. Used template FuncMap to pass in a `strings.Join` function to display as a comma delimited list. An empty value for `ETCD_CIPHER_SUITES` is the same as it not being specified, so it would default to using an auto-populated list from go as it does today.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
