### PR TITLE
Fix OVA S3 upload destinations

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -16,7 +16,7 @@ OUTPUT_BIN_DIR?=$(OUTPUT_DIR)/bin/$(REPO)
 #################### AWS ###########################
 AWS_REGION?=us-west-2
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
-ARTIFACTS_BUCKET?=my-s3-bucket
+ARTIFACTS_BUCKET?=s3://my-s3-bucket
 IMAGE_REPO?=$(if $(AWS_ACCOUNT_ID),$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com,localhost:5000)
 ####################################################
 
@@ -73,6 +73,7 @@ ifneq ($(and $(filter true,$(HAS_RELEASE_BRANCHES)),$(RELEASE_BRANCH)),)
 	ARTIFACTS_PATH:=$(ARTIFACTS_PATH)$(RELEASE_BRANCH_SUFFIX)
 	OUTPUT_DIR?=_output$(RELEASE_BRANCH_SUFFIX)
 	PROJECT_ROOT?=$(MAKE_ROOT)$(RELEASE_BRANCH_SUFFIX)
+	ARTIFACTS_UPLOAD_PATH?=$(PROJECT_PATH)$(RELEASE_BRANCH_SUFFIX)
 
 	# Deps are always released branched
 	BINARY_DEPS_DIR?=_output/$(RELEASE_BRANCH)/dependencies
@@ -92,6 +93,7 @@ else ifeq ($(HAS_RELEASE_BRANCHES),true)
 	GIT_TAG=non-existent
 else
 	PROJECT_ROOT?=$(MAKE_ROOT)
+	ARTIFACTS_UPLOAD_PATH?=$(PROJECT_PATH)
 	OUTPUT_DIR?=_output
 endif
 
@@ -363,7 +365,7 @@ endif
 
 .PHONY: upload-artifacts
 upload-artifacts: s3-artifacts
-	$(BASE_DIRECTORY)/build/lib/upload_artifacts.sh $(ARTIFACTS_PATH) $(ARTIFACTS_BUCKET) $(PROJECT_PATH) $(BUILD_IDENTIFIER) $(GIT_HASH) $(LATEST) $(UPLOAD_DRY_RUN)
+	$(BASE_DIRECTORY)/build/lib/upload_artifacts.sh $(ARTIFACTS_PATH) $(ARTIFACTS_BUCKET) $(ARTIFACTS_UPLOAD_PATH) $(BUILD_IDENTIFIER) $(GIT_HASH) $(LATEST) $(UPLOAD_DRY_RUN)
 
 .PHONY: s3-artifacts
 s3-artifacts: tarballs

--- a/UPSTREAM_PROJECTS.yaml
+++ b/UPSTREAM_PROJECTS.yaml
@@ -83,10 +83,10 @@ projects:
     repos:
       - name: etcdadm-bootstrap-provider
         versions:
-          - tag: v0.1.1
+          - tag: v0.1.2
       - name: etcdadm-controller
         versions:
-          - tag: v0.1.2
+          - tag: v0.1.3
   - org: plunder-app
     repos:
       - name: kube-vip

--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -79,8 +79,8 @@ function build::common::upload_artifacts() {
   local -r dry_run=$7
 
   if [ "$dry_run" = "true" ]; then
-    aws s3 cp "$artifactspath" s3://"$artifactsbucket"/"$projectpath"/"$buildidentifier"-"$githash"/artifacts --recursive --dryrun
-    aws s3 cp "$artifactspath" s3://"$artifactsbucket"/"$projectpath"/latest --recursive --dryrun
+    aws s3 cp "$artifactspath" "$artifactsbucket"/"$projectpath"/"$buildidentifier"-"$githash"/artifacts --recursive --dryrun
+    aws s3 cp "$artifactspath" "$artifactsbucket"/"$projectpath"/"$latesttag" --recursive --dryrun
   else
     # Upload artifacts to s3 
     # 1. To proper path on s3 with buildId-githash


### PR DESCRIPTION
Ensuring OVAs go to S3 folders named after release-branches.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
