### PR TITLE
eks-anywhere-test: cleanup attribution handling for helm chart

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -309,7 +309,7 @@ $(OUTPUT_DIR)/images/%:
 	@mkdir -p $(@D)
 
 $(OUTPUT_DIR)/ATTRIBUTION.txt:
-	@mkdir $(OUTPUT_DIR)
+	@mkdir -p $(OUTPUT_DIR)
 	@cp $(ATTRIBUTION_TARGETS) $(OUTPUT_DIR)
 
 

--- a/Common.mk
+++ b/Common.mk
@@ -309,6 +309,7 @@ $(OUTPUT_DIR)/images/%:
 	@mkdir -p $(@D)
 
 $(OUTPUT_DIR)/ATTRIBUTION.txt:
+	@mkdir $(OUTPUT_DIR)
 	@cp $(ATTRIBUTION_TARGETS) $(OUTPUT_DIR)
 
 
@@ -389,9 +390,11 @@ validate-checksums: $(BINARY_TARGETS)
 
 .PHONY: helm/build
 helm/build: ## Build helm chart
+helm/build: $(OUTPUT_DIR)/ATTRIBUTION.txt
 	$(BUILD_LIB)/helm_build.sh $(IMAGE_REPO) $(IMAGE_COMPONENT) $(IMAGE_TAG) $(OUTPUT_DIR)
 
 .PHONY: helm/push
+helm/push: $(OUTPUT_DIR)/ATTRIBUTION.txt
 helm/push: ## Build helm chart and push to registry defined in IMAGE_REPO.
 	$(BUILD_LIB)/helm_build.sh $(IMAGE_REPO) $(IMAGE_COMPONENT) $(IMAGE_TAG) $(OUTPUT_DIR)
 	$(BUILD_LIB)/helm_push.sh $(IMAGE_REPO) $(IMAGE_COMPONENT) $(IMAGE_TAG) $(OUTPUT_DIR)

--- a/build/lib/helm_build.sh
+++ b/build/lib/helm_build.sh
@@ -27,10 +27,7 @@ export CHART_NAME=$(basename ${IMAGE_REPOSITORY})
 HELM_TEMP_DIR=${OUTPUT_DIR}/helm/${CHART_NAME}
 
 mkdir -p ${OUTPUT_DIR}/helm/${CHART_NAME}
-if [-f "${OUTPUT_DIR}/ATTRIBUTION.txt" ]
-then
-  cp ${OUTPUT_DIR}/ATTRIBUTION.txt ${HELM_TEMP_DIR}/
-fi
+cp ${OUTPUT_DIR}/ATTRIBUTION.txt ${HELM_TEMP_DIR}/
 cp -r helm/${CHART_NAME}/. ${HELM_TEMP_DIR}
 envsubst <helm/Chart.yaml.template >${HELM_TEMP_DIR}/Chart.yaml
 envsubst <helm/values.yaml.template >${HELM_TEMP_DIR}/values.yaml


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Follow up to #226, an attempt to improve the Attribution file handling.  Since we want to include the attribution in the helm chart, we can copy it into the output dir before calling helm just like we do for images.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
