### PR TITLE
Break up helm build into components

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -468,10 +468,12 @@ endif
 helm/build: $(OUTPUT_DIR)/ATTRIBUTION.txt
 helm/build: $(if $(filter true,$(REPO_NO_CLONE)),,$(HELM_GIT_CHECKOUT_TARGET))
 helm/build: $(if $(wildcard $(MAKE_ROOT)/helm/patches),$(HELM_GIT_PATCH_TARGET),)
+	$(BUILD_LIB)/helm_copy.sh $(HELM_SOURCE_REPOSITORY) $(HELM_DESTINATION_REPOSITORY) $(HELM_DIRECTORY) $(OUTPUT_DIR)
 	HELM_REGISTRY=$(IMAGE_REPO) \
 	IMAGE_TAG=$(IMAGE_TAG) \
 	$(HELM_ADDITIONAL_KEY_VALUES) \
-	$(BUILD_LIB)/helm_build.sh $(HELM_SOURCE_REPOSITORY) $(HELM_DESTINATION_REPOSITORY) $(HELM_DIRECTORY) $(OUTPUT_DIR)
+	$(BUILD_LIB)/helm_replace.sh $(HELM_DESTINATION_REPOSITORY) $(OUTPUT_DIR)
+	$(BUILD_LIB)/helm_build.sh $(OUTPUT_DIR) $(HELM_DESTINATION_REPOSITORY)
 
 # Build helm chart and push to registry defined in IMAGE_REPO.
 .PHONY: helm/push

--- a/build/lib/helm_copy.sh
+++ b/build/lib/helm_copy.sh
@@ -18,12 +18,21 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-OUTPUT_DIR="${1?First arguement is output directory}"
+HELM_SOURCE_REPOSITORY="${1?First argument is helm source repository}"
 HELM_DESTINATION_REPOSITORY="${2?Second argument is helm destination repository}"
+HELM_DIRECTORY="${3?Third argument is helm directory}"
+OUTPUT_DIR="${4?Fouth arguement is output directory}"
+
 CHART_NAME=$(basename ${HELM_DESTINATION_REPOSITORY})
+DEST_DIR=${OUTPUT_DIR}/helm/${CHART_NAME}
+SOURCE_DIR=$(basename ${HELM_SOURCE_REPOSITORY})/${HELM_DIRECTORY}/.
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_ROOT}/common.sh"
 
 #
-# Build
+# Copy
 #
-cd ${OUTPUT_DIR}/helm
-helm package "${CHART_NAME}"
+mkdir -p ${DEST_DIR}
+cp -r ${SOURCE_DIR} ${DEST_DIR}
+build::non-golang::copy_licenses ${HELM_SOURCE_REPOSITORY} $DEST_DIR/LICENSES/github.com/${HELM_SOURCE_REPOSITORY}

--- a/build/lib/helm_replace.sh
+++ b/build/lib/helm_replace.sh
@@ -17,13 +17,26 @@ set -x
 set -o errexit
 set -o nounset
 set -o pipefail
+# HELM_REGISTRY
+# IMAGE_TAG
+# HELM_ADDITIONAL_KEY_VALUES
 
-OUTPUT_DIR="${1?First arguement is output directory}"
-HELM_DESTINATION_REPOSITORY="${2?Second argument is helm destination repository}"
+HELM_DESTINATION_REPOSITORY="${1?First argument is helm destination repository}"
+OUTPUT_DIR="${2?Second arguement is output directory}"
+
 CHART_NAME=$(basename ${HELM_DESTINATION_REPOSITORY})
+DEST_DIR=${OUTPUT_DIR}/helm/${CHART_NAME}
 
 #
-# Build
+# Search and replace
 #
-cd ${OUTPUT_DIR}/helm
-helm package "${CHART_NAME}"
+SEDFILE=${OUTPUT_DIR}/helm/sedfile
+envsubst <helm/sedfile.template >${SEDFILE}
+TEMPLATE_DIR=helm/templates
+cat helm/files.txt | while read SOURCE_FILE DESTINATION_FILE
+do
+  TMPFILE=/tmp/$(basename ${SOURCE_FILE})
+  cp ${SOURCE_FILE} ${TMPFILE}
+  sed -f ${SEDFILE} ${TMPFILE} >${DEST_DIR}/${DESTINATION_FILE}
+  rm -f ${TMPFILE}
+done


### PR DESCRIPTION
I created this PR for two reasons

1. To address this concern https://github.com/aws/eks-anywhere-build-tooling/pull/440/files#r809427929 too many parameters to the helm_build.sh file. This doesn't completely resolve that, but it is a step to resolve that.
2. Break up the steps of helm/build so helm/push can get the shasums of the container images and helm/build can skip that step.