### PR TITLE
Put packer log in expected artifacts path

### DIFF
--- a/build/lib/validate_artifacts.sh
+++ b/build/lib/validate_artifacts.sh
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -x
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -77,13 +77,14 @@ $(FAKE_UBUNTU_OVA_PATH):
 $(FAKE_UBUNTU_RAW_PATH):
 	@mkdir -p $(@D)
 	touch $@
-	touch $(ARTIFACTS_PATH)/raw/packer.log
+	touch $(@D)/packer.log
 
 $(FINAL_UBUNTU_OVA_PATH):
 	mv $(IMAGE_BUILDER_DIR)/output/*.ova $@
 
 $(FINAL_UBUNTU_RAW_IMAGE_PATH):
 	mv $(IMAGE_BUILDER_DIR)/output/*.gz $@
+	mv $(IMAGE_BUILDER_DIR)/output/packer.log $(@D)/packer.log
 
 $(FINAL_BOTTLEROCKET_OVA_PATH): FULL_OUTPUT_DIR=$(MAKE_ROOT)/$(OUTPUT_DIR)/ova
 $(FINAL_BOTTLEROCKET_OVA_PATH):
@@ -147,7 +148,7 @@ release-ova-ubuntu-2004: MAKEFLAGS=
 release-ova-ubuntu-2004: FULL_OUTPUT_DIR=$(MAKE_ROOT)/$(OUTPUT_DIR)/ova
 release-ova-ubuntu-2004: PACKER_TYPE_VAR_FILES=$(PACKER_OVA_VAR_FILES)
 release-ova-ubuntu-2004: deps-ova setup-vsphere setup-packer-configs-ova
-	PACKER_FLAGS="-force" PACKER_LOG=1 PACKER_LOG_PATH=$(ARTIFACTS_PATH)/packer.log PACKER_VAR_FILES="$(PACKER_VAR_FILES)" \
+	PACKER_FLAGS="-force" PACKER_LOG=1 PACKER_LOG_PATH=$(ARTIFACTS_PATH)/ova/packer.log PACKER_VAR_FILES="$(PACKER_VAR_FILES)" \
 		OVF_CUSTOM_PROPERTIES="$(FULL_OUTPUT_DIR)/config/ovf_custom_properties.json" \
 		$(MAKE) -C $(IMAGE_BUILDER_DIR) build-node-ova-vsphere-ubuntu-2004
 

--- a/projects/kubernetes-sigs/image-builder/build/build_raw_image.sh
+++ b/projects/kubernetes-sigs/image-builder/build/build_raw_image.sh
@@ -108,8 +108,9 @@ fi
 
 # Run permissions setup for KVM builds on instance
 # Run make command to build raw image
-ssh $SSH_OPTS $REMOTE_HOST "sudo usermod -a -G kvm ec2-user; sudo chmod 666 /dev/kvm; sudo chown root:kvm /dev/kvm; PACKER_VAR_FILES='$PACKER_VAR_FILES' PACKER_FLAGS=-force PACKER_LOG=1 make build-raw-ubuntu-2004 -C /home/ec2-user/$REPO_NAME/$IMAGE_BUILDER_MAKE_ROOT"
+ssh $SSH_OPTS $REMOTE_HOST "sudo usermod -a -G kvm ec2-user; sudo chmod 666 /dev/kvm; sudo chown root:kvm /dev/kvm; PACKER_VAR_FILES='$PACKER_VAR_FILES' PACKER_FLAGS=-force PACKER_LOG=1 PACKER_LOG_PATH=/home/ec2-user/$REPO_NAME/$IMAGE_BUILDER_MAKE_ROOT/output/packer.log make build-raw-ubuntu-2004 -C /home/ec2-user/$REPO_NAME/$IMAGE_BUILDER_MAKE_ROOT"
 
 # Copy built raw image from the instance back into the CI build environment
 mkdir -p $REPO_ROOT/$IMAGE_BUILDER_MAKE_ROOT/output
 scp $SSH_OPTS $REMOTE_HOST:/home/ec2-user/$REPO_NAME/$IMAGE_BUILDER_MAKE_ROOT/output/*.gz $REPO_ROOT/$IMAGE_BUILDER_MAKE_ROOT/output/
+scp $SSH_OPTS $REMOTE_HOST:/home/ec2-user/$REPO_NAME/$IMAGE_BUILDER_MAKE_ROOT/output/packer.log $REPO_ROOT/$IMAGE_BUILDER_MAKE_ROOT/output/


### PR DESCRIPTION
Putting packer log under ova folder.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
