### PR TITLE
remove openssl install, it's already on the base image for codebuild

### DIFF
--- a/release/staging-build.yml
+++ b/release/staging-build.yml
@@ -11,13 +11,6 @@ env:
     VSPHERE_CONNECTION_DATA: "vsphere_ci_beta_connection:vsphere_connection_data"
 
 phases:
-  # On AL2, the Cargo build system requires the openssl-devel package
-  # for installing OpenSSL libraries
-  install:
-    run-as: root
-    commands:
-      - yum install -y openssl-devel
-
   pre_build:
     run-as: root
     commands:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
this caused the staging release to fail; removing as it should not be needed


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
