### PR TITLE
Add common buildspec for all projects

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,14 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+    - ./build/lib/setup.sh
+
+  build:
+    commands:
+    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi
+
+  post_build:
+    commands:
+    - make upload-artifacts -C $PROJECT_PATH


### PR DESCRIPTION
Each project folder has a buildspec, but they're all identical. So we should replace them with a single one at root. This change will be done as a blue-green deployment.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
