### PR TITLE
Adding back dependency pcre for wget

### DIFF
--- a/projects/tinkerbell/tink/docker/linux/tink-server/Dockerfile
+++ b/projects/tinkerbell/tink/docker/linux/tink-server/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /newroot
 
 RUN set -x && \
     clean_install "wget" && \
-    remove_package "bash coreutils gawk info sed grep pcre" && \
+    remove_package "bash coreutils gawk info sed grep" && \
     cleanup "wget"
 
 FROM $BASE_IMAGE


### PR DESCRIPTION
*Description of changes:*
Looks like wget needed `pcre` to run.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
