### PR TITLE
Adding Image repo var to buildspec to push helm to gallery on builds.

### DIFF
--- a/projects/jetstack/cert-manager/buildspec.yml
+++ b/projects/jetstack/cert-manager/buildspec.yml
@@ -1,5 +1,9 @@
 version: 0.2
 
+env:
+  variables:
+    IMAGE_REPO: public.ecr.aws/l0g8r8j6
+    
 phases:
   pre_build:
     commands:

--- a/projects/redis/redis/buildspec.yml
+++ b/projects/redis/redis/buildspec.yml
@@ -1,5 +1,9 @@
 version: 0.2
 
+env:
+  variables:
+    IMAGE_REPO: public.ecr.aws/l0g8r8j6
+    
 phases:
   pre_build:
     commands:


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

*Issue #, if available:*

*Description of changes:*

This will enable the shell script `build/lib/helm_push.sh` to push the built helm charts to gallery, giving us a central location for testing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
