### PR TITLE
Creating ARTIFACTS_PATH before cp

### DIFF
--- a/projects/tinkerbell/hook/Makefile
+++ b/projects/tinkerbell/hook/Makefile
@@ -59,6 +59,7 @@ $(CREATE_HOOK_FILES): tarballs
 	make dist-existing-images -C $(REPO)
 	mkdir -p $(OUTPUT_DIR)/hook/$(GIT_TAG)
 	cp $(REPO)/dist/* $(OUTPUT_DIR)/hook/$(GIT_TAG)/
+	mkdir -p $(ARTIFACTS_PATH)
 	cp -rf $(OUTPUT_DIR)/hook $(ARTIFACTS_PATH)
 
 

--- a/projects/tinkerbell/hook/Makefile
+++ b/projects/tinkerbell/hook/Makefile
@@ -60,7 +60,7 @@ $(CREATE_HOOK_FILES): tarballs
 	mkdir -p $(OUTPUT_DIR)/hook/$(GIT_TAG)
 	cp $(REPO)/dist/* $(OUTPUT_DIR)/hook/$(GIT_TAG)/
 	mkdir -p $(ARTIFACTS_PATH)
-	cp -rf $(OUTPUT_DIR)/hook $(ARTIFACTS_PATH)
+	cp -rf $(OUTPUT_DIR)/hook/* $(ARTIFACTS_PATH)
 
 
 ########### DO NOT EDIT #############################

--- a/projects/tinkerbell/hook/expected_artifacts
+++ b/projects/tinkerbell/hook/expected_artifacts
@@ -1,4 +1,4 @@
-5.10.57/initramfs-aarch64
-5.10.57/initramfs-x86_64
-5.10.57/vmlinuz-aarch64
-5.10.57/vmlinuz-x86_64
+$GIT_TAG/initramfs-aarch64
+$GIT_TAG/initramfs-x86_64
+$GIT_TAG/vmlinuz-aarch64
+$GIT_TAG/vmlinuz-x86_64


### PR DESCRIPTION
*Description of changes:*
Since we set `SIMPLE_CREATE_TARBALLS=false` we need to create the artifacts path to copy the final OSIE files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
