### PR TITLE
licenses: no need to keep code

### DIFF
--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -148,7 +148,11 @@ function build::gather_licenses() {
   # which makes deleting them later awkward
   # this behavior may change in the future with the following PR
   # https://github.com/google/go-licenses/pull/28
-  chmod -R 777 "${outputdir}/LICENSES"  
+  # We can delete these additional files because we are running go mod vendor
+  # prior to this call so we know the source is the same as upstream
+  # go-licenses is copying this code because it doesnt know if its be modified or not
+  chmod -R 777 "${outputdir}/LICENSES"
+  find "${outputdir}/LICENSES" -type f \( -name '*.yml' -o -name '*.go' -o -name '*.mod' -o -name '*.sum' -o -name '*gitignore' \) -delete
 
   # most of the packages show up the go-license.csv file as the module name
   # from the go.mod file, storing that away since the source dirs usually get deleted


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
go-licenses is pretty conservative about copying code for projects with certain licenses since they "could" have been modified.  We know this is not the case since we are calling go mod vendor to pull from upstream before building.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
