### PR TITLE
changed tink-cli binary name to tink

### DIFF
--- a/projects/tinkerbell/tink/CHECKSUMS
+++ b/projects/tinkerbell/tink/CHECKSUMS
@@ -1,6 +1,6 @@
-4c59f359e33fb8ef83e15178dda529996e1d96d999ee54fef3fba029250c4c03  _output/bin/tink/linux-amd64/tink-cli
+4c59f359e33fb8ef83e15178dda529996e1d96d999ee54fef3fba029250c4c03  _output/bin/tink/linux-amd64/tink
 08344b1e36c4e1ddcbafa4ec24f7221da544f375535b3b1f1472f97c2a73fd99  _output/bin/tink/linux-amd64/tink-server
 c6cb49cf317691697b8d09d73e866633b566f56e0e8f8286505b224e82274c39  _output/bin/tink/linux-amd64/tink-worker
-e99289098cb8ab24c02475c2c7b3f7ecc6cecda4c7898af26b442948f302560f  _output/bin/tink/linux-arm64/tink-cli
+e99289098cb8ab24c02475c2c7b3f7ecc6cecda4c7898af26b442948f302560f  _output/bin/tink/linux-arm64/tink
 4db1b5f8e7de2b445eb66ba2d8cb737c8c478ac81e245a13eddebc3dfd209f3f  _output/bin/tink/linux-arm64/tink-server
 e6d672bd5a6e6c43b56276020a28e97629ce7620fda069c21d15833b3f859831  _output/bin/tink/linux-arm64/tink-worker

--- a/projects/tinkerbell/tink/Help.mk
+++ b/projects/tinkerbell/tink/Help.mk
@@ -12,11 +12,11 @@ checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
 patch-repo: ## Patch upstream repo with patches in patches directory
 
 ##@ Binary Targets
-binaries: ## Build all binaries: `tink-cli tink-server tink-worker` for `linux/amd64 linux/arm64`
-_output/bin/tink/linux-amd64/tink-cli: ## Build `_output/bin/tink/linux-amd64/tink-cli`
+binaries: ## Build all binaries: `tink tink-server tink-worker` for `linux/amd64 linux/arm64`
+_output/bin/tink/linux-amd64/tink: ## Build `_output/bin/tink/linux-amd64/tink`
 _output/bin/tink/linux-amd64/tink-server: ## Build `_output/bin/tink/linux-amd64/tink-server`
 _output/bin/tink/linux-amd64/tink-worker: ## Build `_output/bin/tink/linux-amd64/tink-worker`
-_output/bin/tink/linux-arm64/tink-cli: ## Build `_output/bin/tink/linux-arm64/tink-cli`
+_output/bin/tink/linux-arm64/tink: ## Build `_output/bin/tink/linux-arm64/tink`
 _output/bin/tink/linux-arm64/tink-server: ## Build `_output/bin/tink/linux-arm64/tink-server`
 _output/bin/tink/linux-arm64/tink-worker: ## Build `_output/bin/tink/linux-arm64/tink-worker`
 
@@ -38,6 +38,11 @@ _output/dependencies/linux-arm64/eksa/cloudflare/cfssl: ## Fetch `_output/depend
 checksums: ## Update checksums file based on currently built binaries.
 validate-checksums: # Validate checksums of currently built binaries against checksums file.
 
+##@ Artifact Targets
+tarballs: ## Create tarballs by calling build/lib/simple_create_tarballs.sh unless SIMPLE_CREATE_TARBALLS=false, then tarballs must be defined in project Makefile
+s3-artifacts: # Prepare ARTIFACTS_PATH folder structure with tarballs/manifests/other items to be uploaded to s3
+upload-artifacts: # Upload tarballs and other artifacts from ARTIFACTS_PATH to S3
+
 ##@ License Targets
 gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
 attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
@@ -52,6 +57,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums local-images attribution  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/tinkerbell/tink/Makefile
+++ b/projects/tinkerbell/tink/Makefile
@@ -14,7 +14,7 @@ TINK_WORKER_IMAGE_COMPONENT=tinkerbell/tink/tink-worker
 
 IMAGE_NAMES=tink-cli tink-server tink-worker
 
-BINARY_TARGET_FILES=tink-cli tink-server tink-worker
+BINARY_TARGET_FILES=tink tink-server tink-worker
 SOURCE_PATTERNS=./cmd/tink-cli ./cmd/tink-server ./cmd/tink-worker
 
 VERSION?=$(shell git -C $(REPO) rev-parse --short HEAD)

--- a/projects/tinkerbell/tink/docker/linux/tink-cli/Dockerfile
+++ b/projects/tinkerbell/tink/docker/linux/tink-cli/Dockerfile
@@ -4,7 +4,7 @@ FROM $BASE_IMAGE
 ARG TARGETARCH
 ARG TARGETOS
 
-COPY _output/bin/tink/$TARGETOS-$TARGETARCH/tink-cli /usr/bin/tink
+COPY _output/bin/tink/$TARGETOS-$TARGETARCH/tink /usr/bin/tink
 COPY _output/LICENSES /LICENSES
 COPY ATTRIBUTION.txt /ATTRIBUTION.txt
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changed tink-cli binary name to tink

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
