### PR TITLE
cgo: refactor to be more reusable

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -289,6 +289,12 @@ define GET_CLONE_URL
 $(shell source $(BUILD_LIB)/common.sh && build::common::get_clone_url $(1) $(2) $(AWS_REGION) $(CODEBUILD_CI))
 endef
 
+# Indenting the block results in the URL getting prefixed with a
+# space, hence no indentation below.
+define TO_UPPER
+$(shell echo '$(1)' | tr '[:lower:]' '[:upper:]')
+endef
+
 # to avoid dealing with cross compling issues using a buildctl
 # multi-stage build to build the binaries for both amd64 and arm64
 # licenses and attribution are also run from the builder image since
@@ -296,12 +302,16 @@ endef
 define CGO_BINARY_TARGET_BODY
 	$(OUTPUT_BIN_DIR)/$(subst /,-,$(1))/$(2): $(GO_MOD_DOWNLOAD_TARGETS)
 		@mkdir -p $(CGO_SOURCE)/eks-anywhere-build-tooling/
-		rsync -rm  --exclude='.git/logs/***' \
-			--exclude='projects/$(COMPONENT)/_output/bin/***' --exclude='projects/$(COMPONENT)/$(REPO)/***' \
+		rsync -rm  --exclude='.git/***' \
+			--exclude='***/_output/***' --exclude='projects/$(COMPONENT)/$(REPO)/***' \
 			--include='projects/$(COMPONENT)/***' --include='*/' --exclude='projects/***'  \
 			$(BASE_DIRECTORY)/ $(CGO_SOURCE)/eks-anywhere-build-tooling/
 		@mkdir -p $(OUTPUT_BIN_DIR)/$(subst /,-,$(1))
-		$(MAKE) binary-builder/cgo/$(1:linux/%=%) IMAGE_OUTPUT=dest=$(OUTPUT_BIN_DIR)/$(subst /,-,$(1))
+		# Need so git properly finds the root of the repo
+		@mkdir -p $(CGO_SOURCE)/eks-anywhere-build-tooling/.git/{refs,objects}
+		@cp $(BASE_DIRECTORY)/.git/HEAD $(CGO_SOURCE)/eks-anywhere-build-tooling/.git
+		$(MAKE) binary-builder/cgo/$(1:linux/%=%) \
+			IMAGE_OUTPUT=dest=$(OUTPUT_BIN_DIR)/$(subst /,-,$(1)) CGO_TARGET=$$@ IMAGE_BUILD_ARGS="GOPROXY COMPONENT CGO_TARGET"
 
 endef
 
@@ -487,9 +497,9 @@ helm/push: helm/build
 
 .PHONY: %/cgo/amd64 %/cgo/arm64
 %/cgo/amd64 %/cgo/arm64: IMAGE_OUTPUT_TYPE?=local
-%/cgo/amd64 %/cgo/arm64: DOCKERFILE_FOLDER?=./docker/build
+%/cgo/amd64 %/cgo/arm64: DOCKERFILE_FOLDER?=$(BUILD_LIB)/docker/linux/cgo
 %/cgo/amd64 %/cgo/arm64: IMAGE_NAME=binary-builder
-%/cgo/amd64 %/cgo/arm64: IMAGE_BUILD_ARGS?=GOPROXY
+%/cgo/amd64 %/cgo/arm64: IMAGE_BUILD_ARGS?=GOPROXY COMPONENT
 %/cgo/amd64 %/cgo/arm64: IMAGE_CONTEXT_DIR?=$(CGO_SOURCE)
 %/cgo/amd64 %/cgo/arm64: BUILDER_IMAGE=$(BASE_IMAGE_REPO)/builder-base:latest
 

--- a/build/lib/docker/linux/cgo/Dockerfile
+++ b/build/lib/docker/linux/cgo/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:experimental
+
+# To around the lack of a overlayfs in presubmit jobs since they run on fargate
+# we have to keep the layers to a minimum.
+# All the source files and librarys are gatered into once folder on the base and then
+# copied in the builder
+ARG BUILDER_IMAGE
+FROM ${BUILDER_IMAGE} as builder
+
+ARG TARGETARCH
+ARG TARGETOS
+ARG COMPONENT
+ARG CGO_TARGET
+
+ARG GOPROXY
+ENV GOPROXY=$GOPROXY
+
+COPY ./eks-anywhere-build-tooling /eks-anywhere-build-tooling
+COPY ./$TARGETOS-$TARGETARCH /eks-anywhere-build-tooling/projects/$COMPONENT/_output/source/$TARGETOS-$TARGETARCH
+
+WORKDIR /eks-anywhere-build-tooling
+RUN make -C projects/$COMPONENT $CGO_TARGET BINARY_PLATFORMS=$TARGETOS/$TARGETARCH
+
+FROM scratch
+
+ARG TARGETARCH
+ARG TARGETOS
+ARG COMPONENT
+ARG CGO_TARGET
+
+COPY --from=builder /eks-anywhere-build-tooling/projects/$COMPONENT/$CGO_TARGET .

--- a/build/lib/run_target_docker.sh
+++ b/build/lib/run_target_docker.sh
@@ -32,14 +32,19 @@ echo "Run 'make stop-docker-builder' when you are done to stop it."
 echo "****************************************************************"
 
 if ! docker ps -f name=eks-a-builder | grep -w eks-a-builder; then
