### PR TITLE
Patches for CAPT BMC-Hardware Power and Deprovision

### DIFF
--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/CHECKSUMS
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/CHECKSUMS
@@ -1,2 +1,2 @@
-c0028c21123dd9670bd8cd2ce2db275ab4fcaa525178e95d642217fd7a29886b  _output/bin/cluster-api-provider-tinkerbell/linux-amd64/manager
-653469d4797becb8f80f8c34adafb19f4e195281ecffd35753addddd1fa701f0  _output/bin/cluster-api-provider-tinkerbell/linux-arm64/manager
+5e3328565f6b5ce50ef3240c2c006476fa5c9687b38e39d372325e5c6a9d4a37  _output/bin/cluster-api-provider-tinkerbell/linux-amd64/manager
+ef30c9eb34babd5e4ac4d2fa0a4f3bef89ce99addc1ba54db0a7d0e784e3f4c2  _output/bin/cluster-api-provider-tinkerbell/linux-arm64/manager

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/CHECKSUMS
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/CHECKSUMS
@@ -1,2 +1,2 @@
-5e3328565f6b5ce50ef3240c2c006476fa5c9687b38e39d372325e5c6a9d4a37  _output/bin/cluster-api-provider-tinkerbell/linux-amd64/manager
-ef30c9eb34babd5e4ac4d2fa0a4f3bef89ce99addc1ba54db0a7d0e784e3f4c2  _output/bin/cluster-api-provider-tinkerbell/linux-arm64/manager
+59933cf1b5c8eb138bc16a2192148d0ff2ac38cb2f57a1f6e95ccb644ba55931  _output/bin/cluster-api-provider-tinkerbell/linux-amd64/manager
+364e330537371bdad20ef6aeee10a46ad25bc60ff1f5ba30713d8a48bb9e63ed  _output/bin/cluster-api-provider-tinkerbell/linux-arm64/manager

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/CHECKSUMS
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/CHECKSUMS
@@ -1,2 +1,2 @@
-59933cf1b5c8eb138bc16a2192148d0ff2ac38cb2f57a1f6e95ccb644ba55931  _output/bin/cluster-api-provider-tinkerbell/linux-amd64/manager
-364e330537371bdad20ef6aeee10a46ad25bc60ff1f5ba30713d8a48bb9e63ed  _output/bin/cluster-api-provider-tinkerbell/linux-arm64/manager
+73625ac93be61fec9af76ddf5d4cfa4729b0aeaf7220c65333df47de01af21ea  _output/bin/cluster-api-provider-tinkerbell/linux-amd64/manager
+1171e1b64d8bd8bd4f625771aff48ce476c20ed53fa6b8a82e4b21f0e6c12179  _output/bin/cluster-api-provider-tinkerbell/linux-arm64/manager

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0004-Modifying-BMC-CRD-to-read-from-Secret.patch
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0004-Modifying-BMC-CRD-to-read-from-Secret.patch
@@ -1,46 +1,55 @@
-From 58f87a0e01f800afecbbfa2f7a1c8675b2f43e8f Mon Sep 17 00:00:00 2001
+From 4f1f3655bc94f0283be33a256a3ccd8ea3e2817d Mon Sep 17 00:00:00 2001
 From: Aravind Ramalingam <ramaliar@amazon.com>
 Date: Mon, 3 Jan 2022 14:31:18 -0800
 Subject: [PATCH 1/5] Modifying BMC CRD to read from Secret
 
 ---
- config/crd/bases/tinkerbell.org_bmc.yaml | 17 +++++------
- pbnj/api/v1alpha1/bmc_types.go           |  9 ++----
- pbnj/controllers/controller.go           | 38 ++++++++++++++++++++++--
- 3 files changed, 45 insertions(+), 19 deletions(-)
+ config/crd/bases/tinkerbell.org_bmc.yaml   | 25 ++++++++------
+ pbnj/api/v1alpha1/bmc_types.go             | 11 +++----
+ pbnj/api/v1alpha1/zz_generated.deepcopy.go |  1 +
+ pbnj/controllers/controller.go             | 38 ++++++++++++++++++++--
+ 4 files changed, 55 insertions(+), 20 deletions(-)
 
 diff --git a/config/crd/bases/tinkerbell.org_bmc.yaml b/config/crd/bases/tinkerbell.org_bmc.yaml
-index 3222146..a6683d0 100644
+index 3222146..0219089 100644
 --- a/config/crd/bases/tinkerbell.org_bmc.yaml
 +++ b/config/crd/bases/tinkerbell.org_bmc.yaml
-@@ -38,16 +38,14 @@ spec:
+@@ -38,26 +38,31 @@ spec:
            spec:
              description: BMCSpec defines the desired state of BMC.
              properties:
--              host:
--                description: Host is the host IP address of the BMC
--                minLength: 1
--                type: string
++              authSecretRef:
++                description: AuthSecretRef is the SecretReference that contains authentication
++                  information of the BMC. The Secret must contain username and password
++                  keys.
++                properties:
++                  name:
++                    description: Name is unique within a namespace to reference a
++                      secret resource.
++                    type: string
++                  namespace:
++                    description: Namespace defines the space within which the secret
++                      name must be unique.
++                    type: string
++                type: object
+               host:
+                 description: Host is the host IP address of the BMC
+                 minLength: 1
+                 type: string
 -              password:
 -                description: Password is the password to authenticate with the BMC
-+              authSecret:
-+                description: AuthSecret is the Secret that contains authentication
-+                  information of the BMC. The Secret must contain username and password
-+                  keys
-                 minLength: 1
-                 type: string
+-                minLength: 1
+-                type: string
 -              username:
 -                description: Username is the username to authenticate with the BMC
-+              host:
-+                description: Host is the host IP address of the BMC
-                 minLength: 1
-                 type: string
+-                minLength: 1
+-                type: string
                vendor:
-@@ -55,9 +53,8 @@ spec:
+                 description: Vendor is the vendor name of the BMC
                  minLength: 1
                  type: string
              required:
-+            - authSecret
++            - authSecretRef
              - host
 -            - password
 -            - username
@@ -48,28 +57,48 @@ index 3222146..a6683d0 100644
              type: object
            status:
 diff --git a/pbnj/api/v1alpha1/bmc_types.go b/pbnj/api/v1alpha1/bmc_types.go
-index ab86d9f..f89bd53 100644
+index ab86d9f..471105c 100644
 --- a/pbnj/api/v1alpha1/bmc_types.go
 +++ b/pbnj/api/v1alpha1/bmc_types.go
