### PR TITLE
Adding wget and sleep to tink images

### DIFF
--- a/projects/tinkerbell/tink/Makefile
+++ b/projects/tinkerbell/tink/Makefile
@@ -28,8 +28,9 @@ FETCH_BINARIES_TARGETS=eksa/cloudflare/cfssl
 
 include $(BASE_DIRECTORY)/Common.mk
 
-$(call IMAGE_TARGETS_FOR_NAME, tink-server): $(call FULL_FETCH_BINARIES_TARGETS, $(FETCH_BINARIES_TARGETS))
+tink-cli/images/%: BASE_IMAGE_NAME=eks-distro-minimal-base-glibc
 
+$(call IMAGE_TARGETS_FOR_NAME, tink-server): $(call FULL_FETCH_BINARIES_TARGETS, $(FETCH_BINARIES_TARGETS))
 
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block

--- a/projects/tinkerbell/tink/docker/linux/tink-cli/Dockerfile
+++ b/projects/tinkerbell/tink/docker/linux/tink-cli/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE # https://gallery.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base
+ARG BASE_IMAGE # https://gallery.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc
 ARG BUILDER_IMAGE
 
 FROM $BUILDER_IMAGE as sleep-builder

--- a/projects/tinkerbell/tink/docker/linux/tink-cli/Dockerfile
+++ b/projects/tinkerbell/tink/docker/linux/tink-cli/Dockerfile
@@ -1,11 +1,26 @@
 ARG BASE_IMAGE # https://gallery.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base
+ARG BUILDER_IMAGE
+
+FROM $BUILDER_IMAGE as sleep-builder
+
+# sleep comes from the coreutils package which pulls in more deps than we need
+# manually installing sleep from the rpm
+# sleep only depends on glibc so there are no additional deps needed
+RUN set -x && \
+    yumdownloader --destdir=/tmp/downloads coreutils && \
+    cd /newroot && \
+    rpm2cpio /tmp/downloads/coreutils*.rpm | cpio -idv ./usr/bin/sleep
+
 FROM $BASE_IMAGE
 
 ARG TARGETARCH
 ARG TARGETOS
 
+WORKDIR /
+
+COPY --from=sleep-builder /newroot/usr/bin/sleep /usr/bin/
 COPY _output/bin/tink/$TARGETOS-$TARGETARCH/tink /usr/bin/tink
 COPY _output/LICENSES /LICENSES
 COPY ATTRIBUTION.txt /ATTRIBUTION.txt
 
-CMD sleep infinity
+ENTRYPOINT ["/usr/bin/sleep", "infinity"]

--- a/projects/tinkerbell/tink/docker/linux/tink-server/Dockerfile
+++ b/projects/tinkerbell/tink/docker/linux/tink-server/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /newroot
 
 RUN set -x && \
     clean_install "wget" && \
-    remove_package "bash coreutils gawk info sed grep pcre libidn" && \
+    remove_package "bash coreutils gawk info sed grep pcre" && \
     cleanup "wget"
 
 FROM $BASE_IMAGE

--- a/projects/tinkerbell/tink/docker/linux/tink-server/Dockerfile
+++ b/projects/tinkerbell/tink/docker/linux/tink-server/Dockerfile
@@ -1,8 +1,23 @@
 ARG BASE_IMAGE # https://gallery.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base
+ARG BUILDER_IMAGE
+
+FROM $BUILDER_IMAGE as wget-builder
+
+WORKDIR /newroot
+
+RUN set -x && \
+    clean_install "wget" && \
+    remove_package "bash coreutils gawk info sed grep pcre libidn" && \
+    cleanup "wget"
+
 FROM $BASE_IMAGE
 
 ARG TARGETARCH
 ARG TARGETOS
+
+WORKDIR /
+
+COPY --from=wget-builder /newroot /
 
 COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksa/cloudflare/cfssl /usr/local/bin
 COPY _output/bin/tink/$TARGETOS-$TARGETARCH/tink-server /usr/bin/tink-server


### PR DESCRIPTION
*Description of changes:*
`tink-server` requires wget to perform health checks.
`tink-cli` needs sleep to be a long running container.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
