### PR TITLE
Automated cherry pick of #240: fetch-binaries: use latest tag when deciding s3 folder

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -16,7 +16,7 @@ OUTPUT_BIN_DIR?=$(OUTPUT_DIR)/bin/$(REPO)
 #################### AWS ###########################
 AWS_REGION?=us-west-2
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
-ARTIFACTS_BUCKET?=my-s3-bucket
+ARTIFACTS_BUCKET?=s3://my-s3-bucket
 IMAGE_REPO?=$(if $(AWS_ACCOUNT_ID),$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com,localhost:5000)
 ####################################################
 
@@ -73,6 +73,7 @@ ifneq ($(and $(filter true,$(HAS_RELEASE_BRANCHES)),$(RELEASE_BRANCH)),)
 	ARTIFACTS_PATH:=$(ARTIFACTS_PATH)$(RELEASE_BRANCH_SUFFIX)
 	OUTPUT_DIR?=_output$(RELEASE_BRANCH_SUFFIX)
 	PROJECT_ROOT?=$(MAKE_ROOT)$(RELEASE_BRANCH_SUFFIX)
+	ARTIFACTS_UPLOAD_PATH?=$(PROJECT_PATH)$(RELEASE_BRANCH_SUFFIX)
 
 	# Deps are always released branched
 	BINARY_DEPS_DIR?=_output/$(RELEASE_BRANCH)/dependencies
@@ -92,6 +93,7 @@ else ifeq ($(HAS_RELEASE_BRANCHES),true)
 	GIT_TAG=non-existent
 else
 	PROJECT_ROOT?=$(MAKE_ROOT)
+	ARTIFACTS_UPLOAD_PATH?=$(PROJECT_PATH)
 	OUTPUT_DIR?=_output
 endif
 
@@ -363,7 +365,7 @@ endif
 
 .PHONY: upload-artifacts
 upload-artifacts: s3-artifacts
-	$(BASE_DIRECTORY)/build/lib/upload_artifacts.sh $(ARTIFACTS_PATH) $(ARTIFACTS_BUCKET) $(PROJECT_PATH) $(BUILD_IDENTIFIER) $(GIT_HASH) $(LATEST) $(UPLOAD_DRY_RUN)
+	$(BASE_DIRECTORY)/build/lib/upload_artifacts.sh $(ARTIFACTS_PATH) $(ARTIFACTS_BUCKET) $(ARTIFACTS_UPLOAD_PATH) $(BUILD_IDENTIFIER) $(GIT_HASH) $(LATEST) $(UPLOAD_DRY_RUN)
 
 .PHONY: s3-artifacts
 s3-artifacts: tarballs

--- a/Common.mk
+++ b/Common.mk
@@ -206,7 +206,7 @@ KUSTOMIZE_TARGET=$(OUTPUT_DIR)/kustomize
 ####################################################
 
 #################### TARGETS FOR OVERRIDING ########
-BUILD_TARGETS?=validate-checksums $(if $(IMAGE_NAMES),local-images,) attribution attribution-pr $(if $(filter true,$(HAS_S3_ARTIFACTS)),upload-artifacts,)
+BUILD_TARGETS?=validate-checksums $(if $(IMAGE_NAMES),local-images,) attribution $(if $(filter true,$(HAS_S3_ARTIFACTS)),upload-artifacts,) attribution-pr
 RELEASE_TARGETS?=validate-checksums $(if $(IMAGE_NAMES),images,) $(if $(filter true,$(HAS_S3_ARTIFACTS)),upload-artifacts,)
 ####################################################
 

--- a/Common.mk
+++ b/Common.mk
@@ -30,7 +30,7 @@ ifneq ($(BRANCH_NAME),main)
 	LATEST=$(BRANCH_NAME)
 endif
 ifneq ($(PULL_BASE_REF),main)
-	LATEST=$(BRANCH_NAME)
+	LATEST=$(PULL_BASE_REF)
 endif
 LATEST_TAG?=$(LATEST)
 ####################################################

--- a/Common.mk
+++ b/Common.mk
@@ -363,7 +363,7 @@ endif
 
 .PHONY: upload-artifacts
 upload-artifacts: s3-artifacts
