### PR TITLE
Revert "remove duplicated validate-checksums target (#460)"

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -228,8 +228,8 @@ GIT_DEPS_DIR?=$(OUTPUT_DIR)/gitdependencies
 ####################################################
 
 #################### TARGETS FOR OVERRIDING ########
-BUILD_TARGETS?=checksums $(if $(IMAGE_NAMES),local-images,) attribution $(if $(filter true,$(HAS_S3_ARTIFACTS)),upload-artifacts,) attribution-pr
-RELEASE_TARGETS?=checksums $(if $(IMAGE_NAMES),images,) $(if $(filter true,$(HAS_S3_ARTIFACTS)),upload-artifacts,)
+BUILD_TARGETS?=validate-checksums $(if $(IMAGE_NAMES),local-images,) attribution $(if $(filter true,$(HAS_S3_ARTIFACTS)),upload-artifacts,) attribution-pr
+RELEASE_TARGETS?=validate-checksums $(if $(IMAGE_NAMES),images,) $(if $(filter true,$(HAS_S3_ARTIFACTS)),upload-artifacts,)
 ####################################################
 
 define BUILDCTL
@@ -432,7 +432,13 @@ s3-artifacts: tarballs
 .PHONY: checksums
 checksums: $(BINARY_TARGETS)
 ifneq ($(strip $(BINARY_TARGETS)),)
-	$(BASE_DIRECTORY)/build/lib/update_checksums.sh $(MAKE_ROOT) $(PROJECT_ROOT) $(MAKE_ROOT)/$(OUTPUT_BIN_DIR) $(FAKE_ARM_BINARIES_FOR_VALIDATION)
+	$(BASE_DIRECTORY)/build/lib/update_checksums.sh $(MAKE_ROOT) $(PROJECT_ROOT) $(MAKE_ROOT)/$(OUTPUT_BIN_DIR)
+endif
+
+.PHONY: validate-checksums
+validate-checksums: $(BINARY_TARGETS)
+ifneq ($(strip $(BINARY_TARGETS)),)
+	$(BASE_DIRECTORY)/build/lib/validate_checksums.sh $(MAKE_ROOT) $(PROJECT_ROOT) $(MAKE_ROOT)/$(OUTPUT_BIN_DIR) $(FAKE_ARM_BINARIES_FOR_VALIDATION)
 endif
 
 #### Image Helpers

