### PR TITLE
Ensure EC2 keys get created with unique name to avoid collisions

### DIFF
--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -5,7 +5,6 @@ REPO=image-builder
 REPO_OWNER=kubernetes-sigs
 
 IMAGE_BUILDER_DIR=$(REPO)/images/capi
-IMAGE_FORMAT?=ova
 RAW_IMAGE_BUILD_AMI?=ami-0bd99362b6ccd24ea
 RAW_IMAGE_BUILD_INSTANCE_TYPE?=t1.micro
 RAW_IMAGE_BUILD_KEY_NAME?=raw-image-build
@@ -57,18 +56,17 @@ BUILD_AMI_TARGETS=build-ami-ubuntu-2004
 BUILD_OVA_TARGETS=setup-packer-configs-ova release-ova-bottlerocket $(FAKE_UBUNTU_OVA_PATH) $(FINAL_UBUNTU_OVA_PATH) $(FINAL_BOTTLEROCKET_OVA_PATH) upload-artifacts-ova
 BUILD_RAW_TARGETS=release-raw-ubuntu-2004 $(FAKE_UBUNTU_RAW_PATH) $(FINAL_UBUNTU_RAW_IMAGE_PATH) upload-artifacts-raw
 BUILD_TARGETS=$(BUILD_RAW_TARGETS) $(BUILD_AMI_TARGETS) $(BUILD_OVA_TARGETS)
-RELEASE_TARGETS=release-ova-ubuntu-2004 release-ova-bottlerocket upload-artifacts-ova
-S3_TARGET_PREREQUISITES=$(FINAL_UBUNTU_OVA_PATH) $(FINAL_BOTTLEROCKET_OVA_PATH)
-ifeq ($(IMAGE_FORMAT),raw)
-	RELEASE_TARGETS=release-raw-ubuntu-2004 upload-artifacts-raw
+ifeq ($(IMAGE_FORMAT),ova)
+	S3_TARGET_PREREQUISITES=$(FINAL_UBUNTU_OVA_PATH) $(FINAL_BOTTLEROCKET_OVA_PATH)
+	RELEASE_TARGETS=release-ova-ubuntu-2004 release-ova-bottlerocket upload-artifacts-ova
+else ifeq ($(IMAGE_FORMAT),raw)
 	S3_TARGET_PREREQUISITES=$(FINAL_UBUNTU_RAW_IMAGE_PATH)
+	RELEASE_TARGETS=release-raw-ubuntu-2004 upload-artifacts-raw
 endif
 
 include $(BASE_DIRECTORY)/Common.mk
 
 export PATH:=$(CARGO_HOME)/bin:$(MAKE_ROOT)/$(IMAGE_BUILDER_DIR)/.local/bin:$(PATH)
-
-s3-artifacts-%: $(S3_TARGET_PREREQUISITES)
 
 # Since we do not build the ova in presubmit but want to validate upload-artifacts behavior
 $(FAKE_UBUNTU_OVA_PATH):
@@ -175,7 +173,7 @@ check-env-validation:
 
 .PHONY: s3-artifacts-%
 s3-artifacts-%: ARTIFACTS_PATH_IMAGE_FORMAT=$(ARTIFACTS_PATH)/$*
-s3-artifacts-%:
+s3-artifacts-%: $(S3_TARGET_PREREQUISITES)
 	$(MAKE) -C $(MAKE_ROOT) s3-artifacts ARTIFACTS_PATH=$(ARTIFACTS_PATH_IMAGE_FORMAT) IMAGE_FORMAT=$*
 
 .PHONY: upload-artifacts-%

--- a/projects/kubernetes-sigs/image-builder/build/build_raw_image.sh
+++ b/projects/kubernetes-sigs/image-builder/build/build_raw_image.sh
@@ -27,11 +27,19 @@ AMI_ID="${5?Specify fifth argument - AMI ID to create instance}"
 INSTANCE_TYPE="${6?Specify sixth argument - Instance type to create}"
 KEY_NAME="${7?Specify seventh argument - Key name to associate with instance}"
 
