### PR TITLE
kind: fix high cpu agetty processes

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -1,6 +1,6 @@
 # Disable built-in rules and variables
 MAKEFLAGS+=--no-builtin-rules --warn-undefined-variables
-SHELL=/bin/bash
+SHELL=bash
 .SHELLFLAGS:=-eu -o pipefail -c
 .SUFFIXES:
 

--- a/projects/kubernetes-sigs/kind/Help.mk
+++ b/projects/kubernetes-sigs/kind/Help.mk
@@ -59,6 +59,8 @@ attribution-pr: ## Generates PR to update attribution files for projects
 ##@ Clean Targets
 clean: ## Removes source and _output directory
 clean-repo: ## Removes source directory
+create-kind-cluster-amd64: ## Create local kind cluster using built amd64 image
+create-kind-cluster-arm64: ## Create local kind cluster using built arm64 image
 
 ##@ Helpers
 help: ## Display this help

--- a/projects/kubernetes-sigs/kind/Makefile
+++ b/projects/kubernetes-sigs/kind/Makefile
@@ -36,6 +36,7 @@ HAPROXY_IMAGE_COMPONENT=kubernetes-sigs/kind/haproxy
 KIND_BASE_IMAGE_BUILD_ARGS=$(OUTPUT_DIR)/$(RELEASE_BRANCH)/kind-base-image-build-args
 KIND_BASE_KUBEADM_OVERRIDE=$(OUTPUT_DIR)/$(RELEASE_BRANCH)/images/base/files/usr/local/bin/kubeadm
 KIND_NODE_IMAGE_BUILD_ARGS=$(OUTPUT_DIR)/$(RELEASE_BRANCH)/kind-node-image-build-args
+EKSD_KUBE_VERSION=
 
 # Overriding since kind is released branch it will try to add git_tag to latest tag
 LATEST_TAG=$(LATEST)
@@ -174,6 +175,9 @@ $(ARTIFACTS_PATH)/manifests/kindnetd.yaml:
 .PHONY: create-kind-cluster-%
 create-kind-cluster-%:
 	build/create-kind-cluster.sh $(IMAGE_REPO)/$(KIND_NODE_IMAGE_COMPONENT):$(NODE_IMAGE_LATEST_TAG) $* $(RELEASE_BRANCH)
+
+create-kind-cluster-amd64: # Create local kind cluster using built amd64 image
+create-kind-cluster-arm64: # Create local kind cluster using built arm64 image
 
 
 ########### DO NOT EDIT #############################

--- a/projects/kubernetes-sigs/kind/patches/0001-Switch-to-AL2-base-image-for-node-image.patch
+++ b/projects/kubernetes-sigs/kind/patches/0001-Switch-to-AL2-base-image-for-node-image.patch
@@ -1,16 +1,16 @@
-From 0d2af05bf029506e0e563d9e6cb515963d1333e9 Mon Sep 17 00:00:00 2001
+From 7476c8c48137973bec9c782b9518d99e2284bbb6 Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Thu, 22 Jul 2021 12:59:46 -0500
 Subject: [PATCH] Switch to AL2 base image for node image
 
 Signed-off-by: Jackson West <jgw@amazon.com>
 ---
- images/base/Dockerfile                        | 141 ++++++++----------
+ images/base/Dockerfile                        | 145 +++++++++---------
  images/base/files/usr/local/bin/clean-install |   7 +-
- 2 files changed, 70 insertions(+), 78 deletions(-)
+ 2 files changed, 73 insertions(+), 79 deletions(-)
 
 diff --git a/images/base/Dockerfile b/images/base/Dockerfile
-index ec8fcd7c..436f9854 100644
+index ec8fcd7c..f2a02a3e 100644
 --- a/images/base/Dockerfile
 +++ b/images/base/Dockerfile
 @@ -20,40 +20,24 @@
@@ -70,24 +70,28 @@ index ec8fcd7c..436f9854 100644
  
  # copy in static files
  # all scripts are 0755: http://www.filepermissions.com/file-permission/0755