-@@ -18,13 +18,10 @@ type BMCSpec struct {
+@@ -1,6 +1,7 @@
+ package v1alpha1
+ 
+ import (
++	corev1 "k8s.io/api/core/v1"
+ 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+ )
+ 
+@@ -18,13 +19,9 @@ type BMCSpec struct {
  	// +kubebuilder:validation:MinLength=1
  	Host string `json:"host"`
  
 -	// Username is the username to authenticate with the BMC
-+	// AuthSecret is the Secret that contains authentication information of the BMC.
-+	// The Secret must contain username and password keys
- 	// +kubebuilder:validation:MinLength=1
+-	// +kubebuilder:validation:MinLength=1
 -	Username string `json:"username"`
 -
 -	// Password is the password to authenticate with the BMC
 -	// +kubebuilder:validation:MinLength=1
 -	Password string `json:"password"`
-+	AuthSecret string `json:"authSecret"`
++	// AuthSecretRef is the SecretReference that contains authentication information of the BMC.
++	// The Secret must contain username and password keys.
++	AuthSecretRef corev1.SecretReference `json:"authSecretRef"`
  
  	// Vendor is the vendor name of the BMC
  	// +kubebuilder:validation:MinLength=1
+diff --git a/pbnj/api/v1alpha1/zz_generated.deepcopy.go b/pbnj/api/v1alpha1/zz_generated.deepcopy.go
+index 7acc0e5..6c12ba9 100644
+--- a/pbnj/api/v1alpha1/zz_generated.deepcopy.go
++++ b/pbnj/api/v1alpha1/zz_generated.deepcopy.go
+@@ -86,6 +86,7 @@ func (in *BMCList) DeepCopyObject() runtime.Object {
+ // DeepCopyInto is an autogenerated deepcopy function, copying the receiver, writing into out. in must be non-nil.
+ func (in *BMCSpec) DeepCopyInto(out *BMCSpec) {
+ 	*out = *in
++	out.AuthSecretRef = in.AuthSecretRef
+ }
+ 
+ // DeepCopy is an autogenerated deepcopy function, copying the receiver, creating a new BMCSpec.
 diff --git a/pbnj/controllers/controller.go b/pbnj/controllers/controller.go
-index 1991592..0a12a7a 100644
+index 1991592..4946a11 100644
 --- a/pbnj/controllers/controller.go
 +++ b/pbnj/controllers/controller.go
 @@ -6,7 +6,9 @@ import (
@@ -86,7 +115,7 @@ index 1991592..0a12a7a 100644
  func (r *Reconciler) reconcileNormal(ctx context.Context, bmc *pbnjv1alpha1.BMC) (ctrl.Result, error) {
  	logger := ctrl.LoggerFrom(ctx).WithValues("bmc", bmc.Name)
  
-+	username, password, err := r.resolveAuthSecret(ctx, bmc.Spec.AuthSecret)
++	username, password, err := r.resolveAuthSecretRef(ctx, bmc.Spec.AuthSecretRef)
 +	if err != nil {
 +		return ctrl.Result{}, fmt.Errorf("error resolving authentication from Secret: %w", err)
 +	}
@@ -118,16 +147,16 @@ index 1991592..0a12a7a 100644
  	return r.reconcileStatus(ctx, bmc)
  }
  
-+func (r *Reconciler) resolveAuthSecret(ctx context.Context, authSecret string) (string, string, error) {
++func (r *Reconciler) resolveAuthSecretRef(ctx context.Context, secretRef corev1.SecretReference) (string, string, error) { //nolint:lll
 +	secret := &corev1.Secret{}
-+	key := types.NamespacedName{Namespace: "default", Name: authSecret}
++	key := types.NamespacedName{Namespace: secretRef.Namespace, Name: secretRef.Name}
 +
 +	if err := r.Client.Get(ctx, key, secret); err != nil {
 +		if apierrors.IsNotFound(err) {
 +			return "", "", fmt.Errorf("error secret %s not found: %w", key, err)
 +		}
 +
-+		return "", "", fmt.Errorf("failed to retrieve secret %s : %w", authSecret, err)
++		return "", "", fmt.Errorf("failed to retrieve secret %s : %w", secretRef, err)
 +	}
 +
 +	username, ok := secret.Data["username"]

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0004-Modifying-BMC-CRD-to-read-from-Secret.patch
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0004-Modifying-BMC-CRD-to-read-from-Secret.patch
@@ -1,0 +1,151 @@
+From 58f87a0e01f800afecbbfa2f7a1c8675b2f43e8f Mon Sep 17 00:00:00 2001
+From: Aravind Ramalingam <ramaliar@amazon.com>
+Date: Mon, 3 Jan 2022 14:31:18 -0800
+Subject: [PATCH 1/5] Modifying BMC CRD to read from Secret
+
+---
+ config/crd/bases/tinkerbell.org_bmc.yaml | 17 +++++------
+ pbnj/api/v1alpha1/bmc_types.go           |  9 ++----
+ pbnj/controllers/controller.go           | 38 ++++++++++++++++++++++--
+ 3 files changed, 45 insertions(+), 19 deletions(-)
+
+diff --git a/config/crd/bases/tinkerbell.org_bmc.yaml b/config/crd/bases/tinkerbell.org_bmc.yaml
+index 3222146..a6683d0 100644
+--- a/config/crd/bases/tinkerbell.org_bmc.yaml
++++ b/config/crd/bases/tinkerbell.org_bmc.yaml
+@@ -38,16 +38,14 @@ spec:
+           spec:
+             description: BMCSpec defines the desired state of BMC.
+             properties:
+-              host:
+-                description: Host is the host IP address of the BMC
+-                minLength: 1
+-                type: string
+-              password:
+-                description: Password is the password to authenticate with the BMC
++              authSecret:
++                description: AuthSecret is the Secret that contains authentication
++                  information of the BMC. The Secret must contain username and password
++                  keys
+                 minLength: 1
+                 type: string
+-              username:
+-                description: Username is the username to authenticate with the BMC
++              host:
++                description: Host is the host IP address of the BMC
+                 minLength: 1
+                 type: string
+               vendor:
+@@ -55,9 +53,8 @@ spec:
+                 minLength: 1
+                 type: string
+             required:
++            - authSecret
+             - host
+-            - password
+-            - username
+             - vendor
+             type: object
+           status:
+diff --git a/pbnj/api/v1alpha1/bmc_types.go b/pbnj/api/v1alpha1/bmc_types.go
+index ab86d9f..f89bd53 100644
+--- a/pbnj/api/v1alpha1/bmc_types.go
++++ b/pbnj/api/v1alpha1/bmc_types.go
+@@ -18,13 +18,10 @@ type BMCSpec struct {
+ 	// +kubebuilder:validation:MinLength=1
+ 	Host string `json:"host"`
+ 
+-	// Username is the username to authenticate with the BMC
++	// AuthSecret is the Secret that contains authentication information of the BMC.
++	// The Secret must contain username and password keys
+ 	// +kubebuilder:validation:MinLength=1
+-	Username string `json:"username"`
+-
+-	// Password is the password to authenticate with the BMC
+-	// +kubebuilder:validation:MinLength=1
+-	Password string `json:"password"`
++	AuthSecret string `json:"authSecret"`
+ 
+ 	// Vendor is the vendor name of the BMC
+ 	// +kubebuilder:validation:MinLength=1
+diff --git a/pbnj/controllers/controller.go b/pbnj/controllers/controller.go
+index 1991592..0a12a7a 100644
+--- a/pbnj/controllers/controller.go
++++ b/pbnj/controllers/controller.go
+@@ -6,7 +6,9 @@ import (
+ 	"fmt"
+ 
+ 	v1 "github.com/tinkerbell/pbnj/api/v1"
++	corev1 "k8s.io/api/core/v1"
+ 	apierrors "k8s.io/apimachinery/pkg/api/errors"
++	"k8s.io/apimachinery/pkg/types"
+ 	ctrl "sigs.k8s.io/controller-runtime"
+ 	"sigs.k8s.io/controller-runtime/pkg/client"
+ 	"sigs.k8s.io/controller-runtime/pkg/controller"
+@@ -60,6 +62,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
+ func (r *Reconciler) reconcileNormal(ctx context.Context, bmc *pbnjv1alpha1.BMC) (ctrl.Result, error) {
+ 	logger := ctrl.LoggerFrom(ctx).WithValues("bmc", bmc.Name)
+ 
++	username, password, err := r.resolveAuthSecret(ctx, bmc.Spec.AuthSecret)
++	if err != nil {
++		return ctrl.Result{}, fmt.Errorf("error resolving authentication from Secret: %w", err)
++	}
++
+ 	// Power on the machine with bmc.
+ 	powerRequest := &v1.PowerRequest{
+ 		Authn: &v1.Authn{
+@@ -68,8 +75,8 @@ func (r *Reconciler) reconcileNormal(ctx context.Context, bmc *pbnjv1alpha1.BMC)
+ 					Host: &v1.Host{
+ 						Host: bmc.Spec.Host,
+ 					},
+-					Username: bmc.Spec.Username,
+-					Password: bmc.Spec.Password,
++					Username: username,
++					Password: password,
+ 				},
+ 			},
+ 		},
+@@ -79,7 +86,7 @@ func (r *Reconciler) reconcileNormal(ctx context.Context, bmc *pbnjv1alpha1.BMC)
+ 		PowerAction: v1.PowerAction_POWER_ACTION_ON,
+ 	}
+ 
+-	_, err := r.PbnjClient.MachinePower(ctx, powerRequest)
++	_, err = r.PbnjClient.MachinePower(ctx, powerRequest)
+ 	if err != nil {
+ 		logger.Error(err, "Failed to power on machine with bmc")
+ 
+@@ -89,6 +96,31 @@ func (r *Reconciler) reconcileNormal(ctx context.Context, bmc *pbnjv1alpha1.BMC)
+ 	return r.reconcileStatus(ctx, bmc)
+ }
+ 
++func (r *Reconciler) resolveAuthSecret(ctx context.Context, authSecret string) (string, string, error) {
++	secret := &corev1.Secret{}
++	key := types.NamespacedName{Namespace: "default", Name: authSecret}
++
++	if err := r.Client.Get(ctx, key, secret); err != nil {
++		if apierrors.IsNotFound(err) {
++			return "", "", fmt.Errorf("error secret %s not found: %w", key, err)
++		}
++
++		return "", "", fmt.Errorf("failed to retrieve secret %s : %w", authSecret, err)
++	}
++
++	username, ok := secret.Data["username"]
++	if !ok {
++		return "", "", fmt.Errorf("non-existent secret key username") //nolint:goerr113
++	}
++
++	password, ok := secret.Data["password"]
++	if !ok {
++		return "", "", fmt.Errorf("non-existent secret key password") //nolint:goerr113
++	}
++
++	return string(username), string(password), nil
++}
++
+ func (r *Reconciler) reconcileStatus(ctx context.Context, bmc *pbnjv1alpha1.BMC) (ctrl.Result, error) {
+ 	logger := ctrl.LoggerFrom(ctx).WithValues("bmc", bmc.Name)
+ 	patch := client.MergeFrom(bmc.DeepCopy())
+-- 
+2.34.1
+

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0005-Adding-PBNJ-PowerAction-to-BMC-controller.patch
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0005-Adding-PBNJ-PowerAction-to-BMC-controller.patch
@@ -1,4 +1,4 @@
-From 6b27cba82015ce7d9418f9d2c407f7d70f3cc911 Mon Sep 17 00:00:00 2001
+From 0aca7e52bfb89627ac03f588ef05c2c4c0695fb5 Mon Sep 17 00:00:00 2001
 From: Aravind Ramalingam <ramaliar@amazon.com>
 Date: Tue, 4 Jan 2022 20:40:46 -0800
 Subject: [PATCH 2/5] Adding PBNJ PowerAction to BMC controller
@@ -10,10 +10,10 @@ Subject: [PATCH 2/5] Adding PBNJ PowerAction to BMC controller
  3 files changed, 39 insertions(+), 16 deletions(-)
 
 diff --git a/config/crd/bases/tinkerbell.org_bmc.yaml b/config/crd/bases/tinkerbell.org_bmc.yaml
-index a6683d0..0193c71 100644
+index 0219089..50c8e8e 100644
 --- a/config/crd/bases/tinkerbell.org_bmc.yaml
 +++ b/config/crd/bases/tinkerbell.org_bmc.yaml
-@@ -48,6 +48,12 @@ spec:
+@@ -56,6 +56,12 @@ spec:
                  description: Host is the host IP address of the BMC
                  minLength: 1
                  type: string
@@ -26,7 +26,7 @@ index a6683d0..0193c71 100644
                vendor:
                  description: Vendor is the vendor name of the BMC
                  minLength: 1
-@@ -60,7 +66,7 @@ spec:
+@@ -68,7 +74,7 @@ spec:
            status:
              description: BMCStatus defines the observed state of BMC.
              properties:
@@ -36,10 +36,10 @@ index a6683d0..0193c71 100644
                  type: string
              type: object
 diff --git a/pbnj/api/v1alpha1/bmc_types.go b/pbnj/api/v1alpha1/bmc_types.go
-index f89bd53..32124e3 100644
+index 471105c..36a9bd6 100644
 --- a/pbnj/api/v1alpha1/bmc_types.go
 +++ b/pbnj/api/v1alpha1/bmc_types.go
-@@ -7,11 +7,6 @@ import (
+@@ -8,11 +8,6 @@ import (
  // BMCState represents the template state.
  type BMCState string
  
@@ -70,7 +70,7 @@ index f89bd53..32124e3 100644
  
  // +kubebuilder:subresource:status
 diff --git a/pbnj/controllers/controller.go b/pbnj/controllers/controller.go
-index 0a12a7a..6255ee8 100644
+index 4946a11..24d9b77 100644
 --- a/pbnj/controllers/controller.go
 +++ b/pbnj/controllers/controller.go
 @@ -52,7 +52,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
@@ -90,7 +90,7 @@ index 0a12a7a..6255ee8 100644
 +		return r.reconcileStatus(ctx, bmc)
 +	}
 +
- 	username, password, err := r.resolveAuthSecret(ctx, bmc.Spec.AuthSecret)
+ 	username, password, err := r.resolveAuthSecretRef(ctx, bmc.Spec.AuthSecretRef)
  	if err != nil {
  		return ctrl.Result{}, fmt.Errorf("error resolving authentication from Secret: %w", err)
  	}
@@ -136,7 +136,7 @@ index 0a12a7a..6255ee8 100644
 +	return nil
  }
  
- func (r *Reconciler) resolveAuthSecret(ctx context.Context, authSecret string) (string, string, error) {
+ func (r *Reconciler) resolveAuthSecretRef(ctx context.Context, secretRef corev1.SecretReference) (string, string, error) { //nolint:lll
 @@ -125,7 +142,7 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, bmc *pbnjv1alpha1.BMC)
  	logger := ctrl.LoggerFrom(ctx).WithValues("bmc", bmc.Name)
  	patch := client.MergeFrom(bmc.DeepCopy())

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0005-Adding-PBNJ-PowerAction-to-BMC-controller.patch
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0005-Adding-PBNJ-PowerAction-to-BMC-controller.patch
@@ -1,0 +1,151 @@
+From 6b27cba82015ce7d9418f9d2c407f7d70f3cc911 Mon Sep 17 00:00:00 2001
+From: Aravind Ramalingam <ramaliar@amazon.com>
+Date: Tue, 4 Jan 2022 20:40:46 -0800
+Subject: [PATCH 2/5] Adding PBNJ PowerAction to BMC controller
+
+---
+ config/crd/bases/tinkerbell.org_bmc.yaml |  8 +++++-
+ pbnj/api/v1alpha1/bmc_types.go           | 12 ++++----
+ pbnj/controllers/controller.go           | 35 ++++++++++++++++++------
+ 3 files changed, 39 insertions(+), 16 deletions(-)
+
+diff --git a/config/crd/bases/tinkerbell.org_bmc.yaml b/config/crd/bases/tinkerbell.org_bmc.yaml
+index a6683d0..0193c71 100644
+--- a/config/crd/bases/tinkerbell.org_bmc.yaml
++++ b/config/crd/bases/tinkerbell.org_bmc.yaml
+@@ -48,6 +48,12 @@ spec:
+                 description: Host is the host IP address of the BMC
+                 minLength: 1
+                 type: string
++              powerAction:
++                description: PowerAction is the machine power action for PBNJ to run.
++                  The value must be one of the supported machine PowerAction names
++                  for PBNJ.
++                minLength: 1
++                type: string
+               vendor:
+                 description: Vendor is the vendor name of the BMC
+                 minLength: 1
+@@ -60,7 +66,7 @@ spec:
+           status:
+             description: BMCStatus defines the observed state of BMC.
+             properties:
+-              state:
++              powerState:
+                 description: BMCState represents the template state.
+                 type: string
+             type: object
+diff --git a/pbnj/api/v1alpha1/bmc_types.go b/pbnj/api/v1alpha1/bmc_types.go
+index f89bd53..32124e3 100644
+--- a/pbnj/api/v1alpha1/bmc_types.go
++++ b/pbnj/api/v1alpha1/bmc_types.go
+@@ -7,11 +7,6 @@ import (
+ // BMCState represents the template state.
+ type BMCState string
+ 
+-const (
+-	// BMCPowerOn represents a bmc that is in Power On state.
+-	BMCPowerOn = BMCState("PowerOn")
+-)
+-
+ // BMCSpec defines the desired state of BMC.
+ type BMCSpec struct {
+ 	// Host is the host IP address of the BMC
+@@ -26,11 +21,16 @@ type BMCSpec struct {
+ 	// Vendor is the vendor name of the BMC
+ 	// +kubebuilder:validation:MinLength=1
+ 	Vendor string `json:"vendor"`
++
++	// PowerAction is the machine power action for PBNJ to run.
++	// The value must be one of the supported machine PowerAction names for PBNJ.
++	// +kubebuilder:validation:MinLength=1
++	PowerAction string `json:"powerAction,omitempty"`
+ }
+ 
+ // BMCStatus defines the observed state of BMC.
+ type BMCStatus struct {
+-	State BMCState `json:"state,omitempty"`
++	PowerState BMCState `json:"powerState,omitempty"`
+ }
+ 
+ // +kubebuilder:subresource:status
+diff --git a/pbnj/controllers/controller.go b/pbnj/controllers/controller.go
+index 0a12a7a..6255ee8 100644
+--- a/pbnj/controllers/controller.go
++++ b/pbnj/controllers/controller.go
+@@ -52,7 +52,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
+ 		return ctrl.Result{}, fmt.Errorf("failed to get bmc: %w", err)
+ 	}
+ 
+-	if bmc.Status.State == pbnjv1alpha1.BMCPowerOn {
++	if bmc.Status.PowerState == pbnjv1alpha1.BMCState(bmc.Spec.PowerAction) {
+ 		return ctrl.Result{}, nil
+ 	}
+ 
+@@ -62,12 +62,31 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
+ func (r *Reconciler) reconcileNormal(ctx context.Context, bmc *pbnjv1alpha1.BMC) (ctrl.Result, error) {
+ 	logger := ctrl.LoggerFrom(ctx).WithValues("bmc", bmc.Name)
+ 
++	if bmc.Spec.PowerAction == "" {
++		return r.reconcileStatus(ctx, bmc)
++	}
++
+ 	username, password, err := r.resolveAuthSecret(ctx, bmc.Spec.AuthSecret)
+ 	if err != nil {
+ 		return ctrl.Result{}, fmt.Errorf("error resolving authentication from Secret: %w", err)
+ 	}
+ 
+-	// Power on the machine with bmc.
++	err = r.powerAction(ctx, username, password, bmc)
++	if err != nil {
++		logger.Error(err, "Failed to perform power action with bmc", "PowerAction", bmc.Spec.PowerAction)
++
++		return ctrl.Result{}, fmt.Errorf("failed to perform PowerAction: %s", bmc.Spec.PowerAction) //nolint:goerr113
++	}
++
++	return r.reconcileStatus(ctx, bmc)
++}
++
++func (r *Reconciler) powerAction(ctx context.Context, username, password string, bmc *pbnjv1alpha1.BMC) error {
++	powerActionValue, ok := v1.PowerAction_value[bmc.Spec.PowerAction]
++	if !ok {
++		return fmt.Errorf("invalid PowerAction: %s", bmc.Spec.PowerAction) //nolint:goerr113
++	}
++
+ 	powerRequest := &v1.PowerRequest{
+ 		Authn: &v1.Authn{
+ 			Authn: &v1.Authn_DirectAuthn{
+@@ -83,17 +102,15 @@ func (r *Reconciler) reconcileNormal(ctx context.Context, bmc *pbnjv1alpha1.BMC)
+ 		Vendor: &v1.Vendor{
+ 			Name: bmc.Spec.Vendor,
+ 		},
+-		PowerAction: v1.PowerAction_POWER_ACTION_ON,
++		PowerAction: v1.PowerAction(powerActionValue),
+ 	}
+ 
+-	_, err = r.PbnjClient.MachinePower(ctx, powerRequest)
++	_, err := r.PbnjClient.MachinePower(ctx, powerRequest)
+ 	if err != nil {
+-		logger.Error(err, "Failed to power on machine with bmc")
+-
+-		return ctrl.Result{}, fmt.Errorf("error calling MachinePower: %w", err)
++		return fmt.Errorf("error calling PBNJ MachinePower: %w", err)
+ 	}
+ 
+-	return r.reconcileStatus(ctx, bmc)
++	return nil
+ }
+ 
+ func (r *Reconciler) resolveAuthSecret(ctx context.Context, authSecret string) (string, string, error) {
+@@ -125,7 +142,7 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, bmc *pbnjv1alpha1.BMC)
+ 	logger := ctrl.LoggerFrom(ctx).WithValues("bmc", bmc.Name)
+ 	patch := client.MergeFrom(bmc.DeepCopy())
+ 
+-	bmc.Status.State = pbnjv1alpha1.BMCPowerOn
++	bmc.Status.PowerState = pbnjv1alpha1.BMCState(bmc.Spec.PowerAction)
+ 	if err := r.Client.Status().Patch(ctx, bmc, patch); err != nil {
+ 		logger.Error(err, "Failed to patch bmc")
+ 
+-- 
+2.34.1
+

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0006-Adding-PBNJ-BootDevice-to-BMC-CRD-and-client.patch
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0006-Adding-PBNJ-BootDevice-to-BMC-CRD-and-client.patch
@@ -1,4 +1,4 @@
-From 7066de2ae6fd143aecf2173d3bd32d28af3bedea Mon Sep 17 00:00:00 2001
+From db90102bf646bc325d43bdf54c5282521a535a0b Mon Sep 17 00:00:00 2001
 From: Aravind Ramalingam <ramaliar@amazon.com>
 Date: Wed, 5 Jan 2022 01:31:59 -0800
 Subject: [PATCH 3/5] Adding PBNJ BootDevice to BMC CRD and client
@@ -11,13 +11,13 @@ Subject: [PATCH 3/5] Adding PBNJ BootDevice to BMC CRD and client
  4 files changed, 81 insertions(+), 11 deletions(-)
 
 diff --git a/config/crd/bases/tinkerbell.org_bmc.yaml b/config/crd/bases/tinkerbell.org_bmc.yaml
-index 0193c71..46aebf6 100644
+index 50c8e8e..6ec60bc 100644
 --- a/config/crd/bases/tinkerbell.org_bmc.yaml
 +++ b/config/crd/bases/tinkerbell.org_bmc.yaml
-@@ -44,6 +44,11 @@ spec:
-                   keys
-                 minLength: 1
-                 type: string
+@@ -52,6 +52,11 @@ spec:
+                       name must be unique.
+                     type: string
+                 type: object
 +              bootDevice:
 +                description: BootDevice is the machine boot device to set. The value
 +                  must be one of the supported machine BootDevice names by PBNJ.
@@ -26,7 +26,7 @@ index 0193c71..46aebf6 100644
                host:
                  description: Host is the host IP address of the BMC
                  minLength: 1
-@@ -51,7 +56,7 @@ spec:
+@@ -59,7 +64,7 @@ spec:
                powerAction:
                  description: PowerAction is the machine power action for PBNJ to run.
                    The value must be one of the supported machine PowerAction names
@@ -35,7 +35,7 @@ index 0193c71..46aebf6 100644
                  minLength: 1
                  type: string
                vendor:
-@@ -66,6 +71,9 @@ spec:
+@@ -74,6 +79,9 @@ spec:
            status:
              description: BMCStatus defines the observed state of BMC.
              properties:
@@ -46,7 +46,7 @@ index 0193c71..46aebf6 100644
                  description: BMCState represents the template state.
                  type: string
 diff --git a/pbnj/api/v1alpha1/bmc_types.go b/pbnj/api/v1alpha1/bmc_types.go
-index 32124e3..b30ba43 100644
+index 36a9bd6..1e49f65 100644
 --- a/pbnj/api/v1alpha1/bmc_types.go
 +++ b/pbnj/api/v1alpha1/bmc_types.go
 @@ -23,14 +23,20 @@ type BMCSpec struct {
@@ -91,7 +91,7 @@ index 5683a88..21f7d2e 100644
 +	return response, nil
 +}
 diff --git a/pbnj/controllers/controller.go b/pbnj/controllers/controller.go
-index 6255ee8..a14d81b 100644
+index 24d9b77..0221d74 100644
 --- a/pbnj/controllers/controller.go
 +++ b/pbnj/controllers/controller.go
 @@ -18,6 +18,7 @@ import (
@@ -120,7 +120,7 @@ index 6255ee8..a14d81b 100644
 -		return r.reconcileStatus(ctx, bmc)
 -	}
 -
- 	username, password, err := r.resolveAuthSecret(ctx, bmc.Spec.AuthSecret)
+ 	username, password, err := r.resolveAuthSecretRef(ctx, bmc.Spec.AuthSecretRef)
  	if err != nil {
  		return ctrl.Result{}, fmt.Errorf("error resolving authentication from Secret: %w", err)
  	}
@@ -186,9 +186,9 @@ index 6255ee8..a14d81b 100644
 +	return nil
 +}
 +
- func (r *Reconciler) resolveAuthSecret(ctx context.Context, authSecret string) (string, string, error) {
+ func (r *Reconciler) resolveAuthSecretRef(ctx context.Context, secretRef corev1.SecretReference) (string, string, error) { //nolint:lll
  	secret := &corev1.Secret{}
- 	key := types.NamespacedName{Namespace: "default", Name: authSecret}
+ 	key := types.NamespacedName{Namespace: secretRef.Namespace, Name: secretRef.Name}
 @@ -143,6 +186,8 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, bmc *pbnjv1alpha1.BMC)
  	patch := client.MergeFrom(bmc.DeepCopy())
  

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0006-Adding-PBNJ-BootDevice-to-BMC-CRD-and-client.patch
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0006-Adding-PBNJ-BootDevice-to-BMC-CRD-and-client.patch
@@ -1,0 +1,203 @@
+From 7066de2ae6fd143aecf2173d3bd32d28af3bedea Mon Sep 17 00:00:00 2001
+From: Aravind Ramalingam <ramaliar@amazon.com>
+Date: Wed, 5 Jan 2022 01:31:59 -0800
+Subject: [PATCH 3/5] Adding PBNJ BootDevice to BMC CRD and client
+
+---
+ config/crd/bases/tinkerbell.org_bmc.yaml | 10 +++-
+ pbnj/api/v1alpha1/bmc_types.go           |  8 ++-
+ pbnj/client/client.go                    | 11 +++++
+ pbnj/controllers/controller.go           | 63 ++++++++++++++++++++----
+ 4 files changed, 81 insertions(+), 11 deletions(-)
+
+diff --git a/config/crd/bases/tinkerbell.org_bmc.yaml b/config/crd/bases/tinkerbell.org_bmc.yaml
+index 0193c71..46aebf6 100644
+--- a/config/crd/bases/tinkerbell.org_bmc.yaml
++++ b/config/crd/bases/tinkerbell.org_bmc.yaml
+@@ -44,6 +44,11 @@ spec:
+                   keys
+                 minLength: 1
+                 type: string
++              bootDevice:
++                description: BootDevice is the machine boot device to set. The value
++                  must be one of the supported machine BootDevice names by PBNJ.
++                minLength: 1
++                type: string
+               host:
+                 description: Host is the host IP address of the BMC
+                 minLength: 1
+@@ -51,7 +56,7 @@ spec:
+               powerAction:
+                 description: PowerAction is the machine power action for PBNJ to run.
+                   The value must be one of the supported machine PowerAction names
+-                  for PBNJ.
++                  by PBNJ.
+                 minLength: 1
+                 type: string
+               vendor:
+@@ -66,6 +71,9 @@ spec:
+           status:
+             description: BMCStatus defines the observed state of BMC.
+             properties:
++              bootState:
++                description: BMCState represents the template state.
++                type: string
+               powerState:
+                 description: BMCState represents the template state.
+                 type: string
+diff --git a/pbnj/api/v1alpha1/bmc_types.go b/pbnj/api/v1alpha1/bmc_types.go
+index 32124e3..b30ba43 100644
+--- a/pbnj/api/v1alpha1/bmc_types.go
++++ b/pbnj/api/v1alpha1/bmc_types.go
+@@ -23,14 +23,20 @@ type BMCSpec struct {
+ 	Vendor string `json:"vendor"`
+ 
+ 	// PowerAction is the machine power action for PBNJ to run.
+-	// The value must be one of the supported machine PowerAction names for PBNJ.
++	// The value must be one of the supported machine PowerAction names by PBNJ.
+ 	// +kubebuilder:validation:MinLength=1
+ 	PowerAction string `json:"powerAction,omitempty"`
++
++	// BootDevice is the machine boot device to set.
++	// The value must be one of the supported machine BootDevice names by PBNJ.
++	// +kubebuilder:validation:MinLength=1
++	BootDevice string `json:"bootDevice,omitempty"`
+ }
+ 
+ // BMCStatus defines the observed state of BMC.
+ type BMCStatus struct {
+ 	PowerState BMCState `json:"powerState,omitempty"`
++	BootState  BMCState `json:"bootState,omitempty"`
+ }
+ 
+ // +kubebuilder:subresource:status
+diff --git a/pbnj/client/client.go b/pbnj/client/client.go
+index 5683a88..21f7d2e 100644
+--- a/pbnj/client/client.go
++++ b/pbnj/client/client.go
+@@ -50,3 +50,14 @@ func (pc *PbnjClient) MachinePower(ctx context.Context, powerRequest *v1.PowerRe
+ 
+ 	return response, nil
+ }
++
++// MachineBootDev performs a PBNJ machine boot device request.
++func (pc *PbnjClient) MachineBootDev(ctx context.Context, deviceRequest *v1.DeviceRequest) (*v1.StatusResponse, error) {
++	response, err := v1Client.MachineBootDev(ctx, pc.machineClient, pc.taskClient, deviceRequest)
++	if err != nil {
++		return nil, fmt.Errorf("error making pbnj DeviceRequest with boot device %s: %w",
++			deviceRequest.GetBootDevice().String(), err)
++	}
++
++	return response, nil
++}
+diff --git a/pbnj/controllers/controller.go b/pbnj/controllers/controller.go
+index 6255ee8..a14d81b 100644
+--- a/pbnj/controllers/controller.go
++++ b/pbnj/controllers/controller.go
+@@ -18,6 +18,7 @@ import (
+ 
+ type pbnjClient interface {
+ 	MachinePower(ctx context.Context, powerRequest *v1.PowerRequest) (*v1.StatusResponse, error)
++	MachineBootDev(ctx context.Context, deviceRequest *v1.DeviceRequest) (*v1.StatusResponse, error)
+ }
+ 
+ // Reconciler implements the Reconciler interface for managing BMC state.
+@@ -52,7 +53,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
+ 		return ctrl.Result{}, fmt.Errorf("failed to get bmc: %w", err)
+ 	}
+ 
+-	if bmc.Status.PowerState == pbnjv1alpha1.BMCState(bmc.Spec.PowerAction) {
++	if bmc.Status.PowerState == pbnjv1alpha1.BMCState(bmc.Spec.PowerAction) &&
++		bmc.Status.BootState == pbnjv1alpha1.BMCState(bmc.Spec.BootDevice) {
+ 		return ctrl.Result{}, nil
+ 	}
+ 
+@@ -62,20 +64,29 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
+ func (r *Reconciler) reconcileNormal(ctx context.Context, bmc *pbnjv1alpha1.BMC) (ctrl.Result, error) {
+ 	logger := ctrl.LoggerFrom(ctx).WithValues("bmc", bmc.Name)
+ 
+-	if bmc.Spec.PowerAction == "" {
+-		return r.reconcileStatus(ctx, bmc)
+-	}
+-
+ 	username, password, err := r.resolveAuthSecret(ctx, bmc.Spec.AuthSecret)
+ 	if err != nil {
+ 		return ctrl.Result{}, fmt.Errorf("error resolving authentication from Secret: %w", err)
+ 	}
+ 
+-	err = r.powerAction(ctx, username, password, bmc)
+-	if err != nil {
+-		logger.Error(err, "Failed to perform power action with bmc", "PowerAction", bmc.Spec.PowerAction)
++	if bmc.Spec.BootDevice != "" &&
++		bmc.Status.BootState != pbnjv1alpha1.BMCState(bmc.Spec.BootDevice) {
++		err = r.setBootDevice(ctx, username, password, bmc)
++		if err != nil {
++			logger.Error(err, "Failed to set boot device", "BootDevice", bmc.Spec.BootDevice)
+ 
+-		return ctrl.Result{}, fmt.Errorf("failed to perform PowerAction: %s", bmc.Spec.PowerAction) //nolint:goerr113
++			return ctrl.Result{}, fmt.Errorf("failed to set boot device: %s", bmc.Spec.BootDevice) //nolint:goerr113
++		}
++	}
++
++	if bmc.Spec.PowerAction != "" &&
++		bmc.Status.PowerState != pbnjv1alpha1.BMCState(bmc.Spec.PowerAction) {
++		err = r.powerAction(ctx, username, password, bmc)
++		if err != nil {
++			logger.Error(err, "Failed to perform power action with bmc", "PowerAction", bmc.Spec.PowerAction)
++
++			return ctrl.Result{}, fmt.Errorf("failed to perform PowerAction: %s", bmc.Spec.PowerAction) //nolint:goerr113
++		}
+ 	}
+ 
+ 	return r.reconcileStatus(ctx, bmc)
+@@ -113,6 +124,38 @@ func (r *Reconciler) powerAction(ctx context.Context, username, password string,
+ 	return nil
+ }
+ 
++func (r *Reconciler) setBootDevice(ctx context.Context, username, password string, bmc *pbnjv1alpha1.BMC) error {
++	bootDeviceValue, ok := v1.BootDevice_value[bmc.Spec.BootDevice]
++	if !ok {
++		return fmt.Errorf("invalid BootDevice: %s", bmc.Spec.BootDevice) //nolint:goerr113
++	}
++
++	deviceRequest := &v1.DeviceRequest{
++		Authn: &v1.Authn{
++			Authn: &v1.Authn_DirectAuthn{
++				DirectAuthn: &v1.DirectAuthn{
++					Host: &v1.Host{
++						Host: bmc.Spec.Host,
++					},
++					Username: username,
++					Password: password,
++				},
++			},
++		},
++		Vendor: &v1.Vendor{
++			Name: bmc.Spec.Vendor,
++		},
++		BootDevice: v1.BootDevice(bootDeviceValue),
++	}
++
++	_, err := r.PbnjClient.MachineBootDev(ctx, deviceRequest)
++	if err != nil {
++		return fmt.Errorf("error calling PBNJ MachineBootDev: %w", err)
++	}
++
++	return nil
++}
++
+ func (r *Reconciler) resolveAuthSecret(ctx context.Context, authSecret string) (string, string, error) {
+ 	secret := &corev1.Secret{}
+ 	key := types.NamespacedName{Namespace: "default", Name: authSecret}
+@@ -143,6 +186,8 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, bmc *pbnjv1alpha1.BMC)
+ 	patch := client.MergeFrom(bmc.DeepCopy())
+ 
+ 	bmc.Status.PowerState = pbnjv1alpha1.BMCState(bmc.Spec.PowerAction)
++	bmc.Status.BootState = pbnjv1alpha1.BMCState(bmc.Spec.BootDevice)
++
+ 	if err := r.Client.Status().Patch(ctx, bmc, patch); err != nil {
+ 		logger.Error(err, "Failed to patch bmc")
+ 
+-- 
+2.34.1
+

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0007-Adding-BmcRef-to-hardware-and-PowerOn-machine.patch
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0007-Adding-BmcRef-to-hardware-and-PowerOn-machine.patch
@@ -1,4 +1,4 @@
-From 1cf869a526a254156820c55f2fda572f268692d0 Mon Sep 17 00:00:00 2001
+From e4dc8621026e77a130a91f27d1793b441641cfb9 Mon Sep 17 00:00:00 2001
 From: Aravind Ramalingam <ramaliar@amazon.com>
 Date: Wed, 12 Jan 2022 16:11:42 -0800
 Subject: [PATCH 4/5] Adding BmcRef to hardware and PowerOn machine

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0007-Adding-BmcRef-to-hardware-and-PowerOn-machine.patch
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0007-Adding-BmcRef-to-hardware-and-PowerOn-machine.patch
@@ -1,0 +1,121 @@
+From 1cf869a526a254156820c55f2fda572f268692d0 Mon Sep 17 00:00:00 2001
+From: Aravind Ramalingam <ramaliar@amazon.com>
+Date: Wed, 12 Jan 2022 16:11:42 -0800
+Subject: [PATCH 4/5] Adding BmcRef to hardware and PowerOn machine
+
+---
+ .gitignore                                    |  1 +
+ config/crd/bases/tinkerbell.org_hardware.yaml |  4 ++
+ controllers/machine.go                        | 39 +++++++++++++++++++
+ tink/api/v1alpha1/hardware_types.go           |  4 ++
+ 4 files changed, 48 insertions(+)
+
+diff --git a/.gitignore b/.gitignore
+index 6f520c7..0198760 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -19,6 +19,7 @@
+ *.swp
+ *.swo
+ *~
++.DS_Store
+ 
+ tmp/
+ out/
+diff --git a/config/crd/bases/tinkerbell.org_hardware.yaml b/config/crd/bases/tinkerbell.org_hardware.yaml
+index 1b43446..47f5edb 100644
+--- a/config/crd/bases/tinkerbell.org_hardware.yaml
++++ b/config/crd/bases/tinkerbell.org_hardware.yaml
+@@ -38,6 +38,10 @@ spec:
+           spec:
+             description: HardwareSpec defines the desired state of Hardware.
+             properties:
++              bmcRef:
++                description: BmcRef is BMC that corresponds to the Hardware
++                minLength: 1
++                type: string
+               id:
+                 description: ID is the ID of the hardware in Tinkerbell
+                 minLength: 1
+diff --git a/controllers/machine.go b/controllers/machine.go
+index a091c8e..241eb95 100644
+--- a/controllers/machine.go
++++ b/controllers/machine.go
+@@ -35,6 +35,7 @@ import (
+ 
+ 	infrastructurev1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/api/v1beta1"
+ 	"github.com/tinkerbell/cluster-api-provider-tinkerbell/internal/templates"
++	pbnjv1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/pbnj/api/v1alpha1"
+ 	tinkv1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/tink/api/v1alpha1"
+ )
+ 
+@@ -344,6 +345,10 @@ func (mrc *machineReconcileContext) ensureHardware() (*tinkv1.Hardware, error) {
+ 		return nil, fmt.Errorf("ensuring Hardware user data: %w", err)
+ 	}
+ 
++	if err := mrc.ensureHardwarePowerOn(hardware); err != nil {
++		return nil, fmt.Errorf("ensuring Hardware Power On actionL %w", err)
++	}
++
+ 	return hardware, mrc.setStatus(hardware)
+ }
+ 
+@@ -367,6 +372,40 @@ func (mrc *machineReconcileContext) hardwareForMachine() (*tinkv1.Hardware, erro
+ 	return nextAvailableHardware(mrc.ctx, mrc.client, nil)
+ }
+ 
++func (mrc *machineReconcileContext) ensureHardwarePowerOn(hardware *tinkv1.Hardware) error {
++	if hardware.Spec.BmcRef == "" {
++		mrc.log.Info("Skipping PowerOn for hardware", "BMC Ref", hardware.Spec.BmcRef, "Hardware name", hardware.Name)
++
++		return nil
++	}
++	// Fetch the bmc.
++	bmc := &pbnjv1.BMC{}
++	namespacedName := types.NamespacedName{
++		Name: hardware.Spec.BmcRef,
++	}
++
++	if err := mrc.client.Get(mrc.ctx, namespacedName, bmc); err != nil {
++		if apierrors.IsNotFound(err) {
++			return fmt.Errorf("BMC not found: %w", err)
++		}
++
++		return fmt.Errorf("failed to get bmc: %w", err)
++	}
++
++	patchHelper, err := patch.NewHelper(bmc, mrc.client)
++	if err != nil {
++		return fmt.Errorf("initializing patch helper for bmc: %w", err)
++	}
++
++	bmc.Spec.PowerAction = "POWER_ACTION_ON"
++
++	if err := patchHelper.Patch(mrc.ctx, bmc); err != nil {
++		return fmt.Errorf("patching BMC object: %w", err)
++	}
++
++	return nil
++}
++
+ func (mrc *machineReconcileContext) workflowExists() (bool, error) {
+ 	namespacedName := types.NamespacedName{
+ 		Name: mrc.tinkerbellMachine.Name,
+diff --git a/tink/api/v1alpha1/hardware_types.go b/tink/api/v1alpha1/hardware_types.go
+index e4e010d..e9dbf29 100644
+--- a/tink/api/v1alpha1/hardware_types.go
++++ b/tink/api/v1alpha1/hardware_types.go
+@@ -41,6 +41,10 @@ type HardwareSpec struct {
+ 	// metadata
+ 	//+optional
+ 	UserData *string `json:"userData,omitempty"`
++
++	// BmcRef is BMC that corresponds to the Hardware
++	// +kubebuilder:validation:MinLength=1
++	BmcRef string `json:"bmcRef,omitempty"`
+ }
+ 
+ // HardwareStatus defines the observed state of Hardware.
+-- 
+2.34.1
+

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0008-Deprovision-hardware-after-hardware-release.patch
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0008-Deprovision-hardware-after-hardware-release.patch
@@ -1,4 +1,4 @@
-From bebb6e167670d7c7ff23cbb4b3fc52a7cea3c582 Mon Sep 17 00:00:00 2001
+From 1a37bb617e518cb8bfa315f0a854050193c2a6ad Mon Sep 17 00:00:00 2001
 From: Aravind Ramalingam <ramaliar@amazon.com>
 Date: Wed, 12 Jan 2022 18:57:51 -0800
 Subject: [PATCH 5/5] Deprovision hardware after hardware release
@@ -9,7 +9,7 @@ Subject: [PATCH 5/5] Deprovision hardware after hardware release
  2 files changed, 39 insertions(+)
 
 diff --git a/controllers/base.go b/controllers/base.go
-index bfb28a2..f74961a 100644
+index bfb28a2..9b5e6a7 100644
 --- a/controllers/base.go
 +++ b/controllers/base.go
 @@ -32,6 +32,7 @@ import (
@@ -54,7 +54,7 @@ index bfb28a2..f74961a 100644
 +	}
 +
 +	bmc.Spec.BootDevice = "BOOT_DEVICE_PXE"
-+	bmc.Spec.PowerAction = "POWER_ACTION_RESET"
++	bmc.Spec.PowerAction = "POWER_ACTION_HARDOFF"
 +
 +	if err := patchHelper.Patch(bmrc.ctx, bmc); err != nil {
 +		return fmt.Errorf("patching BMC object: %w", err)
@@ -64,7 +64,7 @@ index bfb28a2..f74961a 100644
  }
  
 diff --git a/pbnj/controllers/controller.go b/pbnj/controllers/controller.go
-index a14d81b..139bbbd 100644
+index 0221d74..591b55f 100644
 --- a/pbnj/controllers/controller.go
 +++ b/pbnj/controllers/controller.go
 @@ -146,6 +146,8 @@ func (r *Reconciler) setBootDevice(ctx context.Context, username, password strin

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0008-Deprovision-hardware-after-hardware-release.patch
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0008-Deprovision-hardware-after-hardware-release.patch
@@ -1,0 +1,81 @@
+From bebb6e167670d7c7ff23cbb4b3fc52a7cea3c582 Mon Sep 17 00:00:00 2001
+From: Aravind Ramalingam <ramaliar@amazon.com>
+Date: Wed, 12 Jan 2022 18:57:51 -0800
+Subject: [PATCH 5/5] Deprovision hardware after hardware release
+
+---
+ controllers/base.go            | 37 ++++++++++++++++++++++++++++++++++
+ pbnj/controllers/controller.go |  2 ++
+ 2 files changed, 39 insertions(+)
+
+diff --git a/controllers/base.go b/controllers/base.go
+index bfb28a2..f74961a 100644
+--- a/controllers/base.go
++++ b/controllers/base.go
+@@ -32,6 +32,7 @@ import (
+ 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+ 
+ 	infrastructurev1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/api/v1beta1"
++	pbnjv1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/pbnj/api/v1alpha1"
+ 	tinkv1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/tink/api/v1alpha1"
+ )
+ 
+@@ -161,6 +162,42 @@ func (bmrc *baseMachineReconcileContext) releaseHardware() error {
+ 		return fmt.Errorf("patching Hardware object: %w", err)
+ 	}
+ 
++	return bmrc.deprovisionHardware(hardware)
++}
++
++func (bmrc *baseMachineReconcileContext) deprovisionHardware(hardware *tinkv1.Hardware) error {
++	if hardware.Spec.BmcRef == "" {
++		bmrc.log.Info("Skipping deprovision for hardware", "BMC Ref", hardware.Spec.BmcRef, "Hardware name", hardware.Name)
++
++		return nil
++	}
++
++	// Fetch the bmc.
++	bmc := &pbnjv1.BMC{}
++	namespacedName := types.NamespacedName{
++		Name: hardware.Spec.BmcRef,
++	}
++
++	if err := bmrc.client.Get(bmrc.ctx, namespacedName, bmc); err != nil {
++		if apierrors.IsNotFound(err) {
++			return fmt.Errorf("BMC not found: %w", err)
++		}
++
++		return fmt.Errorf("failed to get bmc: %w", err)
++	}
++
++	patchHelper, err := patch.NewHelper(bmc, bmrc.client)
++	if err != nil {
++		return fmt.Errorf("initializing patch helper for bmc: %w", err)
++	}
++
++	bmc.Spec.BootDevice = "BOOT_DEVICE_PXE"
++	bmc.Spec.PowerAction = "POWER_ACTION_RESET"
++
++	if err := patchHelper.Patch(bmrc.ctx, bmc); err != nil {
++		return fmt.Errorf("patching BMC object: %w", err)
++	}
++
+ 	return nil
+ }
+ 
+diff --git a/pbnj/controllers/controller.go b/pbnj/controllers/controller.go
+index a14d81b..139bbbd 100644
+--- a/pbnj/controllers/controller.go
++++ b/pbnj/controllers/controller.go
+@@ -146,6 +146,8 @@ func (r *Reconciler) setBootDevice(ctx context.Context, username, password strin
+ 			Name: bmc.Spec.Vendor,
+ 		},
+ 		BootDevice: v1.BootDevice(bootDeviceValue),
++		Persistent: false,
++		EfiBoot:    true,
+ 	}
+ 
+ 	_, err := r.PbnjClient.MachineBootDev(ctx, deviceRequest)
+-- 
+2.34.1
+


### PR DESCRIPTION
*Description of changes:*
The patches involve changes to CAPT for enabling Hardware-BMC correspondence. 

- When a hardware is made part of the cluster, the `bmcRef` object is patched to perform powerOn.
- When cluster is deleted and hardware is made available . `bmcRef` object is patched to perform Power Reset and setting PXE boot.
- The BMC credentials are now referenced from a k8s secret.

The commits are the top 5 commits on my fork
[pokearu/cluster-api-provider-tinkerbell](https://github.com/pokearu/cluster-api-provider-tinkerbell/commits/capt-pbnj-integration
)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
