### PR TITLE
Bump kube versions in EKS-D releases list

### DIFF
--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -3,11 +3,11 @@
   kubeVersion: v1.18.20
 1-19:
   number: 12
-  kubeVersion: v1.19.13
+  kubeVersion: v1.19.15
 1-20:
   number: 9
-  kubeVersion: v1.20.7
+  kubeVersion: v1.20.11
 1-21:
   number: 7
-  kubeVersion: v1.21.2
+  kubeVersion: v1.21.5
 latest: 1-21


### PR DESCRIPTION
Bumping up to corresponding Kubernetes versions in the releases file


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
