### PR TITLE
Chart licenses

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -153,7 +153,6 @@ HELM_DESTINATION_REPOSITORY?=$(IMAGE_COMPONENT)
 HELM_ADDITIONAL_KEY_VALUES?=
 HELM_GIT_CHECKOUT_TARGET?=$(HELM_SOURCE_REPOSITORY)/eks-anywhere-checkout-$(HELM_GIT_TAG)
 HELM_GIT_PATCH_TARGET?=$(HELM_SOURCE_REPOSITORY)/eks-anywhere-helm-patched
-HELM_LICENSES_TARGET=$(OUTPUT_DIR)/LICENSES/github.com/$(HELM_SOURCE_OWNER)/$(HELM_SOURCE_REPOSITORY)
 ####################################################
 
 #################### BINARIES ######################
@@ -331,9 +330,6 @@ $(HELM_GIT_CHECKOUT_TARGET): | $(HELM_SOURCE_REPOSITORY)
 	(cd $(HELM_SOURCE_REPOSITORY) && $(BASE_DIRECTORY)/build/lib/wait_for_tag.sh $(HELM_GIT_TAG))
 	git -C $(HELM_SOURCE_REPOSITORY) checkout -f $(HELM_GIT_TAG)
 	touch $@
-
-$(HELM_LICENSES_TARGET):
-	$(BASE_DIRECTORY)/build/lib/gather_non_golang_licenses.sh $(HELM_SOURCE_OWNER)/$(HELM_SOURCE_REPOSITORY) $(HELM_GIT_TAG) $(MAKE_ROOT)/$(OUTPUT_DIR)
 endif
 
 $(HELM_GIT_PATCH_TARGET): $(HELM_GIT_CHECKOUT_TARGET)
@@ -383,7 +379,7 @@ $(GATHER_LICENSES_TARGETS): $(GO_MOD_DOWNLOAD_TARGETS)
 	$(BASE_DIRECTORY)/build/lib/create_attribution.sh $(MAKE_ROOT) $(GOLANG_VERSION) $(MAKE_ROOT)/$(LICENSES_OUTPUT_DIR) $(@F) $(RELEASE_BRANCH)
 
 .PHONY: gather-licenses
-gather-licenses: $(GATHER_LICENSES_TARGETS) $(if $(filter $(REPO),$(HELM_SOURCE_REPOSITORY)),,$(HELM_LICENSES_TARGET))
+gather-licenses: $(GATHER_LICENSES_TARGETS)
 
 .PHONY: attribution
 attribution: $(and $(filter true,$(HAS_LICENSES)),$(ATTRIBUTION_TARGETS))

