### PR TITLE
Push generated Makefile changes to appropriately named branch

### DIFF
--- a/build/update-attribution-files/create_pr.sh
+++ b/build/update-attribution-files/create_pr.sh
@@ -108,7 +108,7 @@ EOF
 function pr::create::help() {
     local -r pr_title="Update Makefile generated help"
     local -r commit_message="[PR BOT] Update Help.mk files"
-    local -r pr_branch="checksums-files-update-$MAIN_BRANCH"
+    local -r pr_branch="help-makefiles-update-$MAIN_BRANCH"
     local -r pr_body=$(cat <<EOF
 This PR updates the Help.mk files across all dependency projects if there have been changes.
 


### PR DESCRIPTION
Isolates changes to Help.mk to their own branch.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
