### PR TITLE
Fix ubuntu ami builds to work with new make targets

### DIFF
--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -42,7 +42,7 @@ HAS_LICENSES=false
 SIMPLE_CREATE_TARBALLS=false
 
 # to support a no op attribution target
-TARGETS_ALLOWED_WITH_NO_RELEASE_BRANCH=build release clean help binaries checksums attribution
+TARGETS_ALLOWED_WITH_NO_RELEASE_BRANCH=build release clean help binaries checksums attribution release-ami-ubuntu-2004
 TUFTOOL_TARGET=$(CARGO_HOME)/bin/tuftool
 BOTTLEROCKET_SETUP_TARGET=$(BOTTLEROCKET_DOWNLOAD_PATH)/bottlerocket-root-json-checksum
 
@@ -138,10 +138,10 @@ build-ami-ubuntu-2004: setup-ami-share deps-ami setup-packer-configs-ami
 
 .PHONY: release-ami-ubuntu-2004
 release-ami-ubuntu-2004: MAKEFLAGS=
-release-ova-ubuntu-2004: FULL_OUTPUT_DIR=$(MAKE_ROOT)/$(OUTPUT_DIR)/ami
+release-ami-ubuntu-2004: FULL_OUTPUT_DIR=$(MAKE_ROOT)/$(OUTPUT_DIR)/ami
 release-ami-ubuntu-2004: PACKER_TYPE_VAR_FILES=$(PACKER_AMI_VAR_FILES)
-release-ami-ubuntu-2004-%: setup-ami-share deps-ami setup-packer-configs-ami
-	PACKER_VAR_FILES="$(PACKER_VAR_FILES)" $(MAKE) -C $(IMAGE_BUILDER_DIR) build-ami-ubuntu-2004
+release-ami-ubuntu-2004: setup-ami-share deps-ami setup-packer-configs-ami
+	PACKER_LOG=1 PACKER_VAR_FILES="$(PACKER_VAR_FILES)" $(MAKE) -C $(IMAGE_BUILDER_DIR) build-ami-ubuntu-2004
 
 .PHONY: release-ova-ubuntu-2004
 release-ova-ubuntu-2004: MAKEFLAGS=

--- a/projects/kubernetes-sigs/image-builder/buildspecs/build-1-20-ubuntu-ami.yml
+++ b/projects/kubernetes-sigs/image-builder/buildspecs/build-1-20-ubuntu-ami.yml
@@ -14,4 +14,4 @@ phases:
 
   build:
     commands:
-      - make release-ami-ubuntu-2004-1-20 -C $PROJECT_PATH
+      - make release-ami-ubuntu-2004 RELEASE_BRANCH=1-20 -C $PROJECT_PATH

--- a/projects/kubernetes-sigs/image-builder/buildspecs/build-1-21-ubuntu-ami.yml
+++ b/projects/kubernetes-sigs/image-builder/buildspecs/build-1-21-ubuntu-ami.yml
@@ -14,4 +14,4 @@ phases:
 
   build:
     commands:
-      - make release-ami-ubuntu-2004-1-21 -C $PROJECT_PATH
+      - make release-ami-ubuntu-2004 RELEASE_BRANCH=1-21 -C $PROJECT_PATH


### PR DESCRIPTION
Part of https://github.com/aws/eks-anywhere/issues/1165

*Description of changes:*
This is the minimum changes to make this work (I think)
Once everything is working correctly, we'll refactor this to use the new build patterns (`release IMAGE_FORMAT=*`, etc.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