-	$(BASE_DIRECTORY)/build/lib/upload_artifacts.sh $(ARTIFACTS_PATH) $(ARTIFACTS_BUCKET) $(PROJECT_PATH) $(BUILD_IDENTIFIER) $(GIT_HASH) $(LATEST_TAG) $(UPLOAD_DRY_RUN)
+	$(BASE_DIRECTORY)/build/lib/upload_artifacts.sh $(ARTIFACTS_PATH) $(ARTIFACTS_BUCKET) $(PROJECT_PATH) $(BUILD_IDENTIFIER) $(GIT_HASH) $(LATEST) $(UPLOAD_DRY_RUN)
 
 .PHONY: s3-artifacts
 s3-artifacts: tarballs
@@ -467,7 +467,7 @@ endif
 
 ##@ Fetch Binary Targets
 $(BINARY_DEPS_DIR)/linux-%:
-	$(BUILD_LIB)/fetch_binaries.sh $(BINARY_DEPS_DIR) $* $(ARTIFACTS_BUCKET) $(LATEST_TAG) $(RELEASE_BRANCH)
+	$(BUILD_LIB)/fetch_binaries.sh $(BINARY_DEPS_DIR) $* $(ARTIFACTS_BUCKET) $(LATEST) $(RELEASE_BRANCH)
 
 # Do not binary deps as intermediate files
 ifneq ($(FETCH_BINARIES_TARGETS),)

