### PR TITLE
Make subnet array one-indexed

### DIFF
--- a/projects/kubernetes-sigs/image-builder/build/build_raw_image.sh
+++ b/projects/kubernetes-sigs/image-builder/build/build_raw_image.sh
@@ -68,7 +68,7 @@ if [ "$CODEBUILD_CI" = "true" ]; then
     # Select a random subnet from Codebuild project's private subnet list
     SUBNET_ID_LIST=$RAW_IMAGE_BUILD_SUBNET_ID
     SUBNET_COUNT=$(echo $SUBNET_ID_LIST | awk -F\, '{print NF}')
-    INDEX=$(($RANDOM % $SUBNET_COUNT))
+    INDEX=$((($RANDOM % $SUBNET_COUNT) + 1))
     SUBNET_ID=$(cut -d',' -f${INDEX} <<< $SUBNET_ID_LIST)
 
     # Define extra args to run the instance in the same subnet and use


### PR DESCRIPTION
This prevents an index value of `0` from being passed to `cut`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