--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -179,10 +179,9 @@ function build::non-golang::gather_licenses(){
 function build::non-golang::copy_licenses(){
   local -r source_dir="$1"
   local -r destination_dir="$2"
-  cd $source_dir
-  license_files=($(find . \( -name "*COPYING*" -o -name "*COPYRIGHT*" -o -name "*LICEN[C|S]E*" -o -name "*NOTICE*" \)))
-  cd -
-  for file in "${license_files[@]}"; do
+  (cd $source_dir; find . \( -name "*COPYING*" -o -name "*COPYRIGHT*" -o -name "*LICEN[C|S]E*" -o -name "*NOTICE*" \)) |
+  while read file
+  do
     license_dest=$destination_dir/$(dirname $file)
     mkdir -p $license_dest
     cp "${source_dir}/${file}" $license_dest/$(basename $file)

--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -171,13 +171,8 @@ function build::non-golang::gather_licenses(){
   git clone https://github.com/${project_org}/${project_name}
   cd $project_name
   git checkout $git_tag
-  license_files=($(find . \( -name "*COPYING*" -o -name "*COPYRIGHT*" -o -name "*LICEN[C|S]E*" -o -name "*NOTICE*" \)))
-  for file in "${license_files[@]}"; do
-    license_dest=$output_dir/LICENSES/github.com/${project_org}/${project_name}/$(dirname $file)
-    mkdir -p $license_dest
-    cp $file $license_dest/$(basename $file)
-  done
   cd ..
+  build::non-golang::copy_licenses $project_name $output_dir/LICENSES/github.com/${project_org}/${project_name}
   rm -rf $project_name
 }
 

--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -181,6 +181,19 @@ function build::non-golang::gather_licenses(){
   rm -rf $project_name
 }
 
+function build::non-golang::copy_licenses(){
+  local -r source_dir="$1"
+  local -r destination_dir="$2"
+  cd $source_dir
+  license_files=($(find . \( -name "*COPYING*" -o -name "*COPYRIGHT*" -o -name "*LICEN[C|S]E*" -o -name "*NOTICE*" \)))
+  cd -
+  for file in "${license_files[@]}"; do
+    license_dest=$destination_dir/$(dirname $file)
+    mkdir -p $license_dest
+    cp "${source_dir}/${file}" $license_dest/$(basename $file)
+  done
+}
+
 function build::generate_attribution(){
   local -r project_root=$1
   local -r golang_version=$2

--- a/build/lib/helm_build.sh
+++ b/build/lib/helm_build.sh
@@ -27,12 +27,15 @@ CHART_NAME=$(basename ${HELM_DESTINATION_REPOSITORY})
 DEST_DIR=${OUTPUT_DIR}/helm/${CHART_NAME}
 SOURCE_DIR=$(basename ${HELM_SOURCE_REPOSITORY})/${HELM_DIRECTORY}/.
 
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_ROOT}/common.sh"
+
 #
 # Copy
 #
 mkdir -p ${DEST_DIR}
-cp ${OUTPUT_DIR}/ATTRIBUTION.txt ${DEST_DIR}/
 cp -r ${SOURCE_DIR} ${DEST_DIR}
+build::non-golang::copy_licenses ${HELM_SOURCE_REPOSITORY} $DEST_DIR/LICENSES/github.com/${HELM_SOURCE_REPOSITORY}
 
 #
 # Search and replace

--- a/projects/jetstack/cert-manager/Makefile
+++ b/projects/jetstack/cert-manager/Makefile
@@ -20,6 +20,10 @@ SOURCE_PATTERNS=./cmd/acmesolver ./cmd/cainjector ./cmd/controller ./cmd/webhook
 
 HAS_HELM_CHART=true
 HELM_DIRECTORY=deploy/charts/cert-manager
+HELM_ADDITIONAL_KEY_VALUES=\
+  CERT_MANAGER_CAINJECTOR_DIGEST=$(shell $(BASE_DIRECTORY)/build/lib/image_shasum.sh ${IMAGE_REPO} jetstack/cert-manager-cainjector $(LATEST)) \
+  CERT_MANAGER_CONTROLLER_DIGEST=$(shell $(BASE_DIRECTORY)/build/lib/image_shasum.sh ${IMAGE_REPO} jetstack/cert-manager-controller $(LATEST)) \
+  CERT_MANAGER_WEBHOOK_DIGEST=$(shell $(BASE_DIRECTORY)/build/lib/image_shasum.sh ${IMAGE_REPO} jetstack/cert-manager-webhook $(LATEST))
 
 include $(BASE_DIRECTORY)/Common.mk
 

--- a/projects/jetstack/cert-manager/helm/patches/0003-Activate-digests-with-templates.patch
+++ b/projects/jetstack/cert-manager/helm/patches/0003-Activate-digests-with-templates.patch
@@ -1,0 +1,43 @@
+From 12b1d31799a4f36fb31350145093cf35c9d7dc47 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Thu, 30 Dec 2021 08:29:55 -0700
+Subject: [PATCH] Activate digests with templates
+
+---
+ deploy/charts/cert-manager/values.yaml | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/deploy/charts/cert-manager/values.yaml b/deploy/charts/cert-manager/values.yaml
+index 75740b218..d93e3c9bc 100644
+--- a/deploy/charts/cert-manager/values.yaml
++++ b/deploy/charts/cert-manager/values.yaml
+@@ -50,7 +50,7 @@ image:
+   # tag: canary
+ 
+   # Setting a digest will override any tag
+-  # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
++  digest: {{CERT_MANAGER_CONTROLLER_DIGEST}}
+   pullPolicy: IfNotPresent
+ 
+ # Override the namespace used to store DNS provider credentials etc. for ClusterIssuer
+@@ -255,7 +255,7 @@ webhook:
+     # tag: canary
+ 
+     # Setting a digest will override any tag
+-    # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
++    digest: {{CERT_MANAGER_WEBHOOK_DIGEST}}
+ 
+     pullPolicy: IfNotPresent
+ 
+@@ -343,7 +343,7 @@ cainjector:
+     # tag: canary
+ 
+     # Setting a digest will override any tag
+-    # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
++    digest: {{CERT_MANAGER_CAINJECTOR_DIGEST}}
+ 
+     pullPolicy: IfNotPresent
+ 
+-- 
+2.29.2
+

--- a/projects/jetstack/cert-manager/helm/sedfile.template
+++ b/projects/jetstack/cert-manager/helm/sedfile.template
@@ -1,3 +1,6 @@
 s,quay.io,${HELM_REGISTRY},g
 s/version: v0.1.0/version: ${IMAGE_TAG}-helm/
 s/appVersion: v0.1.0/appVersion: ${IMAGE_TAG}/
+s/digest: {{CERT_MANAGER_CONTROLLER_DIGEST}}$/digest: ${CERT_MANAGER_CONTROLLER_DIGEST}/
+s/digest: {{CERT_MANAGER_CAINJECTOR_DIGEST}}$/digest: ${CERT_MANAGER_CAINJECTOR_DIGEST}/
+s/digest: {{CERT_MANAGER_WEBHOOK_DIGEST}}$/digest: ${CERT_MANAGER_WEBHOOK_DIGEST}/


### PR DESCRIPTION

- Gathering licenses for helm charts and putting them in containers didn't make much sense, so I've reverted that.
- Gathered licenses just for the helm chart and put them in the helm chart. (works for cert-manager and flux)
- Removed attribute file from helm chart since that is really for the container image
