### PR TITLE
avoid make output in generated help

### DIFF
--- a/build/lib/generate_help_body.sh
+++ b/build/lib/generate_help_body.sh
@@ -51,7 +51,7 @@ sed -i "/$HEADER/,/$FOOTER/d" $HELPFILE
 printf %s "$(< $HELPFILE)" > $HELPFILE
 
 # Generate help items from Common.mk
-EXTRA_HELP="$(make help-list)"
+EXTRA_HELP="$(make help-list --no-print-directory)"
 BINARY_TARGETS_HELP=""
 CHECKSUMS_TARGETS_HELP=""
 if [ ! -z "$(echo "$BINARY_TARGETS" | xargs)" ]; then
@@ -76,7 +76,7 @@ fi
 
 PATCHES_TARGET=""
 if [[ "$HAS_PATCHES" == "true" ]]; then
-    PATCHES_TARGET+="${NL}${NL}patch-repo: ## Patch upstream repo with patches in patches directory"
+    PATCHES_TARGET+="${NL}patch-repo: ## Patch upstream repo with patches in patches directory"
 fi
 
 IMAGE_TARGETS_HELP=""


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Help in https://github.com/aws/eks-anywhere-build-tooling/pull/301 had extra make[2] output in the help files.  This should take care of that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
