### PR TITLE
Extra scripts for Snow provider in ubuntu ami

### DIFF
--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -16,6 +16,8 @@ CARGO_HOME=$(MAKE_ROOT)/_output/cargo
 RUSTUP_HOME=$(MAKE_ROOT)/_output/rustup
 export BOTTLEROCKET_DOWNLOAD_PATH?=$(FULL_OUTPUT_DIR)/bottlerocket/downloads
 
+export BUILDER_ROOT=$(MAKE_ROOT)
+
 VSPHERE_CONNECTION_DATA?={}
 # Aws accounts to share built AMI with
 DEV_ACCOUNTS?=

--- a/projects/kubernetes-sigs/image-builder/ansible/roles/load_additional_files/defaults/main.yml
+++ b/projects/kubernetes-sigs/image-builder/ansible/roles/load_additional_files/defaults/main.yml
@@ -1,0 +1,2 @@
+additional_files: ""
+additional_files_list: []

--- a/projects/kubernetes-sigs/image-builder/ansible/roles/load_additional_files/tasks/files.yml
+++ b/projects/kubernetes-sigs/image-builder/ansible/roles/load_additional_files/tasks/files.yml
@@ -1,0 +1,8 @@
+- name: Copy additional files
+  copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
+    mode: "{{ item.mode }}"
+  loop: "{{ additional_files_list }}"

--- a/projects/kubernetes-sigs/image-builder/ansible/roles/load_additional_files/tasks/main.yml
+++ b/projects/kubernetes-sigs/image-builder/ansible/roles/load_additional_files/tasks/main.yml
@@ -1,0 +1,2 @@
+- import_tasks: files.yml
+  when: additional_files | bool

--- a/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/bootstrap-after.sh
+++ b/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/bootstrap-after.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+VIP=$1
+
+# if it's control plane node to join, generate the manifest after `kubeadm join` command complete successfully
+if grep -q "kubeadm join --config /run/kubeadm/kubeadm-join-config.yaml" /var/lib/cloud/instance/user-data.txt && grep -q success /run/cluster-api/bootstrap-success.complete ; then
+  /etc/eks/generate-kube-vip-manifest.sh $VIP
+fi

--- a/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/bootstrap.sh
+++ b/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/bootstrap.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+VIP="$1"
+
+DNI=$(ip -br link | egrep -v 'lo|ens3|docker0' | awk '{print $1}')
+
+while [ -z $DNI ]
+do
+  echo "DNI is not ready, retry after 5 s"
+  sleep 5
+  DNI=$(ip -br link | egrep -v 'lo|ens3|docker0' | awk '{print $1}')
+done
+
+MAC=$(ip -br link | egrep -v 'lo|ens3|docker0' |  awk '{print $3}')
+
+DEFAULT_GATEWAY=$(ip r | grep default | awk '{print $3}')
+
+cat<<EOF >/etc/netplan/config.yaml
+network:
+    version: 2
+    renderer: networkd
+    ethernets:
+        $DNI:
+            set-name: $DNI
+            dhcp4: true
+            dhcp4-overrides:
+                route-metric: 50
+            match:
+                macaddress: $MAC
+        ens3:
+            routes:
+                - to: 169.254.169.254
+                  via: $DEFAULT_GATEWAY
+EOF
+
+netplan apply
+
+# DNI needs several seconds to lease an ip via DHCP
+MY_IP=$(ip route show | grep default | grep $DNI | awk '{print $9}')
+while [ -z $MY_IP ]
+do
+    echo "ip is not ready, retry after 5 s"
+    sleep 5
+    MY_IP=$(ip route show | grep default | grep $DNI | awk '{print $9}')
+done
+
+# Using instance id as a unique hostname before we implement hostname in capas
+INSTANCE_ID=$(curl 169.254.169.254/latest/meta-data/instance-id | sed -r 's/[.]+/-/g')
+
+hostnamectl set-hostname $INSTANCE_ID
+echo "preserve_hostname: true" > /etc/cloud/cloud.cfg.d/99_hostname.cfg
+
+cat <<EOF > /etc/hosts
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+127.0.0.1   $INSTANCE_ID
+EOF
+
+cat <<EOF >/etc/sysctl.d/kubernetes.conf
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1
+net.ipv4.ip_forward = 1
+EOF
+
+sysctl --system
+
+swapoff -a
+
+# if vip is not provided, it's a worker node, we don't need kube-vip manifest
+# if `kubeadm init` command doesn't exist in the user-data, it's not the first control plane node, we should generate the kube-vip manifest after the `kubeadm join` command finishes
+if [ ! -z $VIP ] && grep -q "kubeadm init --config /run/kubeadm/kubeadm.yaml" /var/lib/cloud/instance/user-data.txt ; then
+  /etc/eks/generate-kube-vip-manifest.sh $VIP
+fi

