### PR TITLE
Accept kube-vip image as input to bootstrap scripts in Snow ami

### DIFF
--- a/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/bootstrap-after.sh
+++ b/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/bootstrap-after.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-VIP=$1
+KUBE_VIP_IMAGE=$1
+VIP=$2
 
 # if it's control plane node to join, generate the manifest after `kubeadm join` command complete successfully
 if grep -q "kubeadm join --config /run/kubeadm/kubeadm-join-config.yaml" /var/lib/cloud/instance/user-data.txt && grep -q success /run/cluster-api/bootstrap-success.complete ; then
-  /etc/eks/generate-kube-vip-manifest.sh $VIP
+  /etc/eks/generate-kube-vip-manifest.sh $KUBE_VIP_IMAGE $VIP
 fi

--- a/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/bootstrap.sh
+++ b/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/bootstrap.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-VIP="$1"
+KUBE_VIP_IMAGE=$1
+VIP="$2"
 
 DNI=$(ip -br link | egrep -v 'lo|ens3|docker0' | awk '{print $1}')
 
@@ -69,5 +70,4 @@ swapoff -a
 # if vip is not provided, it's a worker node, we don't need kube-vip manifest
 # if `kubeadm init` command doesn't exist in the user-data, it's not the first control plane node, we should generate the kube-vip manifest after the `kubeadm join` command finishes
 if [ ! -z $VIP ] && grep -q "kubeadm init --config /run/kubeadm/kubeadm.yaml" /var/lib/cloud/instance/user-data.txt ; then
-  /etc/eks/generate-kube-vip-manifest.sh $VIP
-fi
+  /etc/eks/generate-kube-vip-manifest.sh $KUBE_VIP_IMAGE $VIP

--- a/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/generate-kube-vip-manifest.sh
+++ b/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/generate-kube-vip-manifest.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-VIP=$1
+KUBE_VIP_IMAGE=$1
+VIP=$2
 DNI=$(ip -br link | egrep -v 'lo|ens3|docker0' | awk '{print $1}')
-KUBE_VIP_IMAGE='public.ecr.aws/eks-anywhere/plunder-app/kube-vip:v0.3.7-eks-a-1'
 
 cat<<EOF >/etc/kubernetes/manifests/kube-vip.yaml
 apiVersion: v1


### PR DESCRIPTION
*Description of changes:*
We don't want this image harcoded, we want to be able to pass it when bootstrapping clusters.

These changes mean that when generating the CAPI [template](https://github.com/aws/cluster-api-provider-aws-snow/blob/main/snow-cluster.yaml), we will need to change the kubeadm pre and post commands to include the image. Example:

[Control plane](https://github.com/aws/cluster-api-provider-aws-snow/blob/main/snow-cluster.yaml#L68-L71)
```yaml
    preKubeadmCommands:
      - /etc/eks/bootstrap.sh 192.168.1.111
    postKubeadmCommands:
      - /etc/eks/bootstrap-after.sh 192.168.1.111
```
```yaml
    preKubeadmCommands:
      - /etc/eks/bootstrap.sh public.ecr.aws/eks-anywhere/plunder-app/kube-vip:v0.3.7-eks-a-1 192.168.1.111
    postKubeadmCommands:
      - /etc/eks/bootstrap-after.sh public.ecr.aws/eks-anywhere/plunder-app/kube-vip:v0.3.7-eks-a-1 192.168.1.111
```

No changes needed for [worker nodes](https://github.com/aws/cluster-api-provider-aws-snow/blob/main/snow-cluster.yaml#L146)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
