### PR TITLE
Use whatever repo we are supposed to and docker config.json

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -152,7 +152,6 @@ HELM_DESTINATION_REPOSITORY?=$(IMAGE_COMPONENT)
 HELM_ADDITIONAL_KEY_VALUES?=
 HELM_GIT_CHECKOUT_TARGET?=$(HELM_SOURCE_REPOSITORY)/eks-anywhere-checkout-$(HELM_GIT_TAG)
 HELM_GIT_PATCH_TARGET?=$(HELM_SOURCE_REPOSITORY)/eks-anywhere-helm-patched
-PUBLIC_REGISTRY?=$(shell aws ecr-public describe-registries --region us-east-1 --query 'registries[*].registryUri' --output text)
 ####################################################
 
 #################### BINARIES ######################
@@ -445,7 +444,7 @@ validate-checksums: $(BINARY_TARGETS)
 helm/build: $(OUTPUT_DIR)/ATTRIBUTION.txt
 helm/build: $(if $(filter true,$(REPO_NO_CLONE)),,$(HELM_GIT_CHECKOUT_TARGET))
 helm/build: $(if $(wildcard $(MAKE_ROOT)/helm/patches),$(HELM_GIT_PATCH_TARGET),)
-	HELM_REGISTRY=$(PUBLIC_REGISTRY) \
+	HELM_REGISTRY=$(IMAGE_REPO) \
 	IMAGE_TAG=$(IMAGE_TAG) \
 	$(HELM_ADDITIONAL_KEY_VALUES) \
 	$(BUILD_LIB)/helm_build.sh $(HELM_SOURCE_REPOSITORY) $(HELM_DESTINATION_REPOSITORY) $(HELM_DIRECTORY) $(OUTPUT_DIR)
@@ -453,7 +452,7 @@ helm/build: $(if $(wildcard $(MAKE_ROOT)/helm/patches),$(HELM_GIT_PATCH_TARGET),
 # Build helm chart and push to registry defined in IMAGE_REPO.
 .PHONY: helm/push
 helm/push: helm/build
-	$(BUILD_LIB)/helm_push.sh $(PUBLIC_REGISTRY) $(HELM_DESTINATION_REPOSITORY) $(IMAGE_TAG) $(OUTPUT_DIR)
+	$(BUILD_LIB)/helm_push.sh $(IMAGE_REPO) $(HELM_DESTINATION_REPOSITORY) $(IMAGE_TAG) $(OUTPUT_DIR)
 
 # Build image using buildkit only builds linux/amd64 oci and saves to local tar.
 %/images/amd64: IMAGE_PLATFORMS?=linux/amd64


### PR DESCRIPTION
Change the helm build so

* Push helm chart to IMAGE_REPO (build doesn't have perms to get pub repo)
* Do not overlay the value of DOCKER_CONFIG
* Clean up the clean up
