### PR TITLE
Move kindnetd manifest to versioned folder

### DIFF
--- a/projects/kubernetes-sigs/kind/Makefile
+++ b/projects/kubernetes-sigs/kind/Makefile
@@ -71,7 +71,7 @@ endif
 
 # During build the node image is never built so we can extract this file
 # instead fake it to keep s3-artifacts happy
-s3-artifacts: $(ARTIFACTS_PATH)/manifests/kindnetd.yaml
+s3-artifacts: $(ARTIFACTS_PATH)/manifests/kindnetd/$(GIT_TAG)/kindnetd.yaml
 
 images: kind-base-versioned/images/push kind-node/images/push
 
@@ -153,8 +153,8 @@ $(KIND_BASE_KUBEADM_OVERRIDE):
 $(KIND_NODE_BUILD_AMD64_TARGET): $(KIND_NODE_IMAGE_BUILD_ARGS) $(ORGANIZE_BINARIES_AMD64_TARGET)
 	build/build-kind-node-image.sh $(RELEASE_BRANCH) $(VERSIONED_BASE_IMAGE) amd64
 	@mkdir -p $(ARTIFACTS_PATH)/manifests
-	cp $(BINARY_DEPS_DIR)/linux-amd64/files/rootfs/kind/manifests/default-cni.yaml $(ARTIFACTS_PATH)/manifests/kindnetd.yaml
-	sed -i -e 's/{{ .PodSubnet }}/192.168.0.0\/16/' $(ARTIFACTS_PATH)/manifests/kindnetd.yaml 
+	cp $(BINARY_DEPS_DIR)/linux-amd64/files/rootfs/kind/manifests/default-cni.yaml $(ARTIFACTS_PATH)/manifests/kindnetd/$(GIT_TAG)/kindnetd.yaml
+	sed -i -e 's/{{ .PodSubnet }}/192.168.0.0\/16/' $(ARTIFACTS_PATH)/manifests/kindnetd/$(GIT_TAG)/kindnetd.yaml 
 
 $(KIND_NODE_BUILD_ARM64_TARGET): $(KIND_NODE_IMAGE_BUILD_ARGS) $(ORGANIZE_BINARIES_ARM64_TARGET)
 	build/build-kind-node-image.sh $(RELEASE_BRANCH) $(VERSIONED_BASE_IMAGE) arm64
@@ -168,7 +168,7 @@ $(ORGANIZE_BINARIES_ARM64_TARGET): $(call FULL_FETCH_BINARIES_TARGETS, $(FETCH_B
 $(ARM_ENV_CONF_TARGET):
 	@cp -rf images/node/files/* $(BINARY_DEPS_DIR)/linux-arm64/files/rootfs/
 
-$(ARTIFACTS_PATH)/manifests/kindnetd.yaml:
+$(ARTIFACTS_PATH)/manifests/kindnetd/$(GIT_TAG)/kindnetd.yaml:
 	@mkdir -p $(@D)
 	@touch $@
 

--- a/projects/kubernetes-sigs/kind/expected_artifacts
+++ b/projects/kubernetes-sigs/kind/expected_artifacts
@@ -17,4 +17,4 @@ kind-linux-amd64-$GIT_TAG.tar.gz.sha512
 kind-linux-arm64-$GIT_TAG.tar.gz
 kind-linux-arm64-$GIT_TAG.tar.gz.sha256
 kind-linux-arm64-$GIT_TAG.tar.gz.sha512
-manifests/kindnetd.yaml
+manifests/kindnetd/$GIT_TAG/kindnetd.yaml


### PR DESCRIPTION
For consistency with other projects building manifests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
