### PR TITLE
Increase eks-d AMI sice to 25GB

### DIFF
--- a/projects/kubernetes-sigs/image-builder/packer/ami/packer.json
+++ b/projects/kubernetes-sigs/image-builder/packer/ami/packer.json
@@ -5,5 +5,6 @@
   "snapshot_groups": "",
   "custom_role": "true",
   "custom_role_names": "{{env `BUILDER_ROOT`}}/ansible/roles/load_additional_files",
-  "ansible_extra_vars": "@{{env `BUILDER_ROOT`}}/packer/ami/ansible_extra_vars.yaml"
+  "ansible_extra_vars": "@{{env `BUILDER_ROOT`}}/packer/ami/ansible_extra_vars.yaml",
+  "volume_size": "25"
 }


### PR DESCRIPTION
*Description of changes:*
Until we don't have the option to dynamically set the VM disk size, this
is the only way to have enough disk space to download container images.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