--- a/Common.mk
+++ b/Common.mk
@@ -21,9 +21,15 @@ IMAGE_REPO?=$(if $(AWS_ACCOUNT_ID),$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazo
 ####################################################
 
 #################### LATEST TAG ####################
+# codebuild
 BRANCH_NAME?=main
+# prow
+PULL_BASE_REF?=main
 LATEST=latest
 ifneq ($(BRANCH_NAME),main)
+	LATEST=$(BRANCH_NAME)
+endif
+ifneq ($(PULL_BASE_REF),main)
 	LATEST=$(BRANCH_NAME)
 endif
 LATEST_TAG?=$(LATEST)
@@ -461,7 +467,7 @@ endif
 
 ##@ Fetch Binary Targets
 $(BINARY_DEPS_DIR)/linux-%:
-	$(BUILD_LIB)/fetch_binaries.sh $(BINARY_DEPS_DIR) $* $(ARTIFACTS_BUCKET) $(RELEASE_BRANCH)
+	$(BUILD_LIB)/fetch_binaries.sh $(BINARY_DEPS_DIR) $* $(ARTIFACTS_BUCKET) $(LATEST_TAG) $(RELEASE_BRANCH)
 
 # Do not binary deps as intermediate files
 ifneq ($(FETCH_BINARIES_TARGETS),)

--- a/UPSTREAM_PROJECTS.yaml
+++ b/UPSTREAM_PROJECTS.yaml
@@ -83,10 +83,10 @@ projects:
     repos:
       - name: etcdadm-bootstrap-provider
         versions:
-          - tag: v0.1.1
+          - tag: v0.1.2
       - name: etcdadm-controller
         versions:
-          - tag: v0.1.2
+          - tag: v0.1.3
   - org: plunder-app
     repos:
       - name: kube-vip

--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -79,8 +79,8 @@ function build::common::upload_artifacts() {
   local -r dry_run=$7
 
   if [ "$dry_run" = "true" ]; then
-    aws s3 cp "$artifactspath" s3://"$artifactsbucket"/"$projectpath"/"$buildidentifier"-"$githash"/artifacts --recursive --dryrun
-    aws s3 cp "$artifactspath" s3://"$artifactsbucket"/"$projectpath"/latest --recursive --dryrun
+    aws s3 cp "$artifactspath" "$artifactsbucket"/"$projectpath"/"$buildidentifier"-"$githash"/artifacts --recursive --dryrun
+    aws s3 cp "$artifactspath" "$artifactsbucket"/"$projectpath"/"$latesttag" --recursive --dryrun
   else
     # Upload artifacts to s3 
     # 1. To proper path on s3 with buildId-githash

--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -264,9 +264,10 @@ function build::common::get_latest_eksa_asset_url() {
   local -r artifact_bucket=$1
   local -r project=$2
   local -r arch=${3-amd64}
+  local -r latesttag=${4-latest}
 
   local -r git_tag=$(cat $BUILD_ROOT/../../projects/${project}/GIT_TAG)
-  echo "https://$(basename $artifact_bucket).s3-us-west-2.amazonaws.com/projects/$project/latest/$(basename $project)-linux-$arch-${git_tag}.tar.gz"
+  echo "https://$(basename $artifact_bucket).s3-us-west-2.amazonaws.com/projects/$project/$latesttag/$(basename $project)-linux-$arch-${git_tag}.tar.gz"
 
 }
 

--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -267,8 +267,14 @@ function build::common::get_latest_eksa_asset_url() {
   local -r latesttag=${4-latest}
 
   local -r git_tag=$(cat $BUILD_ROOT/../../projects/${project}/GIT_TAG)
-  echo "https://$(basename $artifact_bucket).s3-us-west-2.amazonaws.com/projects/$project/$latesttag/$(basename $project)-linux-$arch-${git_tag}.tar.gz"
+  local -r url="https://$(basename $artifact_bucket).s3-us-west-2.amazonaws.com/projects/$project/latest/$(basename $project)-linux-$arch-${git_tag}.tar.gz"
 
+  local -r http_code=$(curl -I -L -s -o /dev/null -w "%{http_code}" $url)
+  if [[ "$http_code" == "200" ]]; then 
+    echo "$url"
+  else
+    echo "https://$(basename $artifact_bucket).s3-us-west-2.amazonaws.com/projects/$project/latest/$(basename $project)-linux-$arch-${git_tag}.tar.gz"
+  fi
 }
 
 function build::common::wait_for_tag() {

--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -267,7 +267,7 @@ function build::common::get_latest_eksa_asset_url() {
   local -r latesttag=${4-latest}
 
   local -r git_tag=$(cat $BUILD_ROOT/../../projects/${project}/GIT_TAG)
-  local -r url="https://$(basename $artifact_bucket).s3-us-west-2.amazonaws.com/projects/$project/latest/$(basename $project)-linux-$arch-${git_tag}.tar.gz"
+  local -r url="https://$(basename $artifact_bucket).s3-us-west-2.amazonaws.com/projects/$project/$latesttag/$(basename $project)-linux-$arch-${git_tag}.tar.gz"
 
   local -r http_code=$(curl -I -L -s -o /dev/null -w "%{http_code}" $url)
   if [[ "$http_code" == "200" ]]; then 

--- a/build/lib/fetch_binaries.sh
+++ b/build/lib/fetch_binaries.sh
@@ -25,7 +25,8 @@ source "${SCRIPT_ROOT}/common.sh"
 BINARY_DEPS_DIR="$1" 
 DEP="$2"
 ARTIFACTS_BUCKET="$3"
-RELEASE_BRANCH="${4-$(build::eksd_releases::get_release_branch)}"
+LATEST_TAG="$4"
+RELEASE_BRANCH="${5-$(build::eksd_releases::get_release_branch)}"
 
 DEP=${DEP#"$BINARY_DEPS_DIR"}
 OS_ARCH="$(cut -d '/' -f1 <<< ${DEP})"
@@ -53,7 +54,7 @@ if [[ $PRODUCT = 'eksd' ]]; then
     fi
 else
     TARBALL="$REPO-linux-$ARCH.tar.gz"
-    URL=$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET $REPO_OWNER/$REPO $ARCH)
+    URL=$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET $REPO_OWNER/$REPO $ARCH $LATEST_TAG)
 fi
 
 if [[ $REPO == *.tar.gz ]]; then

--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -106,7 +106,7 @@ deps-ova: $(GIT_PATCH_TARGET)
 
 .PHONY: setup-packer-configs
 setup-packer-configs:
-	build/setup_packer_configs.sh $(RELEASE_BRANCH) $(ARTIFACTS_BUCKET) $(ARTIFACTS_PATH) $(ADDITIONAL_PAUSE_$(RELEASE_BRANCH)_FROM) $(LATEST_TAG)
+	build/setup_packer_configs.sh $(RELEASE_BRANCH) $(ARTIFACTS_BUCKET) $(ARTIFACTS_PATH) $(ADDITIONAL_PAUSE_$(RELEASE_BRANCH)_FROM) $(LATEST)
 
 .PHONY: build-ami-ubuntu-2004
 build-ami-ubuntu-2004: MAKEFLAGS=

--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -106,7 +106,7 @@ deps-ova: $(GIT_PATCH_TARGET)
 
 .PHONY: setup-packer-configs
 setup-packer-configs:
-	build/setup_packer_configs.sh $(RELEASE_BRANCH) $(ARTIFACTS_BUCKET) $(ARTIFACTS_PATH) $(ADDITIONAL_PAUSE_$(RELEASE_BRANCH)_FROM)
+	build/setup_packer_configs.sh $(RELEASE_BRANCH) $(ARTIFACTS_BUCKET) $(ARTIFACTS_PATH) $(ADDITIONAL_PAUSE_$(RELEASE_BRANCH)_FROM) $(LATEST_TAG)
 
 .PHONY: build-ami-ubuntu-2004
 build-ami-ubuntu-2004: MAKEFLAGS=

--- a/projects/kubernetes-sigs/image-builder/build/setup_packer_configs.sh
+++ b/projects/kubernetes-sigs/image-builder/build/setup_packer_configs.sh
@@ -23,6 +23,7 @@ RELEASE_BRANCH="${1?Specify first argument - release branch}"
 ARTIFACTS_BUCKET="${2?Specify second argument - artifact bucket}"
 OVA_PATH="${3? Specify the third argument - ova output path}"
 ADDITIONAL_PAUSE_IMAGE_FROM="${4? Specify the fourth argument - additional pause image}"
+LATEST_TAG="${5? Specify the fifth argument - latest tag}"
 
 CI="${CI:-false}"
 
@@ -70,10 +71,10 @@ export KUBERNETES_FULL_VERSION="$KUBERNETES_VERSION-eks-$RELEASE_BRANCH-$EKSD_RE
 export ETCD_HTTP_SOURCE=$(build::eksd_releases::get_eksd_component_url "etcd" $RELEASE_BRANCH)
 export ETCD_VERSION=$(build::eksd_releases::get_eksd_component_version "etcd" $RELEASE_BRANCH)
 export ETCD_SHA256=$(build::eksd_releases::get_eksd_component_sha "etcd" $RELEASE_BRANCH)
-export ETCDADM_HTTP_SOURCE=${ETCDADM_HTTP_SOURCE:-$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET 'kubernetes-sigs/etcdadm')}
+export ETCDADM_HTTP_SOURCE=${ETCDADM_HTTP_SOURCE:-$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET 'kubernetes-sigs/etcdadm' 'amd64' $LATEST_TAG)}
 # TODO: fix etcdadm build to set correct version
 export ETCDADM_VERSION='v0.0.0-master+$Format:%h$'
-export CRICTL_URL=${CRICTL_URL:-$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET 'kubernetes-sigs/cri-tools')}
+export CRICTL_URL=${CRICTL_URL:-$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET 'kubernetes-sigs/cri-tools' 'amd64' $LATEST_TAG))}
 export CRICTL_SHA256="$CRICTL_URL.sha256"
 
 envsubst '$IMAGE_REPO:$KUBERNETES_ASSET_BASE_URL:$KUBERNETES_VERSION:$KUBERNETES_SERIES:$CRICTL_URL:$CRICTL_SHA256:$ETCD_HTTP_SOURCE:$ETCD_VERSION:$ETCDADM_HTTP_SOURCE:$ETCD_SHA256:$ETCDADM_VERSION:$KUBERNETES_FULL_VERSION' \

