### PR TITLE
Clone ipmitool repo outside docker build stage

### DIFF
--- a/projects/tinkerbell/pbnj/Makefile
+++ b/projects/tinkerbell/pbnj/Makefile
@@ -9,6 +9,7 @@ GOLANG_VERSION?="1.16"
 REPO=pbnj
 REPO_OWNER=tinkerbell
 
+IPMITOOL_CLONE_TARGETS=$(MAKE_ROOT)/ipmitool/eks-anywhere-checkout-$(IPMITOOL_GIT_TAG)
 FIX_BMCLIB_TARGETS=$(REPO)/bmclib
 
 BASE_IMAGE_NAME?=eks-distro-minimal-base-glibc
@@ -16,7 +17,6 @@ BASE_IMAGE_NAME?=eks-distro-minimal-base-glibc
 BINARY_TARGET_FILES=pbnj
 SOURCE_PATTERNS=.
 
-IMAGE_BUILD_ARGS=IPMITOOL_CLONE_URL IPMITOOL_GIT_TAG
 IMAGE_USERADD_USER_ID=10001
 IMAGE_USERADD_USER_NAME=pbnj
 
@@ -26,7 +26,12 @@ FETCH_BINARIES_TARGETS=eksa/grpc-ecosystem/grpc-health-probe
 
 $(GO_MOD_DOWNLOAD_TARGETS): $(FIX_BMCLIB_TARGETS)
 
-$(call IMAGE_TARGETS_FOR_NAME, pbnj): $(call FULL_FETCH_BINARIES_TARGETS, $(FETCH_BINARIES_TARGETS)) pbnj-useradd/images/export
+$(call IMAGE_TARGETS_FOR_NAME, pbnj): $(IPMITOOL_CLONE_TARGETS) $(call FULL_FETCH_BINARIES_TARGETS, $(FETCH_BINARIES_TARGETS)) pbnj-useradd/images/export
+
+$(IPMITOOL_CLONE_TARGETS):
+	git clone $(IPMITOOL_CLONE_URL) $(@D)
+	git -C $(@D) checkout $(IPMITOOL_GIT_TAG)
+	touch $@
 
 # PBNJ had a dependency on an older commit of bmclib module, that
 # had an LGPL dependency (gebn/bmc). This was removed in 

--- a/projects/tinkerbell/pbnj/docker/linux/Dockerfile
+++ b/projects/tinkerbell/pbnj/docker/linux/Dockerfile
@@ -3,9 +3,6 @@ ARG BUILDER_IMAGE
 
 FROM $BUILDER_IMAGE as ipmitool-builder
 
-ARG IPMITOOL_CLONE_URL
-ARG IPMITOOL_GIT_TAG
-
 WORKDIR /
 
 RUN yum install -y \
@@ -16,9 +13,8 @@ RUN yum install -y \
     make \
     readline-devel
 
-RUN git clone $IPMITOOL_CLONE_URL && \
-    cd ipmitool && \
-    git checkout $IPMITOOL_COMMIT && \
+COPY ipmitool /ipmitool
+RUN cd ipmitool && \
     ./bootstrap && \
     ./configure \
         --prefix=/usr/local \


### PR DESCRIPTION
Cloning outside Docker build since we don't have AWS access inside docker build (to clone from CodeCommit).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
