### PR TITLE
Remove command to set unsupported namespace flag in docker provider

### DIFF
--- a/projects/kubernetes-sigs/cluster-api/build/create_manifests.sh
+++ b/projects/kubernetes-sigs/cluster-api/build/create_manifests.sh
@@ -61,7 +61,6 @@ make release-manifests
 make -C test/infrastructure/docker set-manifest-image \
 MANIFEST_IMG=$CAPI_REGISTRY_PREFIX/capd-manager MANIFEST_TAG=$IMAGE_TAG
 make -C test/infrastructure/docker set-manifest-pull-policy PULL_POLICY=IfNotPresent
-yq eval -i -P ".spec.template.spec.containers[0].args += [\"--namespace=eksa-system\"]" test/infrastructure/docker/config/manager/manager.yaml
 PATH="$(pwd)/hack/tools/bin:$PATH" make -C test/infrastructure/docker release-manifests
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
capd controller doesn't support namespace arg. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
