### PR TITLE
Enabling cmk build for cli-tools

### DIFF
--- a/projects/aws/eks-anywhere-build-tooling/Makefile
+++ b/projects/aws/eks-anywhere-build-tooling/Makefile
@@ -16,7 +16,8 @@ BUILD_TARGETS=local-images
 RELEASE_TARGETS=images
 
 FETCH_BINARIES_TARGETS=eksa/fluxcd/flux2 eksa/kubernetes-sigs/cluster-api eksa/kubernetes-sigs/cluster-api-provider-aws \
-	eksa/kubernetes-sigs/kind eksa/replicatedhq/troubleshoot eksa/vmware/govmomi eksd/kubernetes/client eksa/helm/helm eksa/tinkerbell/tink
+	eksa/kubernetes-sigs/kind eksa/replicatedhq/troubleshoot eksa/vmware/govmomi eksd/kubernetes/client eksa/helm/helm eksa/tinkerbell/tink \
+	eksa/apache/cloudstack-cloudmonkey
 
 ORGANIZE_BINARIES_TARGETS=$(addsuffix /eks-a-tools,$(addprefix $(BINARY_DEPS_DIR)/linux-,amd64 arm64))
 

--- a/projects/aws/eks-anywhere-build-tooling/build/organize_binaries.sh
+++ b/projects/aws/eks-anywhere-build-tooling/build/organize_binaries.sh
@@ -39,7 +39,8 @@ declare -A project_bin_licenses=(["eksa/fluxcd/flux2"]="flux FLUX2"
                                  ["eksa/replicatedhq/troubleshoot"]="support-bundle TROUBLESHOOT"
                                  ["eksa/vmware/govmomi"]="govc GOVMOMI"
                                  ['eksa/helm/helm']="helm HELM"
-                                 ['eksa/tinkerbell/tink']="tink TINK")
+                                 ['eksa/tinkerbell/tink']="tink TINK"
+                                 ['eksa/apache/cloudstack-cloudmonkey"]="cmk CLOUDMONKEY"))
 
 for project in "${!project_bin_licenses[@]}"
 do

--- a/projects/aws/eks-anywhere-build-tooling/build/organize_binaries.sh
+++ b/projects/aws/eks-anywhere-build-tooling/build/organize_binaries.sh
@@ -40,7 +40,7 @@ declare -A project_bin_licenses=(["eksa/fluxcd/flux2"]="flux FLUX2"
                                  ["eksa/vmware/govmomi"]="govc GOVMOMI"
                                  ['eksa/helm/helm']="helm HELM"
                                  ['eksa/tinkerbell/tink']="tink TINK"
-                                 ['eksa/apache/cloudstack-cloudmonkey"]="cmk CLOUDMONKEY"))
+                                 ['eksa/apache/cloudstack-cloudmonkey']="cmk CLOUDMONKEY")
 
 for project in "${!project_bin_licenses[@]}"
 do


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The previous PR (https://github.com/aws/eks-anywhere-build-tooling/pull/370) added the cloudmonkey project to be built in eks-a infrastructure. This PR enables the CLI to be available in the cli-tools Docker image.

`make generate` succeeded

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