--- a/projects/kubernetes-sigs/kind/Makefile
+++ b/projects/kubernetes-sigs/kind/Makefile
@@ -116,7 +116,7 @@ kind-node-extract-kindnetd/images/amd64: IMAGE_OUTPUT_TYPE=local
 kind-node-extract-kindnetd/images/amd64: IMAGE_OUTPUT=dest=$(ARTIFACTS_PATH)
 
 $(KIND_BASE_IMAGE_BUILD_ARGS):
-	build/base-image-build-args.sh $(RELEASE_BRANCH) $(ARTIFACTS_BUCKET) $@
+	build/base-image-build-args.sh $(RELEASE_BRANCH) $(ARTIFACTS_BUCKET) $@ $(LATEST_TAG)
 
 $(KIND_NODE_IMAGE_BUILD_ARGS):
 	build/node-image-build-args.sh $(RELEASE_BRANCH) $(KINDNETD_IMAGE_COMPONENT) $(IMAGE_REPO) $(ARTIFACTS_BUCKET) $(IMAGE_TAG) $(LATEST_TAG) $(LATEST) $@

--- a/projects/kubernetes-sigs/kind/Makefile
+++ b/projects/kubernetes-sigs/kind/Makefile
@@ -116,7 +116,7 @@ kind-node-extract-kindnetd/images/amd64: IMAGE_OUTPUT_TYPE=local
 kind-node-extract-kindnetd/images/amd64: IMAGE_OUTPUT=dest=$(ARTIFACTS_PATH)
 
 $(KIND_BASE_IMAGE_BUILD_ARGS):
