### PR TITLE
handle nonstandard attribution file names and ignored files

### DIFF
--- a/build/update-attribution-files/create_pr.sh
+++ b/build/update-attribution-files/create_pr.sh
@@ -120,8 +120,8 @@ EOF
 
 
 # Add attribution files
-for FILE in $(find . -type f \( -name ATTRIBUTION.txt ! -path "*/_output/*" \)); do    
-    git add $FILE
+for FILE in $(find . -type f \( -name "*ATTRIBUTION.txt" ! -path "*/_output/*" \)); do    
+    git check-ignore -q $FILE || git add $FILE
 done
 
 # stash checksums files
@@ -136,7 +136,7 @@ if [ "$(git stash list)" != "" ]; then
 fi
 # Add checksum files
 for FILE in $(find . -type f -name CHECKSUMS); do    
-    git add $FILE
+    git check-ignore -q $FILE || git add $FILE
 done
 
 # stash help.mk files


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We havent been updating KINDNETD_ATTRIBUTION.txt when it needed. This also avoids the error when trying to added ignored files by using the check-ignore trick used for the Makefile git add.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
