### PR TITLE
etcdadm: fix version by setting proper ldflags

### DIFF
--- a/projects/kubernetes-sigs/etcdadm/CHECKSUMS
+++ b/projects/kubernetes-sigs/etcdadm/CHECKSUMS
@@ -1,2 +1,2 @@
-97c5ebe4ae132cd2fcb86bc145d21acf9827b7816644c5e8e996283342abb1ce  _output/bin/etcdadm/linux-amd64/etcdadm
-36a7402508776994090f5cab62f19f02efc33c342566ddb31c808d8c84926a61  _output/bin/etcdadm/linux-arm64/etcdadm
+7f91c0872c35ce6f727a524a95a3d6b959c9ec0d24582b201749e79153faf144  _output/bin/etcdadm/linux-amd64/etcdadm
+39bb47b5336672e7f46fc4cb75ff06cd68b3c20bff4071f9eb15730a0a9ea964  _output/bin/etcdadm/linux-arm64/etcdadm

--- a/projects/kubernetes-sigs/etcdadm/Makefile
+++ b/projects/kubernetes-sigs/etcdadm/Makefile
@@ -6,6 +6,7 @@ REPO=etcdadm
 REPO_OWNER=kubernetes-sigs
 
 BINARY_TARGET_FILES=etcdadm
+EXTRA_GO_LDFLAGS=$(shell $(BUILD_LIB)/version.sh $(REPO) k8s.io/component-base/version)
 
 HAS_S3_ARTIFACTS=true
 

--- a/projects/kubernetes-sigs/etcdadm/README.md
+++ b/projects/kubernetes-sigs/etcdadm/README.md
@@ -3,3 +3,23 @@
 ![Build Status](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiK0pzWGNJc01qaEVYTU9JcjY5MzdFTFVlSmV2aE1ESUVlODhKNHErSUNJSlkrV1o2bDlPS1hRU1BsWGJhNTZEVkNEYXVGeGRpRnJ4VkpjdFNiR2ZVQ21nPSIsIml2UGFyYW1ldGVyU3BlYyI6Ikh6dkhlYVh0QnE1TytCaU0iLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=main)
 
 [etcdadm](https://github.com/kubernetes-sigs/etcdadm) is a command-line tool for operating an etcd cluster. It downloads a specific etcd release, installs the binary, configures a systemd service, generates CA certificates, calls the etcd API to add (or remove) a member, and verifies that the new member is healthy. Its user experience is inspired by kubeadm.
+
+### Updating
+
+1. Review releases and changelogs in upstream [repo](https://github.com/kubernetes-sigs/etcdadm) and decide on new version. 
+   Please review carefully and if there are questions about changes necessary to eks-anywhere to support the new version
+   and/or automatically update between eks-anywhere version reach out to @g-gaston or @mrajashree.
+1. Follow these steps for changes to the patches/ folder:
+    1. Checkout the upstream repo and create a new branch from the desired upstream release tag.
+    1. Review the patches under patches/ folder in this repo. Apply the required patches to the new branch created in the above step. Remove any patches that are either
+    merged upstream or no longer needed. Please reach out to @g-gaston or @mrajashree if there are any questions regarding keeping/removing patches.
+    1. Run `git format-patch <commit>`, where `<commit>` is the last upstream commit on that tag. Move the generated patches under the patches/ folder in this repo.
+1. Update the `GIT_TAG` file to have the new desired version based on the upstream release tags.
+1. Compare the old tag to the new, looking specifically for Makefile changes. 
+ex: [0.13.2 compared to 0.23.0](https://github.com/kubernetes-sigs/etcdadm/compare/v0.1.3...v0.1.5). Check the `$(BIN)` target for
+any build flag changes, tag changes, dependencies, etc. 
+1. Verify the golang version has not changed. The version specified in the variable `GO_IMAGE` in the Makefile seems to be kept up to date.
+1. Update checksums and attribution using `make update-attribution-checksums-docker PROJECT=kubernetes-sigs/etcdadm` from the root of the repo.
+1. Update the version at the top of this Readme.
+1. Run `make generate` from the root of the repo to update the UPSTREAM_PROJECTS.yaml file.
+1. Update the `ETCDADM_VERSION` to the upstream tag [here](https://github.com/aws/eks-anywhere-build-tooling/blob/main/projects/kubernetes-sigs/image-builder/build/setup_packer_configs.sh#L76).

--- a/projects/kubernetes-sigs/image-builder/build/setup_packer_configs.sh
+++ b/projects/kubernetes-sigs/image-builder/build/setup_packer_configs.sh
@@ -72,8 +72,7 @@ export ETCD_HTTP_SOURCE=$(build::eksd_releases::get_eksd_component_url "etcd" $R
 export ETCD_VERSION=$(build::eksd_releases::get_eksd_component_version "etcd" $RELEASE_BRANCH)
 export ETCD_SHA256=$(build::eksd_releases::get_eksd_component_sha "etcd" $RELEASE_BRANCH)
 export ETCDADM_HTTP_SOURCE=${ETCDADM_HTTP_SOURCE:-$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET 'kubernetes-sigs/etcdadm' 'amd64' $LATEST_TAG)}
-# TODO: fix etcdadm build to set correct version
-export ETCDADM_VERSION='v0.0.0-master+$Format:%h$'
+export ETCDADM_VERSION='v0.1.5'
 export CRICTL_URL=${CRICTL_URL:-$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET 'kubernetes-sigs/cri-tools' 'amd64' $LATEST_TAG)}
 export CRICTL_SHA256="$CRICTL_URL.sha256"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We werent passing the expected ldflags to the build so the version subcommand would return nonsense.  This adds the flags using our common version.sh which roughly matches upstream kube projects.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