--- a/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/generate-kube-vip-manifest.sh
+++ b/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/generate-kube-vip-manifest.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+VIP=$1
+DNI=$(ip -br link | egrep -v 'lo|ens3|docker0' | awk '{print $1}')
+KUBE_VIP_IMAGE='public.ecr.aws/eks-anywhere/plunder-app/kube-vip:v0.3.7-eks-a-1'
+
+cat<<EOF >/etc/kubernetes/manifests/kube-vip.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  name: kube-vip
+  namespace: kube-system
+spec:
+  containers:
+  - args:
+    - manager
+    env:
+    - name: vip_arp
+      value: "true"
+    - name: vip_interface
+      value: $DNI
+    - name: port
+      value: "6443"
+    - name: vip_cidr
+      value: "32"
+    - name: cp_enable
+      value: "true"
+    - name: cp_namespace
+      value: kube-system
+    - name: vip_ddns
+      value: "false"
+    - name: vip_leaderelection
+      value: "true"
+    - name: vip_leaseduration
+      value: "5"
+    - name: vip_renewdeadline
+      value: "3"
+    - name: vip_retryperiod
+      value: "1"
+    - name: vip_address
+      value: $VIP
+    image: $KUBE_VIP_IMAGE
+    imagePullPolicy: IfNotPresent
+    name: kube-vip
+    resources: {}
+    securityContext:
+      capabilities:
+        add:
+        - NET_ADMIN
+        - NET_RAW
+        - SYS_TIME
+    volumeMounts:
+    - mountPath: /etc/kubernetes/admin.conf
+      name: kubeconfig
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes/admin.conf
+    name: kubeconfig
+status: {}
+EOF

--- a/projects/kubernetes-sigs/image-builder/packer/ami/ansible_extra_vars.yaml
+++ b/projects/kubernetes-sigs/image-builder/packer/ami/ansible_extra_vars.yaml
@@ -1,0 +1,18 @@
+additional_files: true
+builder_root: "{{ lookup('env', 'BUILDER_ROOT') }}"
+additional_files_list:
+- src: "{{ builder_root }}/packer/ami/additional_files/bootstrap.sh"
+  dest: /etc/eks/
+  owner: root
+  group: root
+  mode: 744
+- src: "{{ builder_root }}/packer/ami/additional_files/bootstrap-after.sh"
+  dest: /etc/eks/
+  owner: root
+  group: root
+  mode: 744
+- src: "{{ builder_root }}/packer/ami/additional_files/generate-kube-vip-manifest.sh"
+  dest: /etc/eks/
+  owner: root
+  group: root
+  mode: 744

--- a/projects/kubernetes-sigs/image-builder/packer/ami/packer.json
+++ b/projects/kubernetes-sigs/image-builder/packer/ami/packer.json
@@ -2,5 +2,8 @@
   "ami_groups": "",
   "ami_regions": "us-west-2",
   "aws_region": "us-west-2",
-  "snapshot_groups": ""
+  "snapshot_groups": "",
+  "custom_role": "true",
+  "custom_role_names": "{{env `BUILDER_ROOT`}}/ansible/roles/load_additional_files",
+  "ansible_extra_vars": "@{{env `BUILDER_ROOT`}}/packer/ami/ansible_extra_vars.yaml"
 }


### PR DESCRIPTION
Part of https://github.com/aws/eks-anywhere/issues/1165

*Description of changes:*
This adds 3 extra scripts that the Snow CAPI provider uses for node bootstrap.

I managed to do it without patching image-builder by:
* Creating a new ansible role and passing it to `image-builder` through [`custom_role_names`](https://image-builder.sigs.k8s.io/capi/capi.html#customization). This plugs it into the main packer build, right after the `load_additional_components` role (after provider and kubernetes roles have already been executed). This role simply iterates over a list of files and copies them in the designated destination paths.
* Creating a yaml file listing all the files we want to copy to the ami and passing it to ansible with `ansible_user_vars`.

Note: I'm exporting `BUILDER_ROOT` (it's just the full path for the image-builder project) to be able to use in the packer's and ansible's var files. Relative paths are problematic since we execute everything from the subfolder where we clone the original image-builder repo.

Note 2: the scripts come from Snow, I just wrote the ami building stuff.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
