### PR TITLE
Using kernel version 5.10.57

### DIFF
--- a/projects/tinkerbell/hook/Makefile
+++ b/projects/tinkerbell/hook/Makefile
@@ -48,7 +48,7 @@ tink-docker/images/%: BASE_IMAGE_NAME=eks-distro-minimal-base-glibc
 
 # Currently the kernel image is being built off upstream.
 # TODO: Setup a build environment to build the linux kernel.
-kernel/images/%: BASE_IMAGE=quay.io/tinkerbell/hook-kernel:5.10.11
+kernel/images/%: BASE_IMAGE=quay.io/tinkerbell/hook-kernel:5.10.57
 
 s3-artifacts: $(CREATE_HOOK_FILES)
 

--- a/projects/tinkerbell/hook/README.md
+++ b/projects/tinkerbell/hook/README.md
@@ -16,6 +16,6 @@
 
 ### Development
 1. The project consists of 3 images. `bootkit`, `tink-docker` and `kernel`.
-1. For `kernel`, the image builds off upstream. The `hook` project uses the kernel.org [linux 5.10.11 kernel](https://mirrors.edge.kernel.org/pub/linux/kernel/v5.x/linux-5.10.11.tar.xz) to build an image.
+1. For `kernel`, the image builds off upstream. The `hook` project uses the kernel.org [linux 5.10.57 kernel](https://mirrors.edge.kernel.org/pub/linux/kernel/v5.x/linux-5.10.57.tar.xz) to build an image.
 1. For building the in-memory OSIE files, `hook` uses [linuxkit](https://github.com/linuxkit/linuxkit). `Linuxkit build` expects the project images to be present in the repository represented by `IMAGE_REPO` variable.
 1. To build locally, we suggest using a local registry and setting `IMAGE_REPO` variable.


### PR DESCRIPTION
*Description of changes:*
The release on `tinkerbell/hook` uses kernel `5.10.57`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
