### PR TITLE
Remove ECR public env var from buildspecs

### DIFF
--- a/projects/aws/eks-anywhere-test/buildspec.yml
+++ b/projects/aws/eks-anywhere-test/buildspec.yml
@@ -1,9 +1,5 @@
 version: 0.2
 
-env:
-  variables:
-    IMAGE_REPO: public.ecr.aws/l0g8r8j6
-
 phases:
   pre_build:
     commands:

--- a/projects/jetstack/cert-manager/buildspec.yml
+++ b/projects/jetstack/cert-manager/buildspec.yml
@@ -1,9 +1,5 @@
 version: 0.2
 
-env:
-  variables:
-    IMAGE_REPO: public.ecr.aws/l0g8r8j6
-    
 phases:
   pre_build:
     commands:

--- a/projects/redis/redis/buildspec.yml
+++ b/projects/redis/redis/buildspec.yml
@@ -1,9 +1,5 @@
 version: 0.2
 
-env:
-  variables:
-    IMAGE_REPO: public.ecr.aws/l0g8r8j6
-    
 phases:
   pre_build:
     commands:


### PR DESCRIPTION
We will instead use a promotion process to push from private to public ECR. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