-	build/base-image-build-args.sh $(RELEASE_BRANCH) $(ARTIFACTS_BUCKET) $@ $(LATEST_TAG)
+	build/base-image-build-args.sh $(RELEASE_BRANCH) $(ARTIFACTS_BUCKET) $@ $(LATEST)
 
 $(KIND_NODE_IMAGE_BUILD_ARGS):
 	build/node-image-build-args.sh $(RELEASE_BRANCH) $(KINDNETD_IMAGE_COMPONENT) $(IMAGE_REPO) $(ARTIFACTS_BUCKET) $(IMAGE_TAG) $(LATEST_TAG) $(LATEST) $@

--- a/projects/kubernetes-sigs/kind/build/base-image-build-args.sh
+++ b/projects/kubernetes-sigs/kind/build/base-image-build-args.sh
@@ -20,6 +20,7 @@ set -o pipefail
 EKSD_RELEASE_BRANCH="$1"
 ARTIFACTS_BUCKET="$2"
 OUTPUT_FILE="$3"
+LATEST_TAG="$4"
 
 MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 BUILD_LIB="${MAKE_ROOT}/../../../build/lib"
@@ -39,8 +40,8 @@ CNI_PLUGINS_ARM64_URL=$(build::eksd_releases::get_eksd_component_url "cni-plugin
 CNI_PLUGINS_AMD64_SHA256SUM=$(build::eksd_releases::get_eksd_component_sha "cni-plugins" $EKSD_RELEASE_BRANCH amd64)
 CNI_PLUGINS_ARM64_SHA256SUM=$(build::eksd_releases::get_eksd_component_sha "cni-plugins" $EKSD_RELEASE_BRANCH arm64)
 
-CRICTL_AMD64_URL=$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET 'kubernetes-sigs/cri-tools' amd64)
-CRICTL_ARM64_URL=$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET 'kubernetes-sigs/cri-tools' arm64)
+CRICTL_AMD64_URL=$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET 'kubernetes-sigs/cri-tools' amd64 $LATEST_TAG))
+CRICTL_ARM64_URL=$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET 'kubernetes-sigs/cri-tools' arm64 $LATEST_TAG)
 CRICTL_AMD64_SHA256SUM_URL=$CRICTL_AMD64_URL.sha256
 CRICTL_ARM64_SHA256SUM_URL=$CRICTL_ARM64_URL.sha256
 

--- a/projects/kubernetes-sigs/kind/build/base-image-build-args.sh
+++ b/projects/kubernetes-sigs/kind/build/base-image-build-args.sh
@@ -40,7 +40,7 @@ CNI_PLUGINS_ARM64_URL=$(build::eksd_releases::get_eksd_component_url "cni-plugin
 CNI_PLUGINS_AMD64_SHA256SUM=$(build::eksd_releases::get_eksd_component_sha "cni-plugins" $EKSD_RELEASE_BRANCH amd64)
 CNI_PLUGINS_ARM64_SHA256SUM=$(build::eksd_releases::get_eksd_component_sha "cni-plugins" $EKSD_RELEASE_BRANCH arm64)
 
-CRICTL_AMD64_URL=$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET 'kubernetes-sigs/cri-tools' amd64 $LATEST_TAG))
+CRICTL_AMD64_URL=$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET 'kubernetes-sigs/cri-tools' amd64 $LATEST_TAG)
 CRICTL_ARM64_URL=$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET 'kubernetes-sigs/cri-tools' arm64 $LATEST_TAG)
 CRICTL_AMD64_SHA256SUM_URL=$CRICTL_AMD64_URL.sha256
 CRICTL_ARM64_SHA256SUM_URL=$CRICTL_ARM64_URL.sha256


### PR DESCRIPTION
Cherry pick of #240 on v1beta1-experimental.

#240: fetch-binaries: use latest tag when deciding s3 folder

For details on the cherry pick process, see the [cherry pick requests](https://github.com/aws/eks-anywhere-build-tooling/tree/main/docs/development/cherry-picks.md) page.

```release-note

```