### PR TITLE
Mark etcdadm bootstrap provider and controller as producing S3 artifacts

### DIFF
--- a/projects/mrajashree/etcdadm-bootstrap-provider/Makefile
+++ b/projects/mrajashree/etcdadm-bootstrap-provider/Makefile
@@ -9,8 +9,9 @@ BINARY_TARGET_FILES=manager
 
 BASE_IMAGE_NAME?=eks-distro-minimal-base
 
-include $(BASE_DIRECTORY)/Common.mk
+HAS_S3_ARTIFACTS=true
 
+include $(BASE_DIRECTORY)/Common.mk
 
 s3-artifacts: create-manifests
 

--- a/projects/mrajashree/etcdadm-bootstrap-provider/expected_artifacts
+++ b/projects/mrajashree/etcdadm-bootstrap-provider/expected_artifacts
@@ -1,0 +1,15 @@
+SHA256SUM
+SHA256SUM.sha256
+SHA256SUM.sha512
+SHA512SUM
+SHA512SUM.sha256
+SHA512SUM.sha512
+etcdadm-bootstrap-provider-linux-amd64-$GIT_TAG.tar.gz
+etcdadm-bootstrap-provider-linux-amd64-$GIT_TAG.tar.gz.sha256
+etcdadm-bootstrap-provider-linux-amd64-$GIT_TAG.tar.gz.sha512
+etcdadm-bootstrap-provider-linux-arm64-$GIT_TAG.tar.gz
+etcdadm-bootstrap-provider-linux-arm64-$GIT_TAG.tar.gz.sha256
+etcdadm-bootstrap-provider-linux-arm64-$GIT_TAG.tar.gz.sha512
+githash
+manifests/bootstrap-etcdadm-bootstrap/$GIT_TAG/bootstrap-components.yaml
+manifests/bootstrap-etcdadm-bootstrap/$GIT_TAG/metadata.yaml

--- a/projects/mrajashree/etcdadm-controller/Makefile
+++ b/projects/mrajashree/etcdadm-controller/Makefile
@@ -9,8 +9,9 @@ BINARY_TARGET_FILES=manager
 
 BASE_IMAGE_NAME?=eks-distro-minimal-base
 
-include $(BASE_DIRECTORY)/Common.mk
+HAS_S3_ARTIFACTS=true
 
+include $(BASE_DIRECTORY)/Common.mk
 
 s3-artifacts: create-manifests
 

--- a/projects/mrajashree/etcdadm-controller/expected_artifacts
+++ b/projects/mrajashree/etcdadm-controller/expected_artifacts
@@ -1,0 +1,15 @@
+SHA256SUM
+SHA256SUM.sha256
+SHA256SUM.sha512
+SHA512SUM
+SHA512SUM.sha256
+SHA512SUM.sha512
+etcdadm-controller-linux-amd64-$GIT_TAG.tar.gz
+etcdadm-controller-linux-amd64-$GIT_TAG.tar.gz.sha256
+etcdadm-controller-linux-amd64-$GIT_TAG.tar.gz.sha512
+etcdadm-controller-linux-arm64-$GIT_TAG.tar.gz
+etcdadm-controller-linux-arm64-$GIT_TAG.tar.gz.sha256
+etcdadm-controller-linux-arm64-$GIT_TAG.tar.gz.sha512
+githash
+manifests/bootstrap-etcdadm-controller/$GIT_TAG/bootstrap-components.yaml
+manifests/bootstrap-etcdadm-controller/$GIT_TAG/metadata.yaml


### PR DESCRIPTION
These were removed by mistake in a previous commit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
