### PR TITLE
eksd: bump to 1.22 dev release 6

### DIFF
--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -12,7 +12,7 @@ releases:
   number: 9
   kubeVersion: v1.21.5
 - branch: 1-22
-  number: 5
+  number: 6
   kubeVersion: v1.22.6
   dev: true
 latest: 1-21


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Should be the last dev release of 1.22

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
