### PR TITLE
Add etcdadm patch to accept multiple endpoints

### DIFF
--- a/projects/kubernetes-sigs/etcdadm/CHECKSUMS
+++ b/projects/kubernetes-sigs/etcdadm/CHECKSUMS
@@ -1,2 +1,2 @@
-2353653927faf78c59b6a050fdea96aa7a3c9a5dcf17e5c8016e6b98849b5c20  _output/bin/etcdadm/linux-amd64/etcdadm
-edde611471a9b7653f5263e7e821bd931117222433e101b43056ffeec7c323dd  _output/bin/etcdadm/linux-arm64/etcdadm
+ef422ae3359cc4c0c69adc0b9299d780fc538db6f85c7479803d5d3c9d12e5d8  _output/bin/etcdadm/linux-amd64/etcdadm
+7161b11862564176ab76b5dca62d8ee7a042000dd0d0b6749479ae90b9f728ea  _output/bin/etcdadm/linux-arm64/etcdadm

--- a/projects/kubernetes-sigs/etcdadm/patches/0012-Allow-using-multiple-endpoints-for-etcd-client.patch
+++ b/projects/kubernetes-sigs/etcdadm/patches/0012-Allow-using-multiple-endpoints-for-etcd-client.patch
@@ -1,0 +1,144 @@
+From 39ded007b641418818b5fad71c746c74e768524a Mon Sep 17 00:00:00 2001
+From: Rajashree Mandaogane <mandaor@amazon.com>
+Date: Tue, 1 Mar 2022 21:09:22 -0800
+Subject: [PATCH] Allow using multiple endpoints for etcd client
+
+The etcdadm init command creates a single member etcd cluster. Other
+members can be added to the cluster using the etcdadm join command with
+the endpoint of the first member.
+If this first member gets deleted, we need to decide on a different endpoint
+to be used for the join command for future members. Instead, once the
+cluster is created, we should be able to use endpoints of all members with the
+join command.
+This endpoint only gets used to create an etcd client for listing/adding members.
+This commit modifies the ClientForEndpoint method to use all
+endpoints that are passed in. This way the etcdadm join command can accept
+a comma separated list of etcd members.
+---
+ apis/config.go |  2 +-
+ cmd/info.go    |  2 +-
+ cmd/init.go    |  2 +-
+ cmd/join.go    | 14 +++++++++-----
+ cmd/reset.go   |  2 +-
+ etcd/etcd.go   |  6 +++---
+ 6 files changed, 16 insertions(+), 12 deletions(-)
+
+diff --git a/apis/config.go b/apis/config.go
+index 7de11c5d..83a5775a 100644
+--- a/apis/config.go
++++ b/apis/config.go
+@@ -94,7 +94,7 @@ type EtcdAdmConfig struct {
+ 
+ 	InitSystem InitSystem
+ 
+-	Endpoint string
++	Endpoints []string
+ 
+ 	// CipherSuites is a list of supported TLS cipher suites, mapping to the --cipher-suites flag.
+ 	// Default is empty, which means that they will be auto-populated by Go.
+diff --git a/cmd/info.go b/cmd/info.go
+index 73f25adb..cf847009 100644
+--- a/cmd/info.go
++++ b/cmd/info.go
+@@ -38,7 +38,7 @@ var infoCmd = &cobra.Command{
+ 			log.Fatalf("[defaults] Error: %s", err)
+ 		}
+ 
+-		client, err := etcd.ClientForEndpoint(etcdAdmConfig.LoopbackClientURL.String(), &etcdAdmConfig)
++		client, err := etcd.ClientForEndpoints([]string{etcdAdmConfig.LoopbackClientURL.String()}, &etcdAdmConfig)
+ 		if err != nil {
+ 			log.Fatalf("[membership] Error requesting member information: %s", err)
+ 		}
+diff --git a/cmd/init.go b/cmd/init.go
+index 2fe20179..a9da0f68 100644
+--- a/cmd/init.go
++++ b/cmd/init.go
+@@ -203,7 +203,7 @@ func healthcheck() phase {
+ 		phaseName: "health",
+ 		runFunc: func(in *phaseInput) error {
+ 			log.Println("[health] Checking local etcd endpoint health")
+-			client, err := etcd.ClientForEndpoint(in.etcdAdmConfig.LoopbackClientURL.String(), in.etcdAdmConfig)
++			client, err := etcd.ClientForEndpoints([]string{in.etcdAdmConfig.LoopbackClientURL.String()}, in.etcdAdmConfig)
+ 			if err != nil {
+ 				return fmt.Errorf("error creating health endpoint client: %w", err)
+ 			}
+diff --git a/cmd/join.go b/cmd/join.go
+index 97843998..fb6f15e3 100644
+--- a/cmd/join.go
++++ b/cmd/join.go
+@@ -21,6 +21,7 @@ import (
+ 	"fmt"
+ 	"net/url"
+ 	"os"
++	"strings"
+ 
+ 	log "sigs.k8s.io/etcdadm/pkg/logrus"
+ 
+@@ -86,11 +87,13 @@ func newJoinRunner() *runner {
+ }
+ 
+ func joinPhasesSetup(cmd *cobra.Command, args []string) (*phaseInput, error) {
+-	endpoint := args[0]
+-	if _, err := url.Parse(endpoint); err != nil {
+-		return nil, fmt.Errorf("endpoint %q must be a valid URL: %s", endpoint, err)
++	endpoints := strings.Split(args[0], ",")
++	for _, endpoint := range endpoints {
++		if _, err := url.ParseRequestURI(endpoint); err != nil {
++			return nil, fmt.Errorf("endpoint %q must be a valid URL: %s", endpoint, err)
++		}
+ 	}
+-	etcdAdmConfig.Endpoint = endpoint
++	etcdAdmConfig.Endpoints = endpoints
+ 
+ 	apis.SetDefaults(&etcdAdmConfig)
+ 	if err := apis.SetJoinDynamicDefaults(&etcdAdmConfig); err != nil {
+@@ -135,7 +138,8 @@ func membership() phase {
+ 			var localMember *etcdserverpb.Member
+ 			var members []*etcdserverpb.Member
+ 			log.Println("[membership] Checking if this member was added")
+-			client, err := etcd.ClientForEndpoint(in.etcdAdmConfig.Endpoint, in.etcdAdmConfig)
++			log.Printf("[membership] Generating etcd client with endpoints %s", in.etcdAdmConfig.Endpoints)
++			client, err := etcd.ClientForEndpoints(in.etcdAdmConfig.Endpoints, in.etcdAdmConfig)
+ 			if err != nil {
+ 				return fmt.Errorf("error checking membership: %v", err)
+ 			}
+diff --git a/cmd/reset.go b/cmd/reset.go
+index b345c52b..7ada9e11 100644
+--- a/cmd/reset.go
++++ b/cmd/reset.go
+@@ -62,7 +62,7 @@ var resetCmd = &cobra.Command{
+ 			if !skipRemoveMember {
+ 				var localMember *etcdserverpb.Member
+ 				log.Println("[membership] Checking if this member was removed")
+-				client, err := etcd.ClientForEndpoint(etcdAdmConfig.LoopbackClientURL.String(), &etcdAdmConfig)
++				client, err := etcd.ClientForEndpoints([]string{etcdAdmConfig.LoopbackClientURL.String()}, &etcdAdmConfig)
+ 				if err != nil {
+ 					log.Fatalf("[membership] Error checking membership: %v", err)
+ 				}
+diff --git a/etcd/etcd.go b/etcd/etcd.go
+index ba48826f..f4f85503 100644
+--- a/etcd/etcd.go
++++ b/etcd/etcd.go
+@@ -29,8 +29,8 @@ import (
+ 	"sigs.k8s.io/etcdadm/apis"
+ )
+ 
+-// ClientForEndpoint returns an etcd client that will use the given etcd endpoint.
+-func ClientForEndpoint(endpoint string, cfg *apis.EtcdAdmConfig) (*clientv3.Client, error) {
++// ClientForEndpoints returns an etcd client that will use the given etcd endpoints.
++func ClientForEndpoints(endpoints []string, cfg *apis.EtcdAdmConfig) (*clientv3.Client, error) {
+ 	tlsInfo := transport.TLSInfo{
+ 		CertFile:      cfg.EtcdctlCertFile,
+ 		KeyFile:       cfg.EtcdctlKeyFile,
+@@ -42,7 +42,7 @@ func ClientForEndpoint(endpoint string, cfg *apis.EtcdAdmConfig) (*clientv3.Clie
+ 	}
+ 
+ 	cli, err := clientv3.New(clientv3.Config{
+-		Endpoints:   []string{endpoint},
++		Endpoints:   endpoints,
+ 		DialTimeout: 5 * time.Second,
+ 		TLS:         tlsConfig,
+ 	})
+-- 
+2.30.1
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
During etcd cluster creation, etcdadm first creates a single member etcd cluster through the `etcdadm init` command, and then the rest of the members can join the cluster using the `etcdadm join <endpoint>` command.
If this first member gets deleted, we need to decide on a new endpoint to be used for the join command. Instead if we pass in all etcd members to the join command we won't need to check if one of them is unavailable.
This endpoint is only used within etcdadm to generate the etcd client. Etcd client can be generated for multiple endpoints. This commit modifies the etcd client generation to use as many endpoints are passed in. 

*Testing*
Built etcdadm binary, and used it through the etcdadm-bootstrap-provider's logic to [install a different etcdadm binary instead of using the baked in etcdadm](https://github.com/mrajashree/etcdadm-bootstrap-provider/blob/v1beta1/controllers/etcdadmconfig_controller.go#L247). Verified that the init and join commands worked and the logs contained the addition log added in this PR.
Tested EKS-A cluster creation, and tested deletion of the machine/VM corresponding to the first etcd leader and saw it gets replaced.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
