### PR TITLE
fix help generation on builder base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,18 +52,28 @@ add-generated-help-block-project-%:
 
 .PHONY: add-generated-help-block
 add-generated-help-block: $(addprefix add-generated-help-block-project-, $(ALL_PROJECTS))
+	build/update-attribution-files/create_pr.sh
 
 .PHONY: attribution-files-project-%
 attribution-files-project-%:
 	$(eval PROJECT_PATH=projects/$(subst _,/,$*))
-	build/update-attribution-files/make_attribution.sh $(PROJECT_PATH)
+	build/update-attribution-files/make_attribution.sh $(PROJECT_PATH) attribution
 
 .PHONY: attribution-files
 attribution-files: $(addprefix attribution-files-project-, $(ALL_PROJECTS))
 	cat _output/total_summary.txt
 
+.PHONY: checksum-files-project-%
+checksum-files-project-%:
+	$(eval PROJECT_PATH=projects/$(subst _,/,$*))
+	build/update-attribution-files/make_attribution.sh $(PROJECT_PATH) checksums
+
+.PHONY: checksum-files
+checksum-files: $(addprefix checksum-files-project-, $(ALL_PROJECTS))
+	build/update-attribution-files/create_pr.sh
+
 .PHONY: update-attribution-files
-update-attribution-files: attribution-files add-generated-help-block
+update-attribution-files: add-generated-help-block attribution-files checksum-files
 	build/update-attribution-files/create_pr.sh
 
 .PHONY: run-target-in-docker

--- a/build/lib/generate_help_body.sh
+++ b/build/lib/generate_help_body.sh
@@ -80,7 +80,7 @@ if [[ "$HAS_PATCHES" == "true" ]]; then
 fi
 
 IMAGE_TARGETS_HELP=""
-if [ ! -z "$LOCAL_IMAGE_TARGETS" ]; then
+if [ ! -z "$(echo "$LOCAL_IMAGE_TARGETS" | xargs)" ]; then
     IMAGE_TARGETS_HELP+="${NL}${NL}##@ Image Targets"
     IMAGE_TARGETS_HELP+="${NL}local-images: ## Builds \`$(echo ${LOCAL_IMAGE_TARGETS} | xargs)\` as oci tars for presumbit validation"
     IMAGE_TARGETS_HELP+="${NL}images: ## Pushes \`$(echo ${IMAGE_TARGETS} | xargs)\` to IMAGE_REPO"
@@ -144,7 +144,7 @@ cat >> $HELPFILE << EOF
 ${NL}${NL}${NL}${HEADER}
 # To update call: make add-generated-help-block
 # This is added to help document dynamic targets and support shell autocompletion
-${GIT_TARGETS_HELP}${BINARY_TARGETS_HELP}${PATCHES_TARGET}${IMAGE_TARGETS_HELP}${HELM_TARGETS}${FETCH_BINARY_TARGETS_HELP}${CHECKSUMS_TARGETS_HELP}${ARTIFACTS_TARGETS}${LICENSES_TARGETS}${CLEAN_TARGETS}
+${GIT_TARGETS_HELP}${PATCHES_TARGET}${BINARY_TARGETS_HELP}${IMAGE_TARGETS_HELP}${HELM_TARGETS}${FETCH_BINARY_TARGETS_HELP}${CHECKSUMS_TARGETS_HELP}${ARTIFACTS_TARGETS}${LICENSES_TARGETS}${CLEAN_TARGETS}
 ${EXTRA_HELP}
 
 ##@ Build Targets

--- a/build/update-attribution-files/make_attribution.sh
+++ b/build/update-attribution-files/make_attribution.sh
@@ -20,6 +20,7 @@ set -o pipefail
 shopt -s globstar
 
 PROJECT="$1"
+TARGET="$2"
 
 MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
 PROJECT_ROOT=$MAKE_ROOT/$PROJECT
@@ -31,7 +32,7 @@ function build::attribution::generate(){
     if [ $# -ge 1 ]; then
         export RELEASE_BRANCH="$1"
     fi
-    make -C $PROJECT_ROOT binaries attribution checksums
+    make -C $PROJECT_ROOT $TARGET
     if [ -f $PROJECT_ROOT/_output/**/summary.txt ]; then
         for summary in $PROJECT_ROOT/_output/**/summary.txt; do
             sed -i "s/+.*=/ =/g" $summary
@@ -39,7 +40,6 @@ function build::attribution::generate(){
                 $summary _output/total_summary.txt | sort > _output/total_summary.tmp && mv _output/total_summary.tmp _output/total_summary.txt
         done
     fi
-    make -C $PROJECT_ROOT clean 
 }
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Should fix yesterdays failure due to a difference in bash on builder-base and mac.  This also

- separates checksum + attribution generation
- moves create_pr to be after each part (help, attribution, help) the script should still work for this and this would allow for anything that passes to still get checked in vs if one fails they all fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
