### PR TITLE
Adding GATHER_LICENSES_TARGETS for ipxe copy target

### DIFF
--- a/projects/tinkerbell/boots/Makefile
+++ b/projects/tinkerbell/boots/Makefile
@@ -18,7 +18,7 @@ IPXE_DEPENDENCY_TARGET=$(REPO)/tftp/ipxe/undionly.kpxe
 
 include $(BASE_DIRECTORY)/Common.mk
 
-$(OUTPUT_BIN_DIR)/linux-amd64/boots $(OUTPUT_BIN_DIR)/linux-arm64/boots: $(IPXE_DEPENDENCY_TARGET)
+$(OUTPUT_BIN_DIR)/linux-amd64/boots $(OUTPUT_BIN_DIR)/linux-arm64/boots $(GATHER_LICENSES_TARGETS): $(IPXE_DEPENDENCY_TARGET)
 
 $(IPXE_DEPENDENCY_TARGET):
 # Boots has a dependency on 4 ipxe binaries that get embedded in the code.


### PR DESCRIPTION
*Description of changes:*
Attribution automation job is failing due to boots project. Adding ipxe copy to GATHER_LICENSES_TARGETS target.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
