### PR TITLE
add generated help to all projects

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -192,7 +192,7 @@ FETCH_BINARIES_TARGETS?=
 LICENSE_PACKAGE_FILTER?=$(SOURCE_PATTERNS)
 REPO_SUBPATH?=
 HAS_LICENSES?=true
-ATTRIBUTION_TARGETS?=$(and $(filter true,$(HAS_LICENSES)), $(if $(wildcard $(RELEASE_BRANCH)/ATTRIBUTION.txt),$(RELEASE_BRANCH)/ATTRIBUTION.txt,ATTRIBUTION.txt))
+ATTRIBUTION_TARGETS?=$(if $(wildcard $(RELEASE_BRANCH)/ATTRIBUTION.txt),$(RELEASE_BRANCH)/ATTRIBUTION.txt,ATTRIBUTION.txt)
 GATHER_LICENSES_TARGETS?=$(OUTPUT_DIR)/attribution/go-license.csv
 LICENSES_OUTPUT_DIR?=$(OUTPUT_DIR)
 LICENSES_TARGETS_FOR_PREREQ=$(if $(filter true,$(HAS_LICENSES)),$(GATHER_LICENSES_TARGETS) $(OUTPUT_DIR)/ATTRIBUTION.txt,)
@@ -348,7 +348,7 @@ $(GATHER_LICENSES_TARGETS): $(GO_MOD_DOWNLOAD_TARGETS)
 gather-licenses: $(GATHER_LICENSES_TARGETS)
 
 .PHONY: attribution
-attribution: $(ATTRIBUTION_TARGETS)
+attribution: $(and $(filter true,$(HAS_LICENSES)),$(ATTRIBUTION_TARGETS))
 
 .PHONY: attribution-pr
 attribution-pr:
@@ -376,7 +376,9 @@ s3-artifacts: tarballs
 	
 .PHONY: checksums
 checksums: $(BINARY_TARGETS)
+ifneq ($(strip $(BINARY_TARGETS)),)
 	$(BASE_DIRECTORY)/build/lib/update_checksums.sh $(MAKE_ROOT) $(PROJECT_ROOT) $(MAKE_ROOT)/$(OUTPUT_BIN_DIR)
+endif
 
 .PHONY: validate-checksums
 validate-checksums: $(BINARY_TARGETS)

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BUILD_TARGETS=$(addprefix build-project-, $(PROJECTS))
 EKSA_TOOLS_PREREQS=kubernetes-sigs_cluster-api kubernetes-sigs_cluster-api-provider-aws kubernetes-sigs_kind fluxcd_flux2 vmware_govmomi
 EKSA_TOOLS_PREREQS_BUILD_TARGETS=$(addprefix build-project-, $(EKSA_TOOLS_PREREQS))
 
-ALL_PROJECTS=$(PROJECTS) $(EKSA_TOOLS_PREREQS)
+ALL_PROJECTS=$(PROJECTS) $(EKSA_TOOLS_PREREQS) aws_bottlerocket-bootstrap aws_eks-anywhere-build-tooling kubernetes-sigs_image-builder
 
 RELEASE_BRANCH?=
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 AWS_REGION?=us-west-2
-IMAGE_REPO=$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com
+IMAGE_REPO?=$(if $(AWS_ACCOUNT_ID),$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com,localhost:5000)
 
 PROJECTS?=aws_eks-anywhere brancz_kube-rbac-proxy kubernetes-sigs_cluster-api-provider-vsphere kubernetes-sigs_cri-tools kubernetes-sigs_vsphere-csi-driver jetstack_cert-manager kubernetes_cloud-provider-vsphere plunder-app_kube-vip kubernetes-sigs_etcdadm fluxcd_helm-controller fluxcd_kustomize-controller fluxcd_notification-controller fluxcd_source-controller rancher_local-path-provisioner mrajashree_etcdadm-bootstrap-provider mrajashree_etcdadm-controller tinkerbell_cluster-api-provider-tinkerbell tinkerbell_hegel
 BUILD_TARGETS=$(addprefix build-project-, $(PROJECTS))
 
 EKSA_TOOLS_PREREQS=kubernetes-sigs_cluster-api kubernetes-sigs_cluster-api-provider-aws kubernetes-sigs_kind fluxcd_flux2 vmware_govmomi
 EKSA_TOOLS_PREREQS_BUILD_TARGETS=$(addprefix build-project-, $(EKSA_TOOLS_PREREQS))
+
+ALL_PROJECTS=$(PROJECTS) $(EKSA_TOOLS_PREREQS)
 
 RELEASE_BRANCH?=
 
@@ -34,68 +36,30 @@ release-binaries-images: build-all-projects
 release-ovas:
 	$(MAKE) release -C projects/kubernetes-sigs/image-builder
 
+.PHONY: clean-project-%
+clean-project-%:
+	$(eval PROJECT_PATH=projects/$(subst _,/,$*))
+	$(MAKE) clean -C $(PROJECT_PATH)
+
 .PHONY: clean
-clean:
-	make -C projects/brancz/kube-rbac-proxy clean
-	make -C projects/kubernetes-sigs/cluster-api clean
-	make -C projects/kubernetes-sigs/cluster-api-provider-aws clean
-	make -C projects/kubernetes-sigs/cluster-api-provider-vsphere clean
-	make -C projects/kubernetes-sigs/cri-tools clean
-	make -C projects/kubernetes-sigs/kind clean
-	make -C projects/kubernetes/cloud-provider-vsphere clean
-	make -C projects/plunder-app/kube-vip clean
-	make -C projects/kubernetes-sigs/etcdadm clean
-	make -C projects/fluxcd/flux2 clean
-	make -C projects/kubernetes/cloud-provider-vsphere clean
-	make -C projects/kubernetes-sigs/vsphere-csi-driver clean
-	make -C projects/rancher/local-path-provisioner clean
-	make -C projects/vmware/govmomi clean
-	make -C projects/jetstack/cert-manager clean
-	make -C projects/fluxcd/helm-controller clean
-	make -C projects/fluxcd/kustomize-controller clean
-	make -C projects/fluxcd/notification-controller clean
-	make -C projects/fluxcd/source-controller clean
-	make -C projects/mrajashree/etcdadm-bootstrap-provider clean
-	make -C projects/mrajashree/etcdadm-controller clean
-	make -C projects/aws/bottlerocket-bootstrap clean
-	make -C projects/replicatedhq/troubleshoot clean
-	make -C projects/tinkerbell/cluster-api-provider-tinkerbell clean
-	make -C projects/tinkerbell/hegel clean
-
-	make -C projects/kubernetes-sigs/image-builder clean
-	make -C projects/aws/eks-anywhere-test clean
-	make -C projects/aws/eks-anywhere-build-tooling clean
-	make -C projects/cilium/cilium clean
-
+clean: $(addprefix clean-project-, $(ALL_PROJECTS))
 	rm -rf _output
 
-.PHONY: attribution-files
-attribution-files:
-	build/update-attribution-files/make_attribution.sh projects/brancz/kube-rbac-proxy
-	build/update-attribution-files/make_attribution.sh projects/kubernetes-sigs/cluster-api
-	build/update-attribution-files/make_attribution.sh projects/kubernetes-sigs/cluster-api-provider-aws
-	build/update-attribution-files/make_attribution.sh projects/kubernetes-sigs/cluster-api-provider-vsphere
-	build/update-attribution-files/make_attribution.sh projects/kubernetes-sigs/cri-tools
-	build/update-attribution-files/make_attribution.sh projects/kubernetes-sigs/kind
-	build/update-attribution-files/make_attribution.sh projects/plunder-app/kube-vip
-	build/update-attribution-files/make_attribution.sh projects/kubernetes-sigs/etcdadm
-	build/update-attribution-files/make_attribution.sh projects/fluxcd/flux2
-	build/update-attribution-files/make_attribution.sh projects/kubernetes/cloud-provider-vsphere
-	build/update-attribution-files/make_attribution.sh projects/kubernetes-sigs/vsphere-csi-driver
-	build/update-attribution-files/make_attribution.sh projects/rancher/local-path-provisioner
-	build/update-attribution-files/make_attribution.sh projects/vmware/govmomi
-	build/update-attribution-files/make_attribution.sh projects/jetstack/cert-manager
-	build/update-attribution-files/make_attribution.sh projects/fluxcd/helm-controller
-	build/update-attribution-files/make_attribution.sh projects/fluxcd/kustomize-controller
-	build/update-attribution-files/make_attribution.sh projects/fluxcd/notification-controller
-	build/update-attribution-files/make_attribution.sh projects/fluxcd/source-controller
-	build/update-attribution-files/make_attribution.sh projects/mrajashree/etcdadm-bootstrap-provider
-	build/update-attribution-files/make_attribution.sh projects/mrajashree/etcdadm-controller
-	build/update-attribution-files/make_attribution.sh projects/aws/bottlerocket-bootstrap
-	build/update-attribution-files/make_attribution.sh projects/replicatedhq/troubleshoot
-	build/update-attribution-files/make_attribution.sh projects/tinkerbell/cluster-api-provider-tinkerbell
-	build/update-attribution-files/make_attribution.sh projects/tinkerbell/hegel
+.PHONY: add-generated-help-block-project-%
+add-generated-help-block-project-%:
+	$(eval PROJECT_PATH=projects/$(subst _,/,$*))
+	$(MAKE) add-generated-help-block -C $(PROJECT_PATH) RELEASE_BRANCH=1-21
 
