### PR TITLE
kind: fix kubeadm version validation

### DIFF
--- a/projects/kubernetes-sigs/kind/build/build-kind-node-image.sh
+++ b/projects/kubernetes-sigs/kind/build/build-kind-node-image.sh
@@ -46,7 +46,7 @@ function build::kind::build_node_image(){
 
 function build::kind::validate_versions(){
     local -r container_id=$1
-    local -r eksd_tag="$KUBE_VERSION-eks-$EKSD_RELEASE_BRANCH"
+    local -r eksd_tag="$KUBE_VERSION-eks-" # there is a commit hash at the end
     # We expect certain versions to be in the kind base/node images since we end up replacing them
     # validate they haven't changed
     if ! docker exec -i $container_id grep "image: $KINDNETD_IMAGE_TAG"  /kind/manifests/default-cni.yaml > /dev/null 2>&1; then


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In the newest eks-d releases the version information that is embedded into the binaries has changed slightly.  This should cover both the older version style and the new.

/hold

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
