### PR TITLE
Automated cherry pick of #288: bump eks-d release numbers

### DIFF
--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -1,13 +1,13 @@
 1-18:
-  number: 12
+  number: 13
   kubeVersion: v1.18.20
 1-19:
-  number: 11
+  number: 12
   kubeVersion: v1.19.13
 1-20:
-  number: 8
+  number: 9
   kubeVersion: v1.20.7
 1-21:
-  number: 6
+  number: 7
   kubeVersion: v1.21.2
 latest: 1-21


### PR DESCRIPTION
Cherry pick of #288 on release-0.6.

#288: bump eks-d release numbers

For details on the cherry pick process, see the [cherry pick requests](https://github.com/aws/eks-anywhere-build-tooling/tree/main/docs/development/cherry-picks.md) page.

```release-note

```