### PR TITLE
pbnj: use destdir when make installing impitool

### DIFF
--- a/projects/tinkerbell/pbnj/docker/linux/Dockerfile
+++ b/projects/tinkerbell/pbnj/docker/linux/Dockerfile
@@ -25,7 +25,7 @@ RUN cd ipmitool && \
         --enable-intf-lanplus \
         --enable-intf-open && \
     make && \
-    make install
+    make DESTDIR=/newroot install
 
 WORKDIR /newroot
 
@@ -45,9 +45,6 @@ COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksa/grpc-ecosystem/grpc-health-
 COPY _output/bin/pbnj/$TARGETOS-$TARGETARCH/pbnj /usr/bin/pbnj
 COPY _output/LICENSES /LICENSES
 COPY ATTRIBUTION.txt /ATTRIBUTION.txt
-
-COPY --from=ipmitool-builder /usr/local/bin/ipmitool /usr/local/bin
-COPY --from=ipmitool-builder /ipmitool/COPYING /LICENSES/github.com/ipmitool/ipmitool/COPYING
 
 ENV GIN_MODE release
 USER pbnj


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This will make sure everything make install puts in place, is in the resulting image, including the license.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