+.PHONY: add-generated-help-block
+add-generated-help-block: $(addprefix add-generated-help-block-project-, $(ALL_PROJECTS))
+
+.PHONY: attribution-files-project-%
+attribution-files-project-%:
+	$(eval PROJECT_PATH=projects/$(subst _,/,$*))
+	build/update-attribution-files/make_attribution.sh $(PROJECT_PATH)
+
+.PHONY: attribution-files
+attribution-files: $(addprefix attribution-files-project-, $(ALL_PROJECTS))
 	cat _output/total_summary.txt
 
 .PHONY: update-attribution-files

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE_REPO?=$(if $(AWS_ACCOUNT_ID),$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazo
 PROJECTS?=aws_eks-anywhere brancz_kube-rbac-proxy kubernetes-sigs_cluster-api-provider-vsphere kubernetes-sigs_cri-tools kubernetes-sigs_vsphere-csi-driver jetstack_cert-manager kubernetes_cloud-provider-vsphere plunder-app_kube-vip kubernetes-sigs_etcdadm fluxcd_helm-controller fluxcd_kustomize-controller fluxcd_notification-controller fluxcd_source-controller rancher_local-path-provisioner mrajashree_etcdadm-bootstrap-provider mrajashree_etcdadm-controller tinkerbell_cluster-api-provider-tinkerbell tinkerbell_hegel
 BUILD_TARGETS=$(addprefix build-project-, $(PROJECTS))
 
-EKSA_TOOLS_PREREQS=kubernetes-sigs_cluster-api kubernetes-sigs_cluster-api-provider-aws kubernetes-sigs_kind fluxcd_flux2 vmware_govmomi
+EKSA_TOOLS_PREREQS=kubernetes-sigs_cluster-api kubernetes-sigs_cluster-api-provider-aws kubernetes-sigs_kind fluxcd_flux2 vmware_govmomi replicatedhq_troubleshoot
 EKSA_TOOLS_PREREQS_BUILD_TARGETS=$(addprefix build-project-, $(EKSA_TOOLS_PREREQS))
 
 ALL_PROJECTS=$(PROJECTS) $(EKSA_TOOLS_PREREQS) aws_bottlerocket-bootstrap aws_eks-anywhere-build-tooling kubernetes-sigs_image-builder

--- a/build/lib/generate_help_body.sh
+++ b/build/lib/generate_help_body.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+PROJECT_ROOT="$1"
+BINARY_TARGET_FILES="$2"
+BINARY_PLATFORMS="$3"
+BINARY_TARGETS="$4"
+REPO="$5"
+HAS_PATCHES="$6"
+LOCAL_IMAGE_TARGETS="$7"
+IMAGE_TARGETS="$8"
+BUILD_TARGETS="$9"
+RELEASE_TARGETS="${10}"
+HAS_S3_ARTIFACTS="${11}"
+HAS_LICENSES="${12}"
+REPO_NO_CLONE="${13}"
+FETCH_BINARIES_TARGETS="${14}"
+
+NL=$'\n'
+HEADER="########### DO NOT EDIT #############################"
+FOOTER="########### END GENERATED ###########################"
+
+MAKEFILE=$PROJECT_ROOT/Makefile
+HELPFILE=$PROJECT_ROOT/Help.mk
+
+sed -i "/$HEADER/,/$FOOTER/d" $MAKEFILE
+# remove trailing newlines
+printf %s "$(< $MAKEFILE)" > $MAKEFILE
+
+touch $HELPFILE
+
+sed -i "/$HEADER/,/$FOOTER/d" $HELPFILE
+# remove trailing newlines
+printf %s "$(< $HELPFILE)" > $HELPFILE
+
+# Generate help items from Common.mk
+EXTRA_HELP="$(make help-list)"
+BINARY_TARGETS_HELP=""
+CHECKSUMS_TARGETS_HELP=""
+if [ ! -z "$(echo "$BINARY_TARGETS" | xargs)" ]; then
+    BINARY_TARGETS_HELP+="${NL}${NL}##@ Binary Targets"
+    BINARY_TARGETS_HELP+="${NL}binaries: ## Build all binaries: \`${BINARY_TARGET_FILES}\` for \`${BINARY_PLATFORMS}\`"
+    TARGETS=(${BINARY_TARGETS// / })
+    for target in "${TARGETS[@]}"; do
+        BINARY_TARGETS_HELP+="${NL}${target}: ## Build \`${target}\`"
+    done
+
+    CHECKSUMS_TARGETS_HELP+="${NL}${NL}##@ Checksum Targets"
+    CHECKSUMS_TARGETS_HELP+="${NL}checksums: ## Update checksums file based on currently built binaries."
+    CHECKSUMS_TARGETS_HELP+="${NL}validate-checksums: # Validate checksums of currently built binaries against checksums file."
+fi
+
+GIT_TARGETS_HELP=""
+if [[ "$REPO_NO_CLONE" != "true" ]]; then
+    GIT_TARGETS_HELP+="${NL}${NL}##@ GIT/Repo Targets"
+    GIT_TARGETS_HELP+="${NL}clone-repo:  ## Clone upstream \`${REPO}\`"
+    GIT_TARGETS_HELP+="${NL}checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file"
+fi
+
+PATCHES_TARGET=""
+if [[ "$HAS_PATCHES" == "true" ]]; then
+    PATCHES_TARGET+="${NL}${NL}patch-repo: ## Patch upstream repo with patches in patches directory"
+fi
+
+IMAGE_TARGETS_HELP=""
+if [ ! -z "$LOCAL_IMAGE_TARGETS" ]; then
+    IMAGE_TARGETS_HELP+="${NL}${NL}##@ Image Targets"
+    IMAGE_TARGETS_HELP+="${NL}local-images: ## Builds \`$(echo ${LOCAL_IMAGE_TARGETS} | xargs)\` as oci tars for presumbit validation"
+    IMAGE_TARGETS_HELP+="${NL}images: ## Pushes \`$(echo ${IMAGE_TARGETS} | xargs)\` to IMAGE_REPO"
+    
+    ALL_IMAGES=()
+    TARGETS=(${LOCAL_IMAGE_TARGETS// / })
+    for target in "${TARGETS[@]}"; do
+        ALL_IMAGES+=("$target")
+    done
+    TARGETS=(${IMAGE_TARGETS// / })
+    for target in "${TARGETS[@]}"; do
+        if [[ ! " ${ALL_IMAGES[*]} " =~ " ${target} " ]]; then
+            ALL_IMAGES+=("$target")
+        fi
+    done
+    for image in "${ALL_IMAGES[@]}"; do
+        IMAGE_TARGETS_HELP+="${NL}$image: ## Builds/pushes \`${image}\`"
+    done
+
+fi
+
+ARTIFACTS_TARGETS=""
+if [[ "$HAS_S3_ARTIFACTS" == "true" ]]; then
+    ARTIFACTS_TARGETS+="${NL}${NL}##@ Artifact Targets" 
+    ARTIFACTS_TARGETS+="${NL}tarballs: ## Create tarballs by calling build/lib/simple_create_tarballs.sh unless SIMPLE_CREATE_TARBALLS=false, then tarballs must be defined in project Makefile"
+    ARTIFACTS_TARGETS+="${NL}s3-artifacts: # Prepare ARTIFACTS_PATH folder structure with tarballs/manifests/other items to be uploaded to s3"
+    ARTIFACTS_TARGETS+="${NL}upload-artifacts: # Upload tarballs and other artifacts from ARTIFACTS_PATH to S3"
+fi
+
+LICENSES_TARGETS=""
+if [[ "$HAS_LICENSES" == "true" ]]; then
+    LICENSES_TARGETS+="${NL}${NL}##@ License Targets" 
+    LICENSES_TARGETS+="${NL}gather-licenses: ## Helper to call \$(GATHER_LICENSES_TARGETS) which gathers all licenses"
+    LICENSES_TARGETS+="${NL}attribution: ## Generates attribution from licenses gathered during \`gather-licenses\`."
+    LICENSES_TARGETS+="${NL}attribution-pr: ## Generates PR to update attribution files for projects"
+fi
+
+CLEAN_TARGETS="${NL}${NL}##@ Clean Targets"
+CLEAN_TARGETS+="${NL}clean: ## Removes source and _output directory"
+if [[ "$REPO_NO_CLONE" != "true" ]]; then
+    CLEAN_TARGETS+="${NL}clean-repo: ## Removes source directory"
+fi
+
+FETCH_BINARY_TARGETS_HELP=""
+if [ ! -z "$(echo "$FETCH_BINARIES_TARGETS" | xargs)" ]; then
+    FETCH_BINARY_TARGETS_HELP+="${NL}${NL}##@ Fetch Binary Targets"
+    TARGETS=(${FETCH_BINARIES_TARGETS// / })
+    for target in "${TARGETS[@]}"; do
+        FETCH_BINARY_TARGETS_HELP+="${NL}${target}: ## Fetch \`${target}\`"
+    done
+fi
+
+cat >> $HELPFILE << EOF
+${NL}${NL}${NL}${HEADER}
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+${GIT_TARGETS_HELP}${BINARY_TARGETS_HELP}${PATCHES_TARGET}${IMAGE_TARGETS_HELP}${FETCH_BINARY_TARGETS_HELP}${CHECKSUMS_TARGETS_HELP}${ARTIFACTS_TARGETS}${LICENSES_TARGETS}${CLEAN_TARGETS}
+${EXTRA_HELP}
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls \`${BUILD_TARGETS}\`
+release: ## Called via prow postsubmit + release jobs, calls \`${RELEASE_TARGETS}\`
+${FOOTER}
+EOF
+
+cat >> $MAKEFILE << EOF
+${NL}${NL}${NL}${HEADER}
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+${FOOTER}
+EOF
+

--- a/build/update-attribution-files/make_attribution.sh
+++ b/build/update-attribution-files/make_attribution.sh
@@ -32,11 +32,13 @@ function build::attribution::generate(){
         export RELEASE_BRANCH="$1"
     fi
     make -C $PROJECT_ROOT binaries attribution checksums
-    for summary in $PROJECT_ROOT/_output/**/summary.txt; do
-        sed -i "s/+.*=/ =/g" $summary
-        awk -F" =\> " '{ count[$1]+=$2} END { for (item in count) printf("%s => %d\n", item, count[item]) }' \
-            $summary _output/total_summary.txt | sort > _output/total_summary.tmp && mv _output/total_summary.tmp _output/total_summary.txt
-    done
+    if [ -f $PROJECT_ROOT/_output/**/summary.txt ]; then
+        for summary in $PROJECT_ROOT/_output/**/summary.txt; do
+            sed -i "s/+.*=/ =/g" $summary
+            awk -F" =\> " '{ count[$1]+=$2} END { for (item in count) printf("%s => %d\n", item, count[item]) }' \
+                $summary _output/total_summary.txt | sort > _output/total_summary.tmp && mv _output/total_summary.tmp _output/total_summary.txt
+        done
+    fi
     make -C $PROJECT_ROOT clean 
 }
 

--- a/projects/aws/bottlerocket-bootstrap/Help.mk
+++ b/projects/aws/bottlerocket-bootstrap/Help.mk
@@ -1,0 +1,39 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ Binary Targets
+binaries: ## Build all binaries: `bottlerocket-bootstrap` for `linux/amd64 linux/arm64`
+_output/bin/bottlerocket-bootstrap/linux-amd64/bottlerocket-bootstrap: ## Build `_output/bin/bottlerocket-bootstrap/linux-amd64/bottlerocket-bootstrap`
+_output/bin/bottlerocket-bootstrap/linux-arm64/bottlerocket-bootstrap: ## Build `_output/bin/bottlerocket-bootstrap/linux-arm64/bottlerocket-bootstrap`
+
+##@ Image Targets
+local-images: ## Builds `bottlerocket-bootstrap/images/amd64` as oci tars for presumbit validation
+images: ## Pushes `bottlerocket-bootstrap/images/push` to IMAGE_REPO
+bottlerocket-bootstrap/images/amd64: ## Builds/pushes `bottlerocket-bootstrap/images/amd64`
+bottlerocket-bootstrap/images/push: ## Builds/pushes `bottlerocket-bootstrap/images/push`
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution attribution-pr `
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+########### END GENERATED ###########################

--- a/projects/aws/bottlerocket-bootstrap/Makefile
+++ b/projects/aws/bottlerocket-bootstrap/Makefile
@@ -59,3 +59,11 @@ clean-extra:
 	@rm -rf vendor .git GIT_TAG
 
 clean: clean-extra
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/aws/eks-anywhere-build-tooling/Help.mk
+++ b/projects/aws/eks-anywhere-build-tooling/Help.mk
@@ -1,0 +1,41 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ Image Targets
+local-images: ## Builds `eks-anywhere-cli-tools/images/amd64` as oci tars for presumbit validation
+images: ## Pushes `eks-anywhere-cli-tools/images/push` to IMAGE_REPO
+eks-anywhere-cli-tools/images/amd64: ## Builds/pushes `eks-anywhere-cli-tools/images/amd64`
+eks-anywhere-cli-tools/images/push: ## Builds/pushes `eks-anywhere-cli-tools/images/push`
+
+##@ Fetch Binary Targets
+_output/dependencies/linux-amd64/eksa/fluxcd/flux2: ## Fetch `_output/dependencies/linux-amd64/eksa/fluxcd/flux2`
+_output/dependencies/linux-amd64/eksa/kubernetes-sigs/cluster-api: ## Fetch `_output/dependencies/linux-amd64/eksa/kubernetes-sigs/cluster-api`
+_output/dependencies/linux-amd64/eksa/kubernetes-sigs/cluster-api-provider-aws: ## Fetch `_output/dependencies/linux-amd64/eksa/kubernetes-sigs/cluster-api-provider-aws`
+_output/dependencies/linux-amd64/eksa/kubernetes-sigs/kind: ## Fetch `_output/dependencies/linux-amd64/eksa/kubernetes-sigs/kind`
+_output/dependencies/linux-amd64/eksa/replicatedhq/troubleshoot: ## Fetch `_output/dependencies/linux-amd64/eksa/replicatedhq/troubleshoot`
+_output/dependencies/linux-amd64/eksa/vmware/govmomi: ## Fetch `_output/dependencies/linux-amd64/eksa/vmware/govmomi`
+_output/dependencies/linux-amd64/eksd/kubernetes/client: ## Fetch `_output/dependencies/linux-amd64/eksd/kubernetes/client`
+_output/dependencies/linux-arm64/eksa/fluxcd/flux2: ## Fetch `_output/dependencies/linux-arm64/eksa/fluxcd/flux2`
+_output/dependencies/linux-arm64/eksa/kubernetes-sigs/cluster-api: ## Fetch `_output/dependencies/linux-arm64/eksa/kubernetes-sigs/cluster-api`
+_output/dependencies/linux-arm64/eksa/kubernetes-sigs/cluster-api-provider-aws: ## Fetch `_output/dependencies/linux-arm64/eksa/kubernetes-sigs/cluster-api-provider-aws`
+_output/dependencies/linux-arm64/eksa/kubernetes-sigs/kind: ## Fetch `_output/dependencies/linux-arm64/eksa/kubernetes-sigs/kind`
+_output/dependencies/linux-arm64/eksa/replicatedhq/troubleshoot: ## Fetch `_output/dependencies/linux-arm64/eksa/replicatedhq/troubleshoot`
+_output/dependencies/linux-arm64/eksa/vmware/govmomi: ## Fetch `_output/dependencies/linux-arm64/eksa/vmware/govmomi`
+_output/dependencies/linux-arm64/eksd/kubernetes/client: ## Fetch `_output/dependencies/linux-arm64/eksd/kubernetes/client`
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `local-images`
+release: ## Called via prow postsubmit + release jobs, calls `images`
+########### END GENERATED ###########################

--- a/projects/aws/eks-anywhere-build-tooling/Makefile
+++ b/projects/aws/eks-anywhere-build-tooling/Makefile
@@ -1,7 +1,7 @@
 BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
 GIT_TAG?=$(shell cat GIT_TAG)
 
-REPO=eks-anwyhere-build-tooling
+REPO=eks-anywhere-build-tooling
 REPO_OWNER=aws
 
 IMAGE_COMPONENT=eks-anywhere-cli-tools
@@ -20,16 +20,20 @@ FETCH_BINARIES_TARGETS=eksa/fluxcd/flux2 eksa/kubernetes-sigs/cluster-api eksa/k
 
 ORGANIZE_BINARIES_TARGETS=$(addsuffix /eks-a-tools,$(addprefix $(BINARY_DEPS_DIR)/linux-,amd64 arm64))
 
+REPO_NO_CLONE=true
+
 include $(BASE_DIRECTORY)/Common.mk
 
 
 $(call IMAGE_TARGETS_FOR_NAME, eks-anywhere-cli-tools): $(ORGANIZE_BINARIES_TARGETS)
 
-.PHONY: fetch-binaries
-fetch-binaries: $(FETCH_BINARIES_TARGET)
-
-$(FETCH_BINARIES_TARGET):
-	build/fetch_binaries.sh $(ARTIFACTS_BUCKET)
-
 $(ORGANIZE_BINARIES_TARGETS): $(call FULL_FETCH_BINARIES_TARGETS, $(FETCH_BINARIES_TARGETS))
 	build/organize_binaries.sh $(lastword $(subst -, ,$(@D)))
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/aws/eks-anywhere-test/Help.mk
+++ b/projects/aws/eks-anywhere-test/Help.mk
@@ -1,0 +1,27 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ Image Targets
+local-images: ## Builds `eks-anywhere-test/images/amd64 helm/build` as oci tars for presumbit validation
+images: ## Pushes `eks-anywhere-test/images/push helm/push` to IMAGE_REPO
+eks-anywhere-test/images/amd64: ## Builds/pushes `eks-anywhere-test/images/amd64`
+helm/build: ## Builds/pushes `helm/build`
+eks-anywhere-test/images/push: ## Builds/pushes `eks-anywhere-test/images/push`
+helm/push: ## Builds/pushes `helm/push`
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `local-images`
+release: ## Called via prow postsubmit + release jobs, calls `images`
+########### END GENERATED ###########################

--- a/projects/aws/eks-anywhere-test/Makefile
+++ b/projects/aws/eks-anywhere-test/Makefile
@@ -10,8 +10,17 @@ HAS_HELM_CHART=true
 BASE_IMAGE_NAME?=eks-distro-minimal-base-glibc
 SIMPLE_CREATE_BINARIES=false
 HAS_LICENSES=false
+REPO_NO_CLONE=true
 
 BUILD_TARGETS=local-images
 RELEASE_TARGETS=images
 
 include $(BASE_DIRECTORY)/Common.mk
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/aws/eks-anywhere/Help.mk
+++ b/projects/aws/eks-anywhere/Help.mk
@@ -1,0 +1,29 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ Image Targets
+local-images: ## Builds `eks-anywhere-diagnostic-collector/images/amd64` as oci tars for presumbit validation
+images: ## Pushes `eks-anywhere-diagnostic-collector/images/push` to IMAGE_REPO
+eks-anywhere-diagnostic-collector/images/amd64: ## Builds/pushes `eks-anywhere-diagnostic-collector/images/amd64`
+eks-anywhere-diagnostic-collector/images/push: ## Builds/pushes `eks-anywhere-diagnostic-collector/images/push`
+
+##@ Fetch Binary Targets
+_output/dependencies/linux-amd64/eksd/kubernetes/client: ## Fetch `_output/dependencies/linux-amd64/eksd/kubernetes/client`
+_output/dependencies/linux-arm64/eksd/kubernetes/client: ## Fetch `_output/dependencies/linux-arm64/eksd/kubernetes/client`
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `local-images`
+release: ## Called via prow postsubmit + release jobs, calls `images`
+########### END GENERATED ###########################

--- a/projects/aws/eks-anywhere/Makefile
+++ b/projects/aws/eks-anywhere/Makefile
@@ -17,7 +17,17 @@ RELEASE_TARGETS=images
 
 FETCH_BINARIES_TARGETS=eksd/kubernetes/client
 
+REPO_NO_CLONE=true
+
 include $(BASE_DIRECTORY)/Common.mk
 
 
 $(call IMAGE_TARGETS_FOR_NAME, eks-anywhere-diagnostic-collector): $(call FULL_FETCH_BINARIES_TARGETS, $(FETCH_BINARIES_TARGETS))
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/brancz/kube-rbac-proxy/Help.mk
+++ b/projects/brancz/kube-rbac-proxy/Help.mk
@@ -1,0 +1,44 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ GIT/Repo Targets
+clone-repo:  ## Clone upstream `kube-rbac-proxy`
+checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
+
+##@ Binary Targets
+binaries: ## Build all binaries: `kube-rbac-proxy` for `linux/amd64 linux/arm64`
+_output/bin/kube-rbac-proxy/linux-amd64/kube-rbac-proxy: ## Build `_output/bin/kube-rbac-proxy/linux-amd64/kube-rbac-proxy`
+_output/bin/kube-rbac-proxy/linux-arm64/kube-rbac-proxy: ## Build `_output/bin/kube-rbac-proxy/linux-arm64/kube-rbac-proxy`
+
+##@ Image Targets
+local-images: ## Builds `kube-rbac-proxy/images/amd64` as oci tars for presumbit validation
+images: ## Pushes `kube-rbac-proxy/images/push` to IMAGE_REPO
+kube-rbac-proxy/images/amd64: ## Builds/pushes `kube-rbac-proxy/images/amd64`
+kube-rbac-proxy/images/push: ## Builds/pushes `kube-rbac-proxy/images/push`
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+clean-repo: ## Removes source directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution attribution-pr `
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+########### END GENERATED ###########################

--- a/projects/brancz/kube-rbac-proxy/Makefile
+++ b/projects/brancz/kube-rbac-proxy/Makefile
@@ -10,3 +10,11 @@ BASE_IMAGE_NAME?=eks-distro-minimal-base-nonroot
 BINARY_TARGET_FILES=kube-rbac-proxy
 
 include $(BASE_DIRECTORY)/Common.mk
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/fluxcd/flux2/Help.mk
+++ b/projects/fluxcd/flux2/Help.mk
@@ -1,0 +1,49 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ GIT/Repo Targets
+clone-repo:  ## Clone upstream `flux2`
+checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
+
+##@ Binary Targets
+binaries: ## Build all binaries: `flux` for `linux/amd64 linux/arm64 darwin/amd64 darwin/arm64`
+_output/bin/flux2/linux-amd64/flux: ## Build `_output/bin/flux2/linux-amd64/flux`
+_output/bin/flux2/linux-arm64/flux: ## Build `_output/bin/flux2/linux-arm64/flux`
+_output/bin/flux2/darwin-amd64/flux: ## Build `_output/bin/flux2/darwin-amd64/flux`
+_output/bin/flux2/darwin-arm64/flux: ## Build `_output/bin/flux2/darwin-arm64/flux`
+
+##@ Image Targets
+local-images: ## Builds `` as oci tars for presumbit validation
+images: ## Pushes `` to IMAGE_REPO
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
+##@ Artifact Targets
+tarballs: ## Create tarballs by calling build/lib/simple_create_tarballs.sh unless SIMPLE_CREATE_TARBALLS=false, then tarballs must be defined in project Makefile
+s3-artifacts: # Prepare ARTIFACTS_PATH folder structure with tarballs/manifests/other items to be uploaded to s3
+upload-artifacts: # Upload tarballs and other artifacts from ARTIFACTS_PATH to S3
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+clean-repo: ## Removes source directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `validate-checksums  attribution attribution-pr upload-artifacts`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums  upload-artifacts`
+########### END GENERATED ###########################

--- a/projects/fluxcd/flux2/Makefile
+++ b/projects/fluxcd/flux2/Makefile
@@ -25,3 +25,11 @@ $(FLUX_MANIFESTS_TARGET): export PATH:=$(MAKE_ROOT)/$(OUTPUT_DIR):$(PATH)
 $(FLUX_MANIFESTS_TARGET): $(KUSTOMIZE_TARGET)
 	# EMBEDDED_MANIFESTS_TARGET from https://github.com/fluxcd/flux2/blob/main/Makefile#L2
 	make -C $(REPO) cmd/flux/.manifests.done
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/fluxcd/helm-controller/Help.mk
+++ b/projects/fluxcd/helm-controller/Help.mk
@@ -1,0 +1,44 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ GIT/Repo Targets
+clone-repo:  ## Clone upstream `helm-controller`
+checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
+
+##@ Binary Targets
+binaries: ## Build all binaries: `helm-controller` for `linux/amd64 linux/arm64`
+_output/bin/helm-controller/linux-amd64/helm-controller: ## Build `_output/bin/helm-controller/linux-amd64/helm-controller`
+_output/bin/helm-controller/linux-arm64/helm-controller: ## Build `_output/bin/helm-controller/linux-arm64/helm-controller`
+
+##@ Image Targets
+local-images: ## Builds `helm-controller/images/amd64` as oci tars for presumbit validation
+images: ## Pushes `helm-controller/images/push` to IMAGE_REPO
+helm-controller/images/amd64: ## Builds/pushes `helm-controller/images/amd64`
+helm-controller/images/push: ## Builds/pushes `helm-controller/images/push`
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+clean-repo: ## Removes source directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution attribution-pr `
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+########### END GENERATED ###########################

--- a/projects/fluxcd/helm-controller/Makefile
+++ b/projects/fluxcd/helm-controller/Makefile
@@ -33,3 +33,11 @@ $(FIX_LICENSES_XEIPUUV_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
 $(FIX_LICENSES_API_LICENSE_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
 # Internal go.mod under /api directory
 	cp $(REPO)/LICENSE $@
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/fluxcd/kustomize-controller/Help.mk
+++ b/projects/fluxcd/kustomize-controller/Help.mk
@@ -1,0 +1,44 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ GIT/Repo Targets
+clone-repo:  ## Clone upstream `kustomize-controller`
+checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
+
+##@ Binary Targets
+binaries: ## Build all binaries: `kustomize-controller` for `linux/amd64 linux/arm64`
+_output/bin/kustomize-controller/linux-amd64/kustomize-controller: ## Build `_output/bin/kustomize-controller/linux-amd64/kustomize-controller`
+_output/bin/kustomize-controller/linux-arm64/kustomize-controller: ## Build `_output/bin/kustomize-controller/linux-arm64/kustomize-controller`
+
+##@ Image Targets
+local-images: ## Builds `kustomize-controller/images/amd64` as oci tars for presumbit validation
+images: ## Pushes `kustomize-controller/images/push` to IMAGE_REPO
+kustomize-controller/images/amd64: ## Builds/pushes `kustomize-controller/images/amd64`
+kustomize-controller/images/push: ## Builds/pushes `kustomize-controller/images/push`
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+clean-repo: ## Removes source directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution attribution-pr `
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+########### END GENERATED ###########################

--- a/projects/fluxcd/kustomize-controller/Makefile
+++ b/projects/fluxcd/kustomize-controller/Makefile
@@ -30,3 +30,11 @@ $(FIX_LICENSES_MOZILLA_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
 $(FIX_LICENSES_API_LICENSE_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
 # Internal go.mod under /api directory
 	cp $(REPO)/LICENSE $@
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/fluxcd/notification-controller/Help.mk
+++ b/projects/fluxcd/notification-controller/Help.mk
@@ -1,0 +1,44 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ GIT/Repo Targets
+clone-repo:  ## Clone upstream `notification-controller`
+checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
+
+##@ Binary Targets
+binaries: ## Build all binaries: `notification-controller` for `linux/amd64 linux/arm64`
+_output/bin/notification-controller/linux-amd64/notification-controller: ## Build `_output/bin/notification-controller/linux-amd64/notification-controller`
+_output/bin/notification-controller/linux-arm64/notification-controller: ## Build `_output/bin/notification-controller/linux-arm64/notification-controller`
+
+##@ Image Targets
+local-images: ## Builds `notification-controller/images/amd64` as oci tars for presumbit validation
+images: ## Pushes `notification-controller/images/push` to IMAGE_REPO
+notification-controller/images/amd64: ## Builds/pushes `notification-controller/images/amd64`
+notification-controller/images/push: ## Builds/pushes `notification-controller/images/push`
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+clean-repo: ## Removes source directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution attribution-pr `
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+########### END GENERATED ###########################

--- a/projects/fluxcd/notification-controller/Makefile
+++ b/projects/fluxcd/notification-controller/Makefile
@@ -29,3 +29,11 @@ $(FIX_LICENSES_K0KUBUN_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
 # which does not have a LICENSE file committed to the repo. Hence we are fetching the license file 
 # from the master branch so that it is available in the vendor directory for go-licenses to pick up
 	wget -q -O $@  https://raw.githubusercontent.com/k0kubun/pp/master/LICENSE.txt
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/fluxcd/source-controller/Help.mk
+++ b/projects/fluxcd/source-controller/Help.mk
@@ -1,0 +1,44 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ GIT/Repo Targets
+clone-repo:  ## Clone upstream `source-controller`
+checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
+
+##@ Binary Targets
+binaries: ## Build all binaries: `source-controller` for `linux/amd64 linux/arm64`
+_output/bin/source-controller/linux-amd64/source-controller: ## Build `_output/bin/source-controller/linux-amd64/source-controller`
+_output/bin/source-controller/linux-arm64/source-controller: ## Build `_output/bin/source-controller/linux-arm64/source-controller`
+
+##@ Image Targets
+local-images: ## Builds `source-controller/images/amd64` as oci tars for presumbit validation
+images: ## Pushes `source-controller/images/push` to IMAGE_REPO
+source-controller/images/amd64: ## Builds/pushes `source-controller/images/amd64`
+source-controller/images/push: ## Builds/pushes `source-controller/images/push`
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+clean-repo: ## Removes source directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution attribution-pr `
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+########### END GENERATED ###########################

--- a/projects/fluxcd/source-controller/Makefile
+++ b/projects/fluxcd/source-controller/Makefile
@@ -49,3 +49,11 @@ $(FIX_LICENSES_API_LICENSE_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
 
 $(LIBGIT2_LICENSES_TARGET):
 	$(BASE_DIRECTORY)/build/lib/gather_non_golang_licenses.sh libgit2/libgit2 v1.1.0 $(MAKE_ROOT)/$(OUTPUT_DIR)
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/jetstack/cert-manager/Help.mk
+++ b/projects/jetstack/cert-manager/Help.mk
@@ -1,0 +1,58 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ GIT/Repo Targets
+clone-repo:  ## Clone upstream `cert-manager`
+checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
+
+##@ Binary Targets
+binaries: ## Build all binaries: `cert-manager-acmesolver cert-manager-cainjector cert-manager-controller cert-manager-webhook` for `linux/amd64 linux/arm64`
+_output/bin/cert-manager/linux-amd64/cert-manager-acmesolver: ## Build `_output/bin/cert-manager/linux-amd64/cert-manager-acmesolver`
+_output/bin/cert-manager/linux-amd64/cert-manager-cainjector: ## Build `_output/bin/cert-manager/linux-amd64/cert-manager-cainjector`
+_output/bin/cert-manager/linux-amd64/cert-manager-controller: ## Build `_output/bin/cert-manager/linux-amd64/cert-manager-controller`
+_output/bin/cert-manager/linux-amd64/cert-manager-webhook: ## Build `_output/bin/cert-manager/linux-amd64/cert-manager-webhook`
+_output/bin/cert-manager/linux-arm64/cert-manager-acmesolver: ## Build `_output/bin/cert-manager/linux-arm64/cert-manager-acmesolver`
+_output/bin/cert-manager/linux-arm64/cert-manager-cainjector: ## Build `_output/bin/cert-manager/linux-arm64/cert-manager-cainjector`
+_output/bin/cert-manager/linux-arm64/cert-manager-controller: ## Build `_output/bin/cert-manager/linux-arm64/cert-manager-controller`
+_output/bin/cert-manager/linux-arm64/cert-manager-webhook: ## Build `_output/bin/cert-manager/linux-arm64/cert-manager-webhook`
+
+patch-repo: ## Patch upstream repo with patches in patches directory
+
+##@ Image Targets
+local-images: ## Builds `cert-manager-acmesolver/images/amd64 cert-manager-cainjector/images/amd64 cert-manager-controller/images/amd64 cert-manager-webhook/images/amd64` as oci tars for presumbit validation
+images: ## Pushes `cert-manager-acmesolver/images/push cert-manager-cainjector/images/push cert-manager-controller/images/push cert-manager-webhook/images/push` to IMAGE_REPO
+cert-manager-acmesolver/images/amd64: ## Builds/pushes `cert-manager-acmesolver/images/amd64`
+cert-manager-cainjector/images/amd64: ## Builds/pushes `cert-manager-cainjector/images/amd64`
+cert-manager-controller/images/amd64: ## Builds/pushes `cert-manager-controller/images/amd64`
+cert-manager-webhook/images/amd64: ## Builds/pushes `cert-manager-webhook/images/amd64`
+cert-manager-acmesolver/images/push: ## Builds/pushes `cert-manager-acmesolver/images/push`
+cert-manager-cainjector/images/push: ## Builds/pushes `cert-manager-cainjector/images/push`
+cert-manager-controller/images/push: ## Builds/pushes `cert-manager-controller/images/push`
+cert-manager-webhook/images/push: ## Builds/pushes `cert-manager-webhook/images/push`
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+clean-repo: ## Removes source directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution attribution-pr `
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+########### END GENERATED ###########################

--- a/projects/jetstack/cert-manager/Makefile
+++ b/projects/jetstack/cert-manager/Makefile
@@ -27,3 +27,11 @@ $(call IMAGE_TARGETS_FOR_NAME, cert-manager-acmesolver): cert-manager-controller
 cert-manager-acmesolver-useradd/images/export: IMAGE_USERADD_USER_NAME=acmesolver
 cert-manager-cainjector-useradd/images/export: IMAGE_USERADD_USER_NAME=cainjector
 cert-manager-controller-useradd/images/export: IMAGE_USERADD_USER_NAME=cert-manager
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/cluster-api-provider-aws/Help.mk
+++ b/projects/kubernetes-sigs/cluster-api-provider-aws/Help.mk
@@ -1,0 +1,59 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ GIT/Repo Targets
+clone-repo:  ## Clone upstream `cluster-api-provider-aws`
+checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
+
+##@ Binary Targets
+binaries: ## Build all binaries: `manager eks-bootstrap-manager eks-controlplane-manager clusterawsadm` for `linux/amd64 linux/arm64`
+_output/bin/cluster-api-provider-aws/linux-amd64/manager: ## Build `_output/bin/cluster-api-provider-aws/linux-amd64/manager`
+_output/bin/cluster-api-provider-aws/linux-amd64/eks-bootstrap-manager: ## Build `_output/bin/cluster-api-provider-aws/linux-amd64/eks-bootstrap-manager`
+_output/bin/cluster-api-provider-aws/linux-amd64/eks-controlplane-manager: ## Build `_output/bin/cluster-api-provider-aws/linux-amd64/eks-controlplane-manager`
+_output/bin/cluster-api-provider-aws/linux-amd64/clusterawsadm: ## Build `_output/bin/cluster-api-provider-aws/linux-amd64/clusterawsadm`
+_output/bin/cluster-api-provider-aws/linux-arm64/manager: ## Build `_output/bin/cluster-api-provider-aws/linux-arm64/manager`
+_output/bin/cluster-api-provider-aws/linux-arm64/eks-bootstrap-manager: ## Build `_output/bin/cluster-api-provider-aws/linux-arm64/eks-bootstrap-manager`
+_output/bin/cluster-api-provider-aws/linux-arm64/eks-controlplane-manager: ## Build `_output/bin/cluster-api-provider-aws/linux-arm64/eks-controlplane-manager`
+_output/bin/cluster-api-provider-aws/linux-arm64/clusterawsadm: ## Build `_output/bin/cluster-api-provider-aws/linux-arm64/clusterawsadm`
+
+##@ Image Targets
+local-images: ## Builds `cluster-api-aws-controller/images/amd64 eks-bootstrap-controller/images/amd64 eks-control-plane-controller/images/amd64` as oci tars for presumbit validation
+images: ## Pushes `cluster-api-aws-controller/images/push eks-bootstrap-controller/images/push eks-control-plane-controller/images/push` to IMAGE_REPO
+cluster-api-aws-controller/images/amd64: ## Builds/pushes `cluster-api-aws-controller/images/amd64`
+eks-bootstrap-controller/images/amd64: ## Builds/pushes `eks-bootstrap-controller/images/amd64`
+eks-control-plane-controller/images/amd64: ## Builds/pushes `eks-control-plane-controller/images/amd64`
+cluster-api-aws-controller/images/push: ## Builds/pushes `cluster-api-aws-controller/images/push`
+eks-bootstrap-controller/images/push: ## Builds/pushes `eks-bootstrap-controller/images/push`
+eks-control-plane-controller/images/push: ## Builds/pushes `eks-control-plane-controller/images/push`
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
+##@ Artifact Targets
+tarballs: ## Create tarballs by calling build/lib/simple_create_tarballs.sh unless SIMPLE_CREATE_TARBALLS=false, then tarballs must be defined in project Makefile
+s3-artifacts: # Prepare ARTIFACTS_PATH folder structure with tarballs/manifests/other items to be uploaded to s3
+upload-artifacts: # Upload tarballs and other artifacts from ARTIFACTS_PATH to S3
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+clean-repo: ## Removes source directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution attribution-pr upload-artifacts`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
+########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/cluster-api-provider-aws/Makefile
+++ b/projects/kubernetes-sigs/cluster-api-provider-aws/Makefile
@@ -27,3 +27,11 @@ s3-artifacts: create-manifests
 .PHONY: create-manifests
 create-manifests: tarballs
 	build/create_manifests.sh $(REPO) $(OUTPUT_DIR) $(ARTIFACTS_PATH) $(GIT_TAG) $(IMAGE_REPO) $(IMAGE_TAG)
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/cluster-api-provider-vsphere/Help.mk
+++ b/projects/kubernetes-sigs/cluster-api-provider-vsphere/Help.mk
@@ -1,0 +1,51 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ GIT/Repo Targets
+clone-repo:  ## Clone upstream `cluster-api-provider-vsphere`
+checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
+
+##@ Binary Targets
+binaries: ## Build all binaries: `manager` for `linux/amd64 linux/arm64`
+_output/bin/cluster-api-provider-vsphere/linux-amd64/manager: ## Build `_output/bin/cluster-api-provider-vsphere/linux-amd64/manager`
+_output/bin/cluster-api-provider-vsphere/linux-arm64/manager: ## Build `_output/bin/cluster-api-provider-vsphere/linux-arm64/manager`
+
+patch-repo: ## Patch upstream repo with patches in patches directory
+
+##@ Image Targets
+local-images: ## Builds `cluster-api-provider-vsphere/images/amd64` as oci tars for presumbit validation
+images: ## Pushes `cluster-api-provider-vsphere/images/push` to IMAGE_REPO
+cluster-api-provider-vsphere/images/amd64: ## Builds/pushes `cluster-api-provider-vsphere/images/amd64`
+cluster-api-provider-vsphere/images/push: ## Builds/pushes `cluster-api-provider-vsphere/images/push`
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
+##@ Artifact Targets
+tarballs: ## Create tarballs by calling build/lib/simple_create_tarballs.sh unless SIMPLE_CREATE_TARBALLS=false, then tarballs must be defined in project Makefile
+s3-artifacts: # Prepare ARTIFACTS_PATH folder structure with tarballs/manifests/other items to be uploaded to s3
+upload-artifacts: # Upload tarballs and other artifacts from ARTIFACTS_PATH to S3
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+clean-repo: ## Removes source directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution attribution-pr upload-artifacts`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
+########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/cluster-api-provider-vsphere/Makefile
+++ b/projects/kubernetes-sigs/cluster-api-provider-vsphere/Makefile
@@ -22,3 +22,11 @@ s3-artifacts: create-manifests
 .PHONY: create-manifests
 create-manifests: tarballs
 	build/create_manifests.sh $(REPO) $(OUTPUT_DIR) $(ARTIFACTS_PATH) $(GIT_TAG) $(IMAGE_REPO) $(IMAGE_TAG)
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/cluster-api/Help.mk
+++ b/projects/kubernetes-sigs/cluster-api/Help.mk
@@ -1,0 +1,69 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ GIT/Repo Targets
+clone-repo:  ## Clone upstream `cluster-api`
+checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
+
+##@ Binary Targets
+binaries: ## Build all binaries: `clusterctl manager kubeadm-bootstrap-manager kubeadm-control-plane-manager cluster-api-provider-docker-manager` for `linux/amd64 linux/arm64`
+_output/bin/cluster-api/linux-amd64/clusterctl: ## Build `_output/bin/cluster-api/linux-amd64/clusterctl`
+_output/bin/cluster-api/linux-amd64/manager: ## Build `_output/bin/cluster-api/linux-amd64/manager`
+_output/bin/cluster-api/linux-amd64/kubeadm-bootstrap-manager: ## Build `_output/bin/cluster-api/linux-amd64/kubeadm-bootstrap-manager`
+_output/bin/cluster-api/linux-amd64/kubeadm-control-plane-manager: ## Build `_output/bin/cluster-api/linux-amd64/kubeadm-control-plane-manager`
+_output/bin/cluster-api/linux-amd64/cluster-api-provider-docker-manager: ## Build `_output/bin/cluster-api/linux-amd64/cluster-api-provider-docker-manager`
+_output/bin/cluster-api/linux-arm64/clusterctl: ## Build `_output/bin/cluster-api/linux-arm64/clusterctl`
+_output/bin/cluster-api/linux-arm64/manager: ## Build `_output/bin/cluster-api/linux-arm64/manager`
+_output/bin/cluster-api/linux-arm64/kubeadm-bootstrap-manager: ## Build `_output/bin/cluster-api/linux-arm64/kubeadm-bootstrap-manager`
+_output/bin/cluster-api/linux-arm64/kubeadm-control-plane-manager: ## Build `_output/bin/cluster-api/linux-arm64/kubeadm-control-plane-manager`
+_output/bin/cluster-api/linux-arm64/cluster-api-provider-docker-manager: ## Build `_output/bin/cluster-api/linux-arm64/cluster-api-provider-docker-manager`
+
+patch-repo: ## Patch upstream repo with patches in patches directory
+
+##@ Image Targets
+local-images: ## Builds `cluster-api-controller/images/amd64 kubeadm-bootstrap-controller/images/amd64 kubeadm-control-plane-controller/images/amd64 cluster-api-docker-controller/images/amd64` as oci tars for presumbit validation
+images: ## Pushes `cluster-api-controller/images/push kubeadm-bootstrap-controller/images/push kubeadm-control-plane-controller/images/push cluster-api-docker-controller/images/push` to IMAGE_REPO
+cluster-api-controller/images/amd64: ## Builds/pushes `cluster-api-controller/images/amd64`
+kubeadm-bootstrap-controller/images/amd64: ## Builds/pushes `kubeadm-bootstrap-controller/images/amd64`
+kubeadm-control-plane-controller/images/amd64: ## Builds/pushes `kubeadm-control-plane-controller/images/amd64`
+cluster-api-docker-controller/images/amd64: ## Builds/pushes `cluster-api-docker-controller/images/amd64`
+cluster-api-controller/images/push: ## Builds/pushes `cluster-api-controller/images/push`
+kubeadm-bootstrap-controller/images/push: ## Builds/pushes `kubeadm-bootstrap-controller/images/push`
+kubeadm-control-plane-controller/images/push: ## Builds/pushes `kubeadm-control-plane-controller/images/push`
+cluster-api-docker-controller/images/push: ## Builds/pushes `cluster-api-docker-controller/images/push`
+
+##@ Fetch Binary Targets
+_output/dependencies/linux-amd64/eksd/kubernetes/client: ## Fetch `_output/dependencies/linux-amd64/eksd/kubernetes/client`
+_output/dependencies/linux-arm64/eksd/kubernetes/client: ## Fetch `_output/dependencies/linux-arm64/eksd/kubernetes/client`
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
+##@ Artifact Targets
+tarballs: ## Create tarballs by calling build/lib/simple_create_tarballs.sh unless SIMPLE_CREATE_TARBALLS=false, then tarballs must be defined in project Makefile
+s3-artifacts: # Prepare ARTIFACTS_PATH folder structure with tarballs/manifests/other items to be uploaded to s3
+upload-artifacts: # Upload tarballs and other artifacts from ARTIFACTS_PATH to S3
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+clean-repo: ## Removes source directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution attribution-pr upload-artifacts`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
+########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/cluster-api/Makefile
+++ b/projects/kubernetes-sigs/cluster-api/Makefile
@@ -49,3 +49,11 @@ $(call IMAGE_TARGETS_FOR_NAME, cluster-api-docker-controller): $(call FULL_FETCH
 .PHONY: create-manifests
 create-manifests: tarballs
 	build/create_manifests.sh $(REPO) $(OUTPUT_DIR) $(ARTIFACTS_PATH) $(GIT_TAG) $(IMAGE_REPO) $(IMAGE_TAG)
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/cri-tools/Help.mk
+++ b/projects/kubernetes-sigs/cri-tools/Help.mk
@@ -1,0 +1,49 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ GIT/Repo Targets
+clone-repo:  ## Clone upstream `cri-tools`
+checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
+
+##@ Binary Targets
+binaries: ## Build all binaries: `crictl critest` for `linux/amd64 linux/arm64`
+_output/bin/cri-tools/linux-amd64/crictl: ## Build `_output/bin/cri-tools/linux-amd64/crictl`
+_output/bin/cri-tools/linux-amd64/critest: ## Build `_output/bin/cri-tools/linux-amd64/critest`
+_output/bin/cri-tools/linux-arm64/crictl: ## Build `_output/bin/cri-tools/linux-arm64/crictl`
+_output/bin/cri-tools/linux-arm64/critest: ## Build `_output/bin/cri-tools/linux-arm64/critest`
+
+##@ Image Targets
+local-images: ## Builds `` as oci tars for presumbit validation
+images: ## Pushes `` to IMAGE_REPO
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
+##@ Artifact Targets
+tarballs: ## Create tarballs by calling build/lib/simple_create_tarballs.sh unless SIMPLE_CREATE_TARBALLS=false, then tarballs must be defined in project Makefile
+s3-artifacts: # Prepare ARTIFACTS_PATH folder structure with tarballs/manifests/other items to be uploaded to s3
+upload-artifacts: # Upload tarballs and other artifacts from ARTIFACTS_PATH to S3
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+clean-repo: ## Removes source directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `validate-checksums  attribution attribution-pr upload-artifacts`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums  upload-artifacts`
+########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/cri-tools/Makefile
+++ b/projects/kubernetes-sigs/cri-tools/Makefile
@@ -17,3 +17,11 @@ include $(BASE_DIRECTORY)/Common.mk
 
 $(OUTPUT_BIN_DIR)/linux-%/critest: GOBUILD_COMMAND=test
 $(OUTPUT_BIN_DIR)/linux-%/critest: EXTRA_GOBUILD_FLAGS+=-c
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/etcdadm/Help.mk
+++ b/projects/kubernetes-sigs/etcdadm/Help.mk
@@ -1,0 +1,49 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ GIT/Repo Targets
+clone-repo:  ## Clone upstream `etcdadm`
+checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
+
+##@ Binary Targets
+binaries: ## Build all binaries: `etcdadm` for `linux/amd64 linux/arm64`
+_output/bin/etcdadm/linux-amd64/etcdadm: ## Build `_output/bin/etcdadm/linux-amd64/etcdadm`
+_output/bin/etcdadm/linux-arm64/etcdadm: ## Build `_output/bin/etcdadm/linux-arm64/etcdadm`
+
+patch-repo: ## Patch upstream repo with patches in patches directory
+
+##@ Image Targets
+local-images: ## Builds `` as oci tars for presumbit validation
+images: ## Pushes `` to IMAGE_REPO
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
+##@ Artifact Targets
+tarballs: ## Create tarballs by calling build/lib/simple_create_tarballs.sh unless SIMPLE_CREATE_TARBALLS=false, then tarballs must be defined in project Makefile
+s3-artifacts: # Prepare ARTIFACTS_PATH folder structure with tarballs/manifests/other items to be uploaded to s3
+upload-artifacts: # Upload tarballs and other artifacts from ARTIFACTS_PATH to S3
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+clean-repo: ## Removes source directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `validate-checksums  attribution attribution-pr upload-artifacts`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums  upload-artifacts`
+########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/etcdadm/Makefile
+++ b/projects/kubernetes-sigs/etcdadm/Makefile
@@ -13,3 +13,11 @@ HAS_S3_ARTIFACTS=true
 IMAGE_NAMES=
 
 include $(BASE_DIRECTORY)/Common.mk
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/kind/Help.mk
+++ b/projects/kubernetes-sigs/kind/Help.mk
@@ -1,0 +1,69 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ GIT/Repo Targets
+clone-repo:  ## Clone upstream `kind`
+checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
+
+##@ Binary Targets
+binaries: ## Build all binaries: `` for `linux/amd64 linux/arm64 darwin/amd64 darwin/arm64`
+_output/bin/kind/linux-amd64/kind: ## Build `_output/bin/kind/linux-amd64/kind`
+_output/bin/kind/linux-arm64/kind: ## Build `_output/bin/kind/linux-arm64/kind`
+_output/bin/kind/darwin-amd64/kind: ## Build `_output/bin/kind/darwin-amd64/kind`
+_output/bin/kind/darwin-arm64/kind: ## Build `_output/bin/kind/darwin-arm64/kind`
+_output/bin/kind/linux-amd64/kindnetd: ## Build `_output/bin/kind/linux-amd64/kindnetd`
+_output/bin/kind/linux-arm64/kindnetd: ## Build `_output/bin/kind/linux-arm64/kindnetd`
+
+patch-repo: ## Patch upstream repo with patches in patches directory
+
+##@ Image Targets
+local-images: ## Builds `kindnetd/images/amd64 kind-base/images/amd64` as oci tars for presumbit validation
+images: ## Pushes `kindnetd/images/push kind-base/images/push` to IMAGE_REPO
+kindnetd/images/amd64: ## Builds/pushes `kindnetd/images/amd64`
+kind-base/images/amd64: ## Builds/pushes `kind-base/images/amd64`
+kindnetd/images/push: ## Builds/pushes `kindnetd/images/push`
+kind-base/images/push: ## Builds/pushes `kind-base/images/push`
+
+##@ Fetch Binary Targets
+_output/1-21/dependencies/linux-amd64/eksd/kubernetes/client: ## Fetch `_output/1-21/dependencies/linux-amd64/eksd/kubernetes/client`
+_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm: ## Fetch `_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm`
+_output/1-21/dependencies/linux-amd64/eksd/cni-plugins: ## Fetch `_output/1-21/dependencies/linux-amd64/eksd/cni-plugins`
+_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/cri-tools: ## Fetch `_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/cri-tools`
+_output/1-21/dependencies/linux-amd64/eksd/etcd/etcd.tar.gz: ## Fetch `_output/1-21/dependencies/linux-amd64/eksd/etcd/etcd.tar.gz`
+_output/1-21/dependencies/linux-arm64/eksd/kubernetes/client: ## Fetch `_output/1-21/dependencies/linux-arm64/eksd/kubernetes/client`
+_output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/etcdadm: ## Fetch `_output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/etcdadm`
+_output/1-21/dependencies/linux-arm64/eksd/cni-plugins: ## Fetch `_output/1-21/dependencies/linux-arm64/eksd/cni-plugins`
+_output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/cri-tools: ## Fetch `_output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/cri-tools`
+_output/1-21/dependencies/linux-arm64/eksd/etcd/etcd.tar.gz: ## Fetch `_output/1-21/dependencies/linux-arm64/eksd/etcd/etcd.tar.gz`
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
+##@ Artifact Targets
+tarballs: ## Create tarballs by calling build/lib/simple_create_tarballs.sh unless SIMPLE_CREATE_TARBALLS=false, then tarballs must be defined in project Makefile
+s3-artifacts: # Prepare ARTIFACTS_PATH folder structure with tarballs/manifests/other items to be uploaded to s3
+upload-artifacts: # Upload tarballs and other artifacts from ARTIFACTS_PATH to S3
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+clean-repo: ## Removes source directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution attribution-pr upload-artifacts`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
+########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/kind/Makefile
+++ b/projects/kubernetes-sigs/kind/Makefile
@@ -161,3 +161,11 @@ $(ARTIFACTS_PATH)/manifests/kindnetd.yaml:
 .PHONY: create-kind-cluster-%
 create-kind-cluster-%:
 	build/create-kind-cluster.sh $(IMAGE_REPO)/$(KIND_NODE_IMAGE_COMPONENT):$(NODE_IMAGE_LATEST_TAG) $* $(RELEASE_BRANCH)
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/vsphere-csi-driver/Help.mk
+++ b/projects/kubernetes-sigs/vsphere-csi-driver/Help.mk
@@ -1,0 +1,48 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ GIT/Repo Targets
+clone-repo:  ## Clone upstream `vsphere-csi-driver`
+checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
+
+##@ Binary Targets
+binaries: ## Build all binaries: `vsphere-csi-driver vsphere-csi-syncer` for `linux/amd64 linux/arm64`
+_output/bin/vsphere-csi-driver/linux-amd64/vsphere-csi-driver: ## Build `_output/bin/vsphere-csi-driver/linux-amd64/vsphere-csi-driver`
+_output/bin/vsphere-csi-driver/linux-amd64/vsphere-csi-syncer: ## Build `_output/bin/vsphere-csi-driver/linux-amd64/vsphere-csi-syncer`
+_output/bin/vsphere-csi-driver/linux-arm64/vsphere-csi-driver: ## Build `_output/bin/vsphere-csi-driver/linux-arm64/vsphere-csi-driver`
+_output/bin/vsphere-csi-driver/linux-arm64/vsphere-csi-syncer: ## Build `_output/bin/vsphere-csi-driver/linux-arm64/vsphere-csi-syncer`
+
+##@ Image Targets
+local-images: ## Builds `csi-driver/images/amd64 csi-syncer/images/amd64` as oci tars for presumbit validation
+images: ## Pushes `csi-driver/images/push csi-syncer/images/push` to IMAGE_REPO
+csi-driver/images/amd64: ## Builds/pushes `csi-driver/images/amd64`
+csi-syncer/images/amd64: ## Builds/pushes `csi-syncer/images/amd64`
+csi-driver/images/push: ## Builds/pushes `csi-driver/images/push`
+csi-syncer/images/push: ## Builds/pushes `csi-syncer/images/push`
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+clean-repo: ## Removes source directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution attribution-pr `
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/vsphere-csi-driver/Makefile
+++ b/projects/kubernetes-sigs/vsphere-csi-driver/Makefile
@@ -29,3 +29,11 @@ $(OUTPUT_FILES_TARGET):
 	cp $(REPO)/pkg/apis/cnsoperator/config/cnsregistervolume_crd.yaml \
 		$(REPO)/pkg/apis/cnsoperator/config/cnsfileaccessconfig_crd.yaml \
 		$(REPO)/pkg/internal/cnsoperator/config/cnsfilevolumeclient_crd.yaml $@
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/kubernetes/cloud-provider-vsphere/Help.mk
+++ b/projects/kubernetes/cloud-provider-vsphere/Help.mk
@@ -1,0 +1,44 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ GIT/Repo Targets
+clone-repo:  ## Clone upstream `cloud-provider-vsphere`
+checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
+
+##@ Binary Targets
+binaries: ## Build all binaries: `vsphere-cloud-controller-manager` for `linux/amd64 linux/arm64`
+_output/1-21/bin/cloud-provider-vsphere/linux-amd64/vsphere-cloud-controller-manager: ## Build `_output/1-21/bin/cloud-provider-vsphere/linux-amd64/vsphere-cloud-controller-manager`
+_output/1-21/bin/cloud-provider-vsphere/linux-arm64/vsphere-cloud-controller-manager: ## Build `_output/1-21/bin/cloud-provider-vsphere/linux-arm64/vsphere-cloud-controller-manager`
+
+##@ Image Targets
+local-images: ## Builds `cloud-provider-vsphere/images/amd64` as oci tars for presumbit validation
+images: ## Pushes `cloud-provider-vsphere/images/push` to IMAGE_REPO
+cloud-provider-vsphere/images/amd64: ## Builds/pushes `cloud-provider-vsphere/images/amd64`
+cloud-provider-vsphere/images/push: ## Builds/pushes `cloud-provider-vsphere/images/push`
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+clean-repo: ## Removes source directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution attribution-pr `
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+########### END GENERATED ###########################

--- a/projects/kubernetes/cloud-provider-vsphere/Makefile
+++ b/projects/kubernetes/cloud-provider-vsphere/Makefile
@@ -33,3 +33,11 @@ $(FIX_LICENSES_VSPHERE_AUTOMATION_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
 		wget -q https://raw.githubusercontent.com/vmware/vsphere-automation-sdk-go/master/LICENSE.txt -O \
 			$(REPO)/vendor/github.com/vmware/vsphere-automation-sdk-go/$$package/LICENSE.txt; \
 	done;
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/mrajashree/etcdadm-bootstrap-provider/Help.mk
+++ b/projects/mrajashree/etcdadm-bootstrap-provider/Help.mk
@@ -1,0 +1,49 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ GIT/Repo Targets
+clone-repo:  ## Clone upstream `etcdadm-bootstrap-provider`
+checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
+
+##@ Binary Targets
+binaries: ## Build all binaries: `manager` for `linux/amd64 linux/arm64`
+_output/bin/etcdadm-bootstrap-provider/linux-amd64/manager: ## Build `_output/bin/etcdadm-bootstrap-provider/linux-amd64/manager`
+_output/bin/etcdadm-bootstrap-provider/linux-arm64/manager: ## Build `_output/bin/etcdadm-bootstrap-provider/linux-arm64/manager`
+
+##@ Image Targets
+local-images: ## Builds `etcdadm-bootstrap-provider/images/amd64` as oci tars for presumbit validation
+images: ## Pushes `etcdadm-bootstrap-provider/images/push` to IMAGE_REPO
+etcdadm-bootstrap-provider/images/amd64: ## Builds/pushes `etcdadm-bootstrap-provider/images/amd64`
+etcdadm-bootstrap-provider/images/push: ## Builds/pushes `etcdadm-bootstrap-provider/images/push`
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
+##@ Artifact Targets
+tarballs: ## Create tarballs by calling build/lib/simple_create_tarballs.sh unless SIMPLE_CREATE_TARBALLS=false, then tarballs must be defined in project Makefile
+s3-artifacts: # Prepare ARTIFACTS_PATH folder structure with tarballs/manifests/other items to be uploaded to s3
+upload-artifacts: # Upload tarballs and other artifacts from ARTIFACTS_PATH to S3
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+clean-repo: ## Removes source directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution attribution-pr upload-artifacts`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
+########### END GENERATED ###########################

--- a/projects/mrajashree/etcdadm-bootstrap-provider/Makefile
+++ b/projects/mrajashree/etcdadm-bootstrap-provider/Makefile
@@ -19,3 +19,11 @@ s3-artifacts: create-manifests
 create-manifests: export PATH:=$(MAKE_ROOT)/$(OUTPUT_DIR):$(PATH)
 create-manifests: $(KUSTOMIZE_TARGET) tarballs
 	build/create_manifests.sh $(REPO) $(OUTPUT_DIR) $(ARTIFACTS_PATH) $(GIT_TAG) $(IMAGE_REPO) $(IMAGE_TAG)
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/mrajashree/etcdadm-controller/Help.mk
+++ b/projects/mrajashree/etcdadm-controller/Help.mk
@@ -1,0 +1,49 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ GIT/Repo Targets
+clone-repo:  ## Clone upstream `etcdadm-controller`
+checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
+
+##@ Binary Targets
+binaries: ## Build all binaries: `manager` for `linux/amd64 linux/arm64`
+_output/bin/etcdadm-controller/linux-amd64/manager: ## Build `_output/bin/etcdadm-controller/linux-amd64/manager`
+_output/bin/etcdadm-controller/linux-arm64/manager: ## Build `_output/bin/etcdadm-controller/linux-arm64/manager`
+
+##@ Image Targets
+local-images: ## Builds `etcdadm-controller/images/amd64` as oci tars for presumbit validation
+images: ## Pushes `etcdadm-controller/images/push` to IMAGE_REPO
+etcdadm-controller/images/amd64: ## Builds/pushes `etcdadm-controller/images/amd64`
+etcdadm-controller/images/push: ## Builds/pushes `etcdadm-controller/images/push`
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
+##@ Artifact Targets
+tarballs: ## Create tarballs by calling build/lib/simple_create_tarballs.sh unless SIMPLE_CREATE_TARBALLS=false, then tarballs must be defined in project Makefile
+s3-artifacts: # Prepare ARTIFACTS_PATH folder structure with tarballs/manifests/other items to be uploaded to s3
+upload-artifacts: # Upload tarballs and other artifacts from ARTIFACTS_PATH to S3
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+clean-repo: ## Removes source directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution attribution-pr upload-artifacts`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
+########### END GENERATED ###########################

--- a/projects/mrajashree/etcdadm-controller/Makefile
+++ b/projects/mrajashree/etcdadm-controller/Makefile
@@ -19,3 +19,11 @@ s3-artifacts: create-manifests
 create-manifests: export PATH:=$(MAKE_ROOT)/$(OUTPUT_DIR):$(PATH)
 create-manifests: $(KUSTOMIZE_TARGET) tarballs
 	build/create_manifests.sh $(REPO) $(OUTPUT_DIR) $(ARTIFACTS_PATH) $(GIT_TAG) $(IMAGE_REPO) $(IMAGE_TAG)
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/plunder-app/kube-vip/Help.mk
+++ b/projects/plunder-app/kube-vip/Help.mk
@@ -1,0 +1,44 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ GIT/Repo Targets
+clone-repo:  ## Clone upstream `kube-vip`
+checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
+
+##@ Binary Targets
+binaries: ## Build all binaries: `kube-vip` for `linux/amd64 linux/arm64`
+_output/bin/kube-vip/linux-amd64/kube-vip: ## Build `_output/bin/kube-vip/linux-amd64/kube-vip`
+_output/bin/kube-vip/linux-arm64/kube-vip: ## Build `_output/bin/kube-vip/linux-arm64/kube-vip`
+
+##@ Image Targets
+local-images: ## Builds `kube-vip/images/amd64` as oci tars for presumbit validation
+images: ## Pushes `kube-vip/images/push` to IMAGE_REPO
+kube-vip/images/amd64: ## Builds/pushes `kube-vip/images/amd64`
+kube-vip/images/push: ## Builds/pushes `kube-vip/images/push`
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+clean-repo: ## Removes source directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution attribution-pr `
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+########### END GENERATED ###########################

--- a/projects/plunder-app/kube-vip/Makefile
+++ b/projects/plunder-app/kube-vip/Makefile
@@ -10,3 +10,11 @@ BASE_IMAGE_NAME?=eks-distro-minimal-base
 BINARY_TARGET_FILES=kube-vip
 
 include $(BASE_DIRECTORY)/Common.mk
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/rancher/local-path-provisioner/Help.mk
+++ b/projects/rancher/local-path-provisioner/Help.mk
@@ -1,0 +1,44 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ GIT/Repo Targets
+clone-repo:  ## Clone upstream `local-path-provisioner`
+checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
+
+##@ Binary Targets
+binaries: ## Build all binaries: `local-path-provisioner` for `linux/amd64 linux/arm64`
+_output/bin/local-path-provisioner/linux-amd64/local-path-provisioner: ## Build `_output/bin/local-path-provisioner/linux-amd64/local-path-provisioner`
+_output/bin/local-path-provisioner/linux-arm64/local-path-provisioner: ## Build `_output/bin/local-path-provisioner/linux-arm64/local-path-provisioner`
+
+##@ Image Targets
+local-images: ## Builds `local-path-provisioner/images/amd64` as oci tars for presumbit validation
+images: ## Pushes `local-path-provisioner/images/push` to IMAGE_REPO
+local-path-provisioner/images/amd64: ## Builds/pushes `local-path-provisioner/images/amd64`
+local-path-provisioner/images/push: ## Builds/pushes `local-path-provisioner/images/push`
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+clean-repo: ## Removes source directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution attribution-pr `
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+########### END GENERATED ###########################

--- a/projects/rancher/local-path-provisioner/Makefile
+++ b/projects/rancher/local-path-provisioner/Makefile
@@ -10,3 +10,11 @@ BASE_IMAGE_NAME?=eks-distro-minimal-base
 BINARY_TARGET_FILES=local-path-provisioner
 
 include $(BASE_DIRECTORY)/Common.mk
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/Help.mk
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/Help.mk
@@ -1,0 +1,51 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ GIT/Repo Targets
+clone-repo:  ## Clone upstream `cluster-api-provider-tinkerbell`
+checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
+
+##@ Binary Targets
+binaries: ## Build all binaries: `manager` for `linux/amd64 linux/arm64`
+_output/bin/cluster-api-provider-tinkerbell/linux-amd64/manager: ## Build `_output/bin/cluster-api-provider-tinkerbell/linux-amd64/manager`
+_output/bin/cluster-api-provider-tinkerbell/linux-arm64/manager: ## Build `_output/bin/cluster-api-provider-tinkerbell/linux-arm64/manager`
+
+patch-repo: ## Patch upstream repo with patches in patches directory
+
+##@ Image Targets
+local-images: ## Builds `cluster-api-provider-tinkerbell/images/amd64` as oci tars for presumbit validation
+images: ## Pushes `cluster-api-provider-tinkerbell/images/push` to IMAGE_REPO
+cluster-api-provider-tinkerbell/images/amd64: ## Builds/pushes `cluster-api-provider-tinkerbell/images/amd64`
+cluster-api-provider-tinkerbell/images/push: ## Builds/pushes `cluster-api-provider-tinkerbell/images/push`
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
+##@ Artifact Targets
+tarballs: ## Create tarballs by calling build/lib/simple_create_tarballs.sh unless SIMPLE_CREATE_TARBALLS=false, then tarballs must be defined in project Makefile
+s3-artifacts: # Prepare ARTIFACTS_PATH folder structure with tarballs/manifests/other items to be uploaded to s3
+upload-artifacts: # Upload tarballs and other artifacts from ARTIFACTS_PATH to S3
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+clean-repo: ## Removes source directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution attribution-pr upload-artifacts`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
+########### END GENERATED ###########################

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/Makefile
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/Makefile
@@ -22,3 +22,11 @@ s3-artifacts: create-manifests
 .PHONY: create-manifests
 create-manifests: tarballs
 	build/create_manifests.sh $(REPO) $(OUTPUT_DIR) $(ARTIFACTS_PATH) $(GIT_TAG) $(IMAGE_REPO) $(IMAGE_TAG)
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/tinkerbell/hegel/Help.mk
+++ b/projects/tinkerbell/hegel/Help.mk
@@ -1,0 +1,44 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ GIT/Repo Targets
+clone-repo:  ## Clone upstream `hegel`
+checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
+
+##@ Binary Targets
+binaries: ## Build all binaries: `hegel` for `linux/amd64 linux/arm64`
+_output/bin/hegel/linux-amd64/hegel: ## Build `_output/bin/hegel/linux-amd64/hegel`
+_output/bin/hegel/linux-arm64/hegel: ## Build `_output/bin/hegel/linux-arm64/hegel`
+
+##@ Image Targets
+local-images: ## Builds `hegel/images/amd64` as oci tars for presumbit validation
+images: ## Pushes `hegel/images/push` to IMAGE_REPO
+hegel/images/amd64: ## Builds/pushes `hegel/images/amd64`
+hegel/images/push: ## Builds/pushes `hegel/images/push`
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+clean-repo: ## Removes source directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution attribution-pr `
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+########### END GENERATED ###########################

--- a/projects/tinkerbell/hegel/Makefile
+++ b/projects/tinkerbell/hegel/Makefile
@@ -25,3 +25,11 @@ $(FIX_LICENSES_STRPTIME_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
 # The project owner had mentioned a MIT License and has it embedded in github.com/pbnjay/strptime/strptime.go.
 # We copied the license out to STRPTIME_LICENSE.txt and moved it into vendor during build.
 	cp STRPTIME_LICENSE.txt $(REPO)/vendor/github.com/pbnjay/strptime/LICENSE.txt
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/vmware/govmomi/Help.mk
+++ b/projects/vmware/govmomi/Help.mk
@@ -1,0 +1,47 @@
+
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+
+
+##@ GIT/Repo Targets
+clone-repo:  ## Clone upstream `govmomi`
+checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
+
+##@ Binary Targets
+binaries: ## Build all binaries: `govc` for `linux/amd64 linux/arm64`
+_output/bin/govmomi/linux-amd64/govc: ## Build `_output/bin/govmomi/linux-amd64/govc`
+_output/bin/govmomi/linux-arm64/govc: ## Build `_output/bin/govmomi/linux-arm64/govc`
+
+##@ Image Targets
+local-images: ## Builds `` as oci tars for presumbit validation
+images: ## Pushes `` to IMAGE_REPO
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
+##@ Artifact Targets
+tarballs: ## Create tarballs by calling build/lib/simple_create_tarballs.sh unless SIMPLE_CREATE_TARBALLS=false, then tarballs must be defined in project Makefile
+s3-artifacts: # Prepare ARTIFACTS_PATH folder structure with tarballs/manifests/other items to be uploaded to s3
+upload-artifacts: # Upload tarballs and other artifacts from ARTIFACTS_PATH to S3
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
+##@ Clean Targets
+clean: ## Removes source and _output directory
+clean-repo: ## Removes source directory
+
+##@ Helpers
+help: ## Display this help
+add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
+
+##@ Build Targets
+build: ## Called via prow presubmit, calls `validate-checksums  attribution attribution-pr upload-artifacts`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums  upload-artifacts`
+########### END GENERATED ###########################

--- a/projects/vmware/govmomi/Makefile
+++ b/projects/vmware/govmomi/Makefile
@@ -13,3 +13,11 @@ HAS_S3_ARTIFACTS=true
 IMAGE_NAMES=
 
 include $(BASE_DIRECTORY)/Common.mk
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This adds a target to generate a project specific help based on makefile vars.  This allows for `make help` to show an accurate list of make targets that are actually be called.  It also, at least in zsh on mac, supports autocompletion so if trying to run a make target hitting tab should fill it out.

Example make help out:

/hold
![Screen Shot 2021-12-07 at 5 24 23 PM](https://user-images.githubusercontent.com/1471144/145121515-1c3eaf7a-6916-4ff9-960e-9e3c67e4a8a4.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
