### PR TITLE
Add user to cert-manager webhook container image

### DIFF
--- a/projects/jetstack/cert-manager/Makefile
+++ b/projects/jetstack/cert-manager/Makefile
@@ -23,7 +23,9 @@ include $(BASE_DIRECTORY)/Common.mk
 $(call IMAGE_TARGETS_FOR_NAME, cert-manager-acmesolver): cert-manager-acmesolver-useradd/images/export
 $(call IMAGE_TARGETS_FOR_NAME, cert-manager-cainjector): cert-manager-cainjector-useradd/images/export
 $(call IMAGE_TARGETS_FOR_NAME, cert-manager-acmesolver): cert-manager-controller-useradd/images/export
+$(call IMAGE_TARGETS_FOR_NAME, cert-manager-webhook): cert-manager-webhook-useradd/images/export
 
 cert-manager-acmesolver-useradd/images/export: IMAGE_USERADD_USER_NAME=acmesolver
 cert-manager-cainjector-useradd/images/export: IMAGE_USERADD_USER_NAME=cainjector
 cert-manager-controller-useradd/images/export: IMAGE_USERADD_USER_NAME=cert-manager
+cert-manager-webhook-useradd/images/export: IMAGE_USERADD_USER_NAME=webhook

--- a/projects/jetstack/cert-manager/docker/linux/cert-manager-webhook/Dockerfile
+++ b/projects/jetstack/cert-manager/docker/linux/cert-manager-webhook/Dockerfile
@@ -4,8 +4,10 @@ FROM $BASE_IMAGE
 ARG TARGETARCH
 ARG TARGETOS
 
+COPY _output/files/cert-manager-webhook /
 COPY _output/bin/cert-manager/$TARGETOS-$TARGETARCH/cert-manager-webhook /usr/bin/webhook
 COPY _output/LICENSES /LICENSES
 COPY ATTRIBUTION.txt /ATTRIBUTION.txt
 
+USER 1000
 ENTRYPOINT ["/usr/bin/webhook"]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Cert-manager v1.5.3 [enables runAsNonRoot by default](https://github.com/jetstack/cert-manager/pull/4036/files). Cert-manager
webhook container runs as root and fails to get created. This
commit adds non root user to webhook container image.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
