### PR TITLE
Remove upload-artifacts phase from buildspec

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -8,7 +8,3 @@ phases:
   build:
     commands:
     - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi
-
-  post_build:
-    commands:
-    - make upload-artifacts -C $PROJECT_PATH


### PR DESCRIPTION
This is handled by the `release` target now and doesn't need to be a separate phase.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
