### PR TITLE
Wait until tarball is available under latest before downloading

### DIFF
--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -306,3 +306,21 @@ function build::common::wait_for_tag() {
     fi
   done
 }
+
+function build::common::wait_for_tarball() {
+  local -r tarball_url=$1
+  sleep_interval=20
+  for i in {1..60}; do
+    echo "Checking for URL ${tarball_url}..."
+    local -r http_code=$(curl -I -L -s -o /dev/null -w "%{http_code}" $tarball_url)
+    if [[ "$http_code" == "200" ]]; then 
+      echo "Tarball exists!" && break
+    fi
+    echo "Tarball does not exist!"
+    echo "Waiting for tarball to be uploaded to ${tarball_url}"
+    sleep $sleep_interval
+    if [ "$i" = "60" ]; then
+      exit 1
+    fi
+  done
+}

--- a/build/lib/fetch_binaries.sh
+++ b/build/lib/fetch_binaries.sh
@@ -33,8 +33,8 @@ OS_ARCH="$(cut -d '/' -f1 <<< ${DEP})"
 PRODUCT=$(cut -d '/' -f2 <<< ${DEP})
 REPO_OWNER=$(cut -d '/' -f3 <<< ${DEP})
 REPO=$(cut -d '/' -f4 <<< ${DEP})
-
 ARCH="$(cut -d '-' -f2 <<< ${OS_ARCH})"
+CODEBUILD_CI="${CODEBUILD_CI:-false}"
 
 OUTPUT_DIR_FILE=$BINARY_DEPS_DIR/linux-$ARCH/$PRODUCT/$REPO_OWNER/$REPO
 if [[ $REPO == *.tar.gz ]]; then
@@ -55,6 +55,10 @@ if [[ $PRODUCT = 'eksd' ]]; then
 else
     TARBALL="$REPO-linux-$ARCH.tar.gz"
     URL=$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET $REPO_OWNER/$REPO $ARCH $LATEST_TAG)
+fi
+
+if [ "$CODEBUILD_CI" = "true" ]; then
+    build::common::wait_for_tarball $URL
 fi
 
 if [[ $REPO == *.tar.gz ]]; then


### PR DESCRIPTION
This function will make the job sleep for 20 mins or until the project tarball is available under `latest/`, whichever is earlier.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
