### PR TITLE
pbnj: fix lanplus by adding openssl-dev when building ipmitool

### DIFF
--- a/projects/tinkerbell/pbnj/docker/linux/Dockerfile
+++ b/projects/tinkerbell/pbnj/docker/linux/Dockerfile
@@ -11,7 +11,8 @@ RUN yum install -y \
     git \
     libtool \
     make \
-    readline-devel
+    readline-devel \
+    openssl-devel
 
 COPY ipmitool /ipmitool
 RUN cd ipmitool && \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
