### PR TITLE
Add make target to check for project paths existence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,3 +101,11 @@ stop-buildkit-and-registry:
 .PHONY: generate
 generate:
 	build/lib/generate_projects_list.sh $(BASE_DIRECTORY)
+
+.PHONY: check-project-path-exists
+check-project-path-exists:
+	@if ! stat $(PROJECT_PATH) &> /dev/null; then \
+		echo "false"; \
+	else \
+		echo "true"; \
+	fi

--- a/projects/apache/cloudstack-cloudmonkey/buildspec.yml
+++ b/projects/apache/cloudstack-cloudmonkey/buildspec.yml
@@ -7,7 +7,7 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi
 
   post_build:
     commands:

--- a/projects/aws/bottlerocket-bootstrap/buildspec.yml
+++ b/projects/aws/bottlerocket-bootstrap/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/aws/cluster-api-provider-cloudstack/buildspec.yml
+++ b/projects/aws/cluster-api-provider-cloudstack/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/aws/eks-anywhere-build-tooling/buildspec.yml
+++ b/projects/aws/eks-anywhere-build-tooling/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/aws/eks-anywhere-test/buildspec.yml
+++ b/projects/aws/eks-anywhere-test/buildspec.yml
@@ -11,4 +11,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/aws/eks-anywhere/buildspec.yml
+++ b/projects/aws/eks-anywhere/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/brancz/kube-rbac-proxy/buildspec.yml
+++ b/projects/brancz/kube-rbac-proxy/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/cilium/cilium/buildspec.yml
+++ b/projects/cilium/cilium/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/cloudflare/cfssl/buildspec.yml
+++ b/projects/cloudflare/cfssl/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/fluxcd/flux2/buildspec.yml
+++ b/projects/fluxcd/flux2/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/fluxcd/helm-controller/buildspec.yml
+++ b/projects/fluxcd/helm-controller/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/fluxcd/kustomize-controller/buildspec.yml
+++ b/projects/fluxcd/kustomize-controller/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/fluxcd/notification-controller/buildspec.yml
+++ b/projects/fluxcd/notification-controller/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/fluxcd/source-controller/buildspec.yml
+++ b/projects/fluxcd/source-controller/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/grpc-ecosystem/grpc-health-probe/buildspec.yml
+++ b/projects/grpc-ecosystem/grpc-health-probe/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/helm/helm/buildspec.yml
+++ b/projects/helm/helm/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/jetstack/cert-manager/buildspec.yml
+++ b/projects/jetstack/cert-manager/buildspec.yml
@@ -11,4 +11,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/kubernetes-sigs/cluster-api-provider-aws/buildspec.yml
+++ b/projects/kubernetes-sigs/cluster-api-provider-aws/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/kubernetes-sigs/cluster-api-provider-vsphere/buildspec.yml
+++ b/projects/kubernetes-sigs/cluster-api-provider-vsphere/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/kubernetes-sigs/cluster-api/buildspec.yml
+++ b/projects/kubernetes-sigs/cluster-api/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/kubernetes-sigs/cri-tools/buildspec.yml
+++ b/projects/kubernetes-sigs/cri-tools/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/kubernetes-sigs/etcdadm/buildspec.yml
+++ b/projects/kubernetes-sigs/etcdadm/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/kubernetes-sigs/kind/buildspec.yml
+++ b/projects/kubernetes-sigs/kind/buildspec.yml
@@ -8,4 +8,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/kubernetes-sigs/vsphere-csi-driver/buildspec.yml
+++ b/projects/kubernetes-sigs/vsphere-csi-driver/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/kubernetes/cloud-provider-vsphere/buildspec.yml
+++ b/projects/kubernetes/cloud-provider-vsphere/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/mrajashree/etcdadm-bootstrap-provider/buildspec.yml
+++ b/projects/mrajashree/etcdadm-bootstrap-provider/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/mrajashree/etcdadm-controller/buildspec.yml
+++ b/projects/mrajashree/etcdadm-controller/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/plunder-app/kube-vip/buildspec.yml
+++ b/projects/plunder-app/kube-vip/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/rancher/local-path-provisioner/buildspec.yml
+++ b/projects/rancher/local-path-provisioner/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/redis/redis/buildspec.yml
+++ b/projects/redis/redis/buildspec.yml
@@ -11,4 +11,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/replicatedhq/troubleshoot/buildspec.yml
+++ b/projects/replicatedhq/troubleshoot/buildspec.yml
@@ -7,7 +7,7 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi
 
   post_build:
     commands:

--- a/projects/tinkerbell/boots/buildspec.yml
+++ b/projects/tinkerbell/boots/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/buildspec.yml
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/tinkerbell/hegel/buildspec.yml
+++ b/projects/tinkerbell/hegel/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/tinkerbell/hook/buildspec.yml
+++ b/projects/tinkerbell/hook/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/tinkerbell/hub/buildspec.yml
+++ b/projects/tinkerbell/hub/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/tinkerbell/pbnj/buildspec.yml
+++ b/projects/tinkerbell/pbnj/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/tinkerbell/tink/buildspec.yml
+++ b/projects/tinkerbell/tink/buildspec.yml
@@ -7,4 +7,4 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/vmware/govmomi/buildspec.yml
+++ b/projects/vmware/govmomi/buildspec.yml
@@ -7,7 +7,7 @@ phases:
 
   build:
     commands:
-    - make release -C $PROJECT_PATH
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi
 
   post_build:
     commands:


### PR DESCRIPTION
Add make target to check if the project path exists before triggering the release make target.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