+CODEBUILD_CI="${CODEBUILD_CI:-false}"
+CI="${CI:-false}"
+
+if [ "$CODEBUILD_CI" = "true" ]; then
+    KEY_NAME="$KEY_NAME-$CODEBUILD_BUILD_ID"
+elif [ "$CI" = "true" ]; then
+    KEY_NAME="$KEY_NAME-$PROW_JOB_ID"
+fi
+
 REPO_NAME=$(basename $REPO_ROOT)
 KEY_LOCATION=$REPO_ROOT/$PROJECT_PATH/$KEY_NAME.pem
 IMAGE_BUILDER_MAKE_ROOT=$PROJECT_PATH/$IMAGE_BUILDER_DIR
 SSH_OPTS="-i $KEY_LOCATION -o StrictHostKeyChecking=no -o ConnectTimeout=120"
-CODEBUILD_CI="${CODEBUILD_CI:-false}"
 
 terminate_instance() {
     aws ec2 terminate-instances --instance-ids $1
@@ -53,18 +61,24 @@ if ! aws ec2 wait key-pair-exists --key-names=$KEY_NAME 2>/dev/null ; then
 fi
 chmod 600 $KEY_LOCATION
 
-# Create a single EC2 instance with provided instance type and AMI
-# Query the instance ID for use in future commands
-# Wait in loop until instance is running
 RUN_INSTANCE_EXTRA_ARGS=""
 if [ "$CODEBUILD_CI" = "true" ]; then
+    # Select a random subnet from Codebuild project's private subnet list
     SUBNET_ID_LIST=$RAW_IMAGE_BUILD_SUBNET_ID
     SUBNET_COUNT=$(echo $SUBNET_ID_LIST | awk -F\, '{print NF}')
     INDEX=$(($RANDOM % $SUBNET_COUNT))
     SUBNET_ID=$(cut -d',' -f${INDEX} <<< $SUBNET_ID_LIST)
+
+    # Define extra args to run the instance in the same subnet and use
+    # the same security group as Codebuild
     RUN_INSTANCE_EXTRA_ARGS="--subnet-id $SUBNET_ID --security-group-ids $RAW_IMAGE_BUILD_SECURITY_GROUP --associate-public-ip-address"
 fi
+
+# Create a single EC2 instance with provided instance type and AMI
+# Query the instance ID for use in future commands
 INSTANCE_ID=$(aws ec2 run-instances --count 1 --image-id=$AMI_ID --instance-type $INSTANCE_TYPE --key-name $KEY_NAME $RUN_INSTANCE_EXTRA_ARGS --query "Instances[0].InstanceId" --output text)
+
+# Wait in loop until instance is running
 aws ec2 wait instance-running --instance-ids $INSTANCE_ID
 
 # Get the public DNS of the instance to use as SSH hostname
@@ -73,6 +87,8 @@ REMOTE_HOST=ec2-user@$PUBLIC_DNS_NAME
 
 MAX_RETRIES=15
 
+# rsync might sometimes fail with flaky connection issues, so
+# implementing retry logic will make it more robust to flakes
 for i in $(seq 1 $MAX_RETRIES); do
     echo "Attempt $(($i))"
 
@@ -95,4 +111,5 @@ fi
 ssh $SSH_OPTS $REMOTE_HOST "sudo usermod -a -G kvm ec2-user; sudo chmod 666 /dev/kvm; sudo chown root:kvm /dev/kvm; PACKER_VAR_FILES='$PACKER_VAR_FILES' PACKER_FLAGS=-force PACKER_LOG=1 make build-raw-ubuntu-2004 -C /home/ec2-user/$REPO_NAME/$IMAGE_BUILDER_MAKE_ROOT"
 
 # Copy built raw image from the instance back into the CI build environment
+mkdir -p $REPO_ROOT/$IMAGE_BUILDER_MAKE_ROOT/output
 scp $SSH_OPTS $REMOTE_HOST:/home/ec2-user/$REPO_NAME/$IMAGE_BUILDER_MAKE_ROOT/output/*.gz $REPO_ROOT/$IMAGE_BUILDER_MAKE_ROOT/output/


### PR DESCRIPTION
Ensures unique EC2 keypair names during build jobs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
