### PR TITLE
Add CAPT patch to remove requirement on machine.Spec.Version

### DIFF
--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/CHECKSUMS
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/CHECKSUMS
@@ -1,2 +1,2 @@
-73625ac93be61fec9af76ddf5d4cfa4729b0aeaf7220c65333df47de01af21ea  _output/bin/cluster-api-provider-tinkerbell/linux-amd64/manager
-1171e1b64d8bd8bd4f625771aff48ce476c20ed53fa6b8a82e4b21f0e6c12179  _output/bin/cluster-api-provider-tinkerbell/linux-arm64/manager
+f69065f80f794cf684a7f4544afff693498f96c0f22431bf8dcafb0a2910cf55  _output/bin/cluster-api-provider-tinkerbell/linux-amd64/manager
+9b9a7eca5347d808c0ce217831e10b752cde74b3ab5d80904675c99990a404c7  _output/bin/cluster-api-provider-tinkerbell/linux-arm64/manager

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0009-Remove-requirement-for-machine.Spec.Version.patch
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0009-Remove-requirement-for-machine.Spec.Version.patch
@@ -1,0 +1,30 @@
+From 6e84664577272b2a1d941d3392cde725d9570636 Mon Sep 17 00:00:00 2001
+From: Abhinav Pandey <abhinavmpandey08@gmail.com>
+Date: Mon, 14 Feb 2022 16:06:44 -0800
+Subject: [PATCH] Remove requirement for machine.Spec.Version
+
+Signed-off-by: Abhinav Pandey <abhinavmpandey08@gmail.com>
+---
+ controllers/base.go | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/controllers/base.go b/controllers/base.go
+index bfb28a2..9b84c3e 100644
+--- a/controllers/base.go
++++ b/controllers/base.go
+@@ -338,12 +338,6 @@ func isMachineReady(machine *clusterv1.Machine) (string, error) {
+ 		return "retrieving bootstrap data: linked Machine's bootstrap.dataSecretName is not available yet", nil
+ 	}
+ 
+-	// Spec says this field is optional, but @detiber says it's effectively required,
+-	// so treat it as so.
+-	if machine.Spec.Version == nil || *machine.Spec.Version == "" {
+-		return "", ErrMachineVersionEmpty
+-	}
+-
+ 	return "", nil
+ }
+ 
+-- 
+2.32.0 (Apple Git-132)
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The CAPI machine crds for external etcd currently do not set `machine.Spec.Version` but CAPT makes it a required field. Etcd machines fail to reconcile as a result.

This patch removes this requirement allowing us to use external etcd with CAPT.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
