### PR TITLE
Add image pull secrets to CAPAS controller deployment

### DIFF
--- a/projects/aws/cluster-api-provider-aws-snow/manifests/infrastructure-components.yaml
+++ b/projects/aws/cluster-api-provider-aws-snow/manifests/infrastructure-components.yaml
@@ -1347,6 +1347,8 @@ spec:
         ports:
         - containerPort: 8443
           name: https
+      imagePullSecrets:
+      - name: ${ECR_CREDS}
       serviceAccountName: capas-controller-manager
       terminationGracePeriodSeconds: 10
       volumes:


### PR DESCRIPTION
This is a (hopefully) temporary workaround till we have public images for Snow.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
