### PR TITLE
Set bash as shell for make in common makefile

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -1,5 +1,6 @@
 # Disable built-in rules and variables
 MAKEFLAGS+=--no-builtin-rules --warn-undefined-variables
+SHELL=/bin/bash
 .SHELLFLAGS:=-eu -o pipefail -c
 .SUFFIXES:
 


### PR DESCRIPTION
*Description of changes:*
By default make's shell is sh, which doesn't support flags like -o pipefail

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