+	docker pull public.ecr.aws/eks-distro-build-tooling/builder-base:latest
 	docker run -d --name eks-a-builder --privileged -e GOPROXY=$GOPROXY --entrypoint sleep \
 		public.ecr.aws/eks-distro-build-tooling/builder-base:latest  infinity 
 fi
 
-rsync -e 'docker exec -i' -rm --exclude='.git/logs/***' \
+rsync -e 'docker exec -i' -rm --exclude='.git/***' \
 	--exclude="projects/$PROJECT/_output/***" --exclude="projects/$PROJECT/$(basename $PROJECT)/***" \
 	--include="projects/$PROJECT/***" --include="projects/kubernetes-sigs/image-builder/BOTTLEROCKET_OVA_RELEASES" \
 	--include="release/SUPPORTED_RELEASE_BRANCHES" --include="projects/kubernetes-sigs/cri-tools/GIT_TAG" \
 	--include='*/' --exclude='projects/***' ./ eks-a-builder:/eks-anywhere-build-tooling
+
+# Need so git properly finds the root of the repo
+docker exec -it eks-a-builder mkdir -p /eks-anywhere-build-tooling/.git/{refs,objects}
+docker cp ./.git/HEAD eks-a-builder:/eks-anywhere-build-tooling/.git
 
 docker exec -it eks-a-builder make $TARGET -C /eks-anywhere-build-tooling/projects/$PROJECT RELEASE_BRANCH=$RELEASE_BRANCH IMAGE_REPO=$IMAGE_REPO ARTIFACTS_BUCKET=$ARTIFACTS_BUCKET

--- a/projects/fluxcd/source-controller/Makefile
+++ b/projects/fluxcd/source-controller/Makefile
@@ -24,7 +24,7 @@ $(OUTPUT_BIN_DIR)/linux-amd64/source-controller: | $(CGO_SOURCE)/linux-amd64/usr
 $(OUTPUT_BIN_DIR)/linux-arm64/source-controller: | $(CGO_SOURCE)/linux-arm64/usr/lib64/libgit2.so
 
 $(CGO_SOURCE)/linux-%/usr/lib64/libgit2.so:
-	$(MAKE) binary-builder-deps/cgo/$* IMAGE_TARGET=deps IMAGE_OUTPUT=dest=$(CGO_SOURCE)/linux-$*
+	$(MAKE) binary-builder-deps/cgo/$* IMAGE_TARGET=deps IMAGE_OUTPUT=dest=$(CGO_SOURCE)/linux-$* DOCKERFILE_FOLDER=./docker/build
 
 $(GATHER_LICENSES_TARGETS): | $(FIX_LICENSES_XEIPUUV_TARGET) $(FIX_LICENSES_API_LICENSE_TARGET) $(LIBGIT2_LICENSES_TARGET)
 

--- a/projects/fluxcd/source-controller/docker/build/Dockerfile
+++ b/projects/fluxcd/source-controller/docker/build/Dockerfile
@@ -1,9 +1,5 @@
 # syntax=docker/dockerfile:experimental
 
-# To around the lack of a overlayfs in presubmit jobs since they run on fargate
-# we have to keep the layers to a minimum.
-# All the source files and librarys are gatered into once folder on the base and then
-# copied in the builder
 ARG BASE_IMAGE
 ARG BUILDER_IMAGE
 FROM ${BASE_IMAGE} as base
@@ -15,24 +11,3 @@ COPY --from=base /usr/include/git2.h ./usr/include
 COPY --from=base /usr/lib64/pkgconfig/*.pc ./usr/lib64/pkgconfig/
 COPY --from=base /usr/lib64/libgit2* ./usr/lib64
 COPY --from=base /usr/lib64/libssh2* ./usr/lib64
-
-
-FROM ${BUILDER_IMAGE} as builder
-
-ARG TARGETARCH
-ARG TARGETOS
-
-ARG GOPROXY
-ENV GOPROXY=$GOPROXY
-
-RUN --mount=type=bind,source=/,target=/files set -x && \
-    cp -rf /files/eks-anywhere-build-tooling / && \
-    cd /eks-anywhere-build-tooling && \
-    make -C projects/fluxcd/source-controller binaries BINARY_PLATFORMS=$TARGETOS/$TARGETARCH
-
-FROM scratch
-
-ARG TARGETARCH
-ARG TARGETOS
-
-COPY --from=builder /eks-anywhere-build-tooling/projects/fluxcd/source-controller/_output/bin/source-controller/$TARGETOS-$TARGETARCH/source-controller .


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The source-controller is the only build we currently use cgo for.  The current implementation is specific to that case.  While working on some of the tink action builds, we originally thought we needed to cgo build them.  I refactor the build process for source-controller to be more reusable with the intention of using it for tink.  We do not need this for tink, but I think this is a better setup and can be used in the future if necessary a bit easier.  There is another tinkerbell related build that we *may* need to use this process to build which we are currently just checking in the upstream files for.

Side note: currently we use an amd64 builder for the amd64 builds and an arm64 build for arm64 builds.  This is because cross-compiling on al2 is just not possible.  I *think* once we have a al2022 based builder-base we actually could simplify this a bit and do cross compiling instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