-@@ -99,10 +83,11 @@ COPY --chmod=0644 files/etc/systemd/system/kubelet.service.d/* /etc/systemd/syst
+@@ -99,56 +83,66 @@ COPY --chmod=0644 files/etc/systemd/system/kubelet.service.d/* /etc/systemd/syst
  RUN echo "Installing Packages ..." \
      && DEBIAN_FRONTEND=noninteractive clean-install \
        systemd \
 -      conntrack iptables iproute2 ethtool socat util-linux mount ebtables udev kmod \
 -      libseccomp2 pigz \
 +      conntrack iptables iproute ethtool socat util-linux ebtables udev kmod \
-+      seccomp2 pigz \
++      libseccomp pigz \
        bash ca-certificates curl rsync \
 -      nfs-common \
 +      nfs-utils \
 +      containerd which tar procps hostname \
      && find /lib/systemd/system/sysinit.target.wants/ -name "systemd-tmpfiles-setup.service" -delete \
      && rm -f /lib/systemd/system/multi-user.target.wants/* \
-     && rm -f /etc/systemd/system/*.wants/* \
-@@ -111,44 +96,51 @@ RUN echo "Installing Packages ..." \
+-    && rm -f /etc/systemd/system/*.wants/* \
++    && rm -vf /etc/systemd/system/*.wants/* \
+     && rm -f /lib/systemd/system/local-fs.target.wants/* \
+     && rm -f /lib/systemd/system/sockets.target.wants/*udev* \
      && rm -f /lib/systemd/system/sockets.target.wants/*initctl* \
      && rm -f /lib/systemd/system/basic.target.wants/* \
++    # avoid runaway agetty processes most likely due to al2 being based on older centos 7
++    && systemctl mask getty@tty1.service \
      && echo "ReadKMsg=no" >> /etc/systemd/journald.conf \
 -    && ln -s "$(which systemd)" /sbin/init \
 - && echo "Enabling kubelet ... " \
@@ -170,7 +174,7 @@ index ec8fcd7c..436f9854 100644
      && rm -f /tmp/cni.sha256 \
      && mkdir -p /opt/cni/bin \
      && tar -C /opt/cni/bin -xzvf /tmp/cni.${TARGETARCH}.tgz \
-@@ -159,13 +151,12 @@ RUN echo "Installing Packages ..." \
+@@ -159,13 +153,12 @@ RUN echo "Installing Packages ..." \
           -o -iname portmap \
           -o -iname loopback \
        \) \
@@ -210,5 +214,5 @@ index 33b3238b..d8c9db56 100755
     /var/lib/apt/lists/* \
     /var/log/* \
 -- 
-2.33.1
+2.35.1
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/1159

*Description of changes:*
Per the ticket above when creating CAPD clusters there is a `agetty` process running which is attached (?) to the tty1 interface, but since it's in a container it's not really able to attach(?).  According to an (old) [issue](https://github.com/moby/moby/issues/4040) logged against docker this has to do something with privileged containers using `init` as their entrypoint, which the kind image def does.  Looking at some of the attached tickets there appears to be two approaches to solving the issue:

- masking, or removing, the getty@ttty1 service in /etc/systemd/system
- replacing `/bin/agetty` with `/bin/true`

This [issue](https://github.com/voxpupuli/beaker-hostgenerator/pull/138) went with the replacing option citing issues with other ttys and processes not exiting with containers exit.  I was not able to reproduce the latter and am not totally sure if/when a container might be launched on a host with multiple ttys.

When disabling the service, there is still a agetty process running that looks like `/sbin/agetty --noclear --keep-baud console 115200,38400,9600 vt220`.  This one does not seem to eat all the cpu and does go away correctly when the container exits.

I went with the first option of disabling the service when building the kind base image.  This feels safer...  If anyone knows more and wants to push the other way and/or if we see other issues in the future we could go with option 2.

Testing:

- Built kind image locally and create a CAPD with it and only saw the one agetty process per container and cpu usage was fine.

For reference, when running docker on mac, to attach to the docker host/vm, I follow this: https://gist.github.com/BretFisher/5e1a0c7bcca4c735e716abf62afad389 specifically

`docker run -it --rm --privileged --pid=host justincormack/nsenter1`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