--- a/projects/aws/bottlerocket-bootstrap/Help.mk
+++ b/projects/aws/bottlerocket-bootstrap/Help.mk
@@ -42,6 +42,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images `
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/aws/cluster-api-provider-aws-snow/Help.mk
+++ b/projects/aws/cluster-api-provider-aws-snow/Help.mk
@@ -7,7 +7,7 @@
 
 
 ##@ GIT/Repo Targets
-clone-repo:  ## Clone upstream `cluster-api-provider-snow`
+clone-repo:  ## Clone upstream `cluster-api-provider-aws-snow`
 checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
 
 ##@ Artifact Targets
@@ -24,6 +24,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums  attribution upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums  upload-artifacts`
+build: ## Called via prow presubmit, calls `validate-checksums  attribution upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums  upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/brancz/kube-rbac-proxy/Help.mk
+++ b/projects/brancz/kube-rbac-proxy/Help.mk
@@ -39,6 +39,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images `
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/cloudflare/cfssl/Help.mk
+++ b/projects/cloudflare/cfssl/Help.mk
@@ -58,6 +58,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/fluxcd/flux2/Help.mk
+++ b/projects/fluxcd/flux2/Help.mk
@@ -56,6 +56,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/fluxcd/helm-controller/Help.mk
+++ b/projects/fluxcd/helm-controller/Help.mk
@@ -39,6 +39,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images `
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/fluxcd/kustomize-controller/Help.mk
+++ b/projects/fluxcd/kustomize-controller/Help.mk
@@ -39,6 +39,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images `
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/fluxcd/notification-controller/Help.mk
+++ b/projects/fluxcd/notification-controller/Help.mk
@@ -39,6 +39,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images `
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/fluxcd/source-controller/Help.mk
+++ b/projects/fluxcd/source-controller/Help.mk
@@ -39,6 +39,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images `
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/helm/helm/Help.mk
+++ b/projects/helm/helm/Help.mk
@@ -38,6 +38,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums  attribution upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums  upload-artifacts`
+build: ## Called via prow presubmit, calls `validate-checksums  attribution upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums  upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/jetstack/cert-manager/Help.mk
+++ b/projects/jetstack/cert-manager/Help.mk
@@ -62,6 +62,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/cluster-api-provider-aws/Help.mk
+++ b/projects/kubernetes-sigs/cluster-api-provider-aws/Help.mk
@@ -54,6 +54,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/cluster-api-provider-vsphere/Help.mk
+++ b/projects/kubernetes-sigs/cluster-api-provider-vsphere/Help.mk
@@ -45,6 +45,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/cluster-api/Help.mk
+++ b/projects/kubernetes-sigs/cluster-api/Help.mk
@@ -63,6 +63,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/cri-tools/Help.mk
+++ b/projects/kubernetes-sigs/cri-tools/Help.mk
@@ -40,6 +40,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums  attribution upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums  upload-artifacts`
+build: ## Called via prow presubmit, calls `validate-checksums  attribution upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums  upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/etcdadm/Help.mk
+++ b/projects/kubernetes-sigs/etcdadm/Help.mk
@@ -39,6 +39,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums  attribution upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums  upload-artifacts`
+build: ## Called via prow presubmit, calls `validate-checksums  attribution upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums  upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/image-builder/Help.mk
+++ b/projects/kubernetes-sigs/image-builder/Help.mk
@@ -26,6 +26,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `release-raw-ubuntu-2004 image-builder/images/capi/output/fake-ubuntu.gz /home/prow/go/src/github.com/aws/eks-anywhere-build-tooling/projects/kubernetes-sigs/image-builder/_output/tar/1-21/raw/ubuntu.gz upload-artifacts-raw build-ami-ubuntu-2004 setup-packer-configs-ova release-ova-bottlerocket image-builder/images/capi/output/fake-ubuntu.ova /home/prow/go/src/github.com/aws/eks-anywhere-build-tooling/projects/kubernetes-sigs/image-builder/_output/tar/1-21/ova/ubuntu.ova /home/prow/go/src/github.com/aws/eks-anywhere-build-tooling/projects/kubernetes-sigs/image-builder/_output/tar/1-21/ova/bottlerocket.ova upload-artifacts-ova`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images `
+build: ## Called via prow presubmit, calls `release-raw-ubuntu-2004 image-builder/images/capi/output/fake-ubuntu.gz /Volumes/workplace/eks-anywhere-build-tooling/projects/kubernetes-sigs/image-builder/_output/tar/1-21/raw/ubuntu.gz upload-artifacts-raw build-ami-ubuntu-2004 setup-packer-configs-ova release-ova-bottlerocket image-builder/images/capi/output/fake-ubuntu.ova /Volumes/workplace/eks-anywhere-build-tooling/projects/kubernetes-sigs/image-builder/_output/tar/1-21/ova/ubuntu.ova /Volumes/workplace/eks-anywhere-build-tooling/projects/kubernetes-sigs/image-builder/_output/tar/1-21/ova/bottlerocket.ova upload-artifacts-ova`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/kind/Help.mk
+++ b/projects/kubernetes-sigs/kind/Help.mk
@@ -67,6 +67,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/vsphere-csi-driver/Help.mk
+++ b/projects/kubernetes-sigs/vsphere-csi-driver/Help.mk
@@ -43,6 +43,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images `
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/kubernetes/cloud-provider-vsphere/Help.mk
+++ b/projects/kubernetes/cloud-provider-vsphere/Help.mk
@@ -39,6 +39,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images `
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/mrajashree/etcdadm-bootstrap-provider/Help.mk
+++ b/projects/mrajashree/etcdadm-bootstrap-provider/Help.mk
@@ -44,6 +44,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/mrajashree/etcdadm-controller/Help.mk
+++ b/projects/mrajashree/etcdadm-controller/Help.mk
@@ -44,6 +44,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/plunder-app/kube-vip/Help.mk
+++ b/projects/plunder-app/kube-vip/Help.mk
@@ -39,6 +39,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images `
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/rancher/local-path-provisioner/Help.mk
+++ b/projects/rancher/local-path-provisioner/Help.mk
@@ -39,6 +39,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images `
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/replicatedhq/troubleshoot/Help.mk
+++ b/projects/replicatedhq/troubleshoot/Help.mk
@@ -41,6 +41,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums  attribution upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums  upload-artifacts`
+build: ## Called via prow presubmit, calls `validate-checksums  attribution upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums  upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/tinkerbell/boots/Help.mk
+++ b/projects/tinkerbell/boots/Help.mk
@@ -40,6 +40,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images `
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/Help.mk
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/Help.mk
@@ -45,6 +45,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/tinkerbell/hegel/Help.mk
+++ b/projects/tinkerbell/hegel/Help.mk
@@ -39,6 +39,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images `
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/tinkerbell/hook/Help.mk
+++ b/projects/tinkerbell/hook/Help.mk
@@ -50,6 +50,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/tinkerbell/hub/Help.mk
+++ b/projects/tinkerbell/hub/Help.mk
@@ -55,6 +55,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images `
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/tinkerbell/pbnj/Help.mk
+++ b/projects/tinkerbell/pbnj/Help.mk
@@ -43,6 +43,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images `
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/tinkerbell/tink/Help.mk
+++ b/projects/tinkerbell/tink/Help.mk
@@ -57,6 +57,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums local-images attribution upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `validate-checksums local-images attribution upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/vmware/govmomi/Help.mk
+++ b/projects/vmware/govmomi/Help.mk
@@ -38,6 +38,6 @@ help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `checksums  attribution upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `checksums  upload-artifacts`
+build: ## Called via prow presubmit, calls `validate-checksums  attribution upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `validate-checksums  upload-artifacts`
 ########### END GENERATED ###########################


### PR DESCRIPTION
This reverts commit dd58a3621dff267715f8609e81e675fc50c405f2.

*Issue #, if available:*

*Description of changes:*
My bad, missed the fact that it was two different scripts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
