### PR TITLE
Local RHEL Image Builder for Qemu

### DIFF
--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -22,8 +22,6 @@ VSPHERE_CONNECTION_DATA?={}
 # Aws accounts to share built AMI with
 DEV_ACCOUNTS?=
 
-ARTIFACTS_BUCKET?=
-
 PACKER_AMI_VAR_FILES=$(MAKE_ROOT)/packer/ami/packer.json
 PACKER_AMI_SHARE_FILE=$(MAKE_ROOT)/packer/ami/share-ami.json
 PACKER_AMI_VAR_FILES+=$(PACKER_AMI_SHARE_FILE)

--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -22,7 +22,7 @@ VSPHERE_CONNECTION_DATA?={}
 # Aws accounts to share built AMI with
 DEV_ACCOUNTS?=
 
-ARTIFACTS_BUCKET?=s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f
+ARTIFACTS_BUCKET?=
 
 PACKER_AMI_VAR_FILES=$(MAKE_ROOT)/packer/ami/packer.json
 PACKER_AMI_SHARE_FILE=$(MAKE_ROOT)/packer/ami/share-ami.json
@@ -175,13 +175,9 @@ release-raw-ubuntu-2004: deps-raw setup-packer-configs-raw
 	build/build_raw_image.sh $(BASE_DIRECTORY) $(PROJECT_PATH) $(IMAGE_BUILDER_DIR) "$(PACKER_VAR_FILES)" $(RAW_IMAGE_BUILD_AMI) $(RAW_IMAGE_BUILD_INSTANCE_TYPE) $(RAW_IMAGE_BUILD_KEY_NAME)
 
 .PHONY: build-qemu-rhel-local
-build-qemu-rhel-local: deps-qemu setup-packer-config-qemu
-build-qemu-rhel-local: CHECKSUM=$(sha256sum $(BASE_IMAGE))
-build-qemu-rhel-local: QEMU_CONFIG_FILE=$(IMAGE_BUILDER_DIR)/packer/qemu/qemu-rhel-8.json
-	cat <<< $(jq '.iso_url="$(BASE_IMAGE)"' $(QEMU_CONFIG_FILE)) > $(QEMU_CONFIG_FILE)
-	cat <<< $(jq '.iso_checksum="$(CHECKSUM)"' $(QEMU_CONFIG_FILE)) > $(QEMU_CONFIG_FILE)
-	PACKER_FLAGS="-force" PACKER_LOG=1 PACKER_LOG_PATH=$(ARTIFACTS_PATH)/ova/packer.log PACKER_VAR_FILES="$(PACKER_VAR_FILES)" \
-	$(MAKE) -C $(IMAGE_BUILDER_DIR) build-qemu-rhel-8
+build-qemu-rhel-local: FULL_OUTPUT_DIR=$(MAKE_ROOT)/$(OUTPUT_DIR)/qemu
+build-qemu-rhel-local: deps-qemu setup-packer-configs-qemu
+	build/build_qemu_rhel_local.sh . $(BASE_IMAGE) $(IMAGE_BUILDER_DIR) "$(PACKER_VAR_FILES)"
 
 .PHONY: validate-ubuntu-2004
 validate-ubuntu-2004: check-env-validation $(GIT_PATCH_TARGET) setup-packer-configs-ova

--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -22,6 +22,8 @@ VSPHERE_CONNECTION_DATA?={}
 # Aws accounts to share built AMI with
 DEV_ACCOUNTS?=
 
+ARTIFACTS_BUCKET?=s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f
+
 PACKER_AMI_VAR_FILES=$(MAKE_ROOT)/packer/ami/packer.json
 PACKER_AMI_SHARE_FILE=$(MAKE_ROOT)/packer/ami/share-ami.json
 PACKER_AMI_VAR_FILES+=$(PACKER_AMI_SHARE_FILE)
@@ -171,6 +173,15 @@ release-raw-ubuntu-2004: MAKEFLAGS=
 release-raw-ubuntu-2004: FULL_OUTPUT_DIR=$(subst $(BASE_DIRECTORY),/home/ec2-user/$(shell basename $(BASE_DIRECTORY)),$(MAKE_ROOT)/$(OUTPUT_DIR))/raw
 release-raw-ubuntu-2004: deps-raw setup-packer-configs-raw
 	build/build_raw_image.sh $(BASE_DIRECTORY) $(PROJECT_PATH) $(IMAGE_BUILDER_DIR) "$(PACKER_VAR_FILES)" $(RAW_IMAGE_BUILD_AMI) $(RAW_IMAGE_BUILD_INSTANCE_TYPE) $(RAW_IMAGE_BUILD_KEY_NAME)
+
+.PHONY: build-qemu-rhel-local
+build-qemu-rhel-local: deps-qemu setup-packer-config-qemu
+build-qemu-rhel-local: CHECKSUM=$(sha256sum $(BASE_IMAGE))
+build-qemu-rhel-local: QEMU_CONFIG_FILE=$(IMAGE_BUILDER_DIR)/packer/qemu/qemu-rhel-8.json
+	cat <<< $(jq '.iso_url="$(BASE_IMAGE)"' $(QEMU_CONFIG_FILE)) > $(QEMU_CONFIG_FILE)
+	cat <<< $(jq '.iso_checksum="$(CHECKSUM)"' $(QEMU_CONFIG_FILE)) > $(QEMU_CONFIG_FILE)
+	PACKER_FLAGS="-force" PACKER_LOG=1 PACKER_LOG_PATH=$(ARTIFACTS_PATH)/ova/packer.log PACKER_VAR_FILES="$(PACKER_VAR_FILES)" \
+	$(MAKE) -C $(IMAGE_BUILDER_DIR) build-qemu-rhel-8
 
 .PHONY: validate-ubuntu-2004
 validate-ubuntu-2004: check-env-validation $(GIT_PATCH_TARGET) setup-packer-configs-ova

--- a/projects/kubernetes-sigs/image-builder/README.md
+++ b/projects/kubernetes-sigs/image-builder/README.md
@@ -29,3 +29,37 @@ EKS-A CLI project uses these images as the node image when constructing workload
 1. Compare the old tag to the new, looking specifically for Makefile changes. If any of the make targets used in projects/kubernetes-sigs/image-builder/Makefile to call upstream make changed, make those appropriate changes.
 1. Update the version at the top of this Readme.
 1. Monitor node image builds and e2e tests as updates to this project can potentially break cluster create and update process.
+
+### Building your own image
+
+Users can build their own node images from a custom base image using this image-building process. The generated image can be used 
+with EKS-A CLI to create clusters.
+
+Currently this process only supports building RHEL images for KVM hypervisor.
+
+#### Prerequisites
+- Builder machine running Ubuntu 20.04 on metal
+
+#### Steps
+- Clone this repository on the builder machine `git clone https://github.com/aws/eks-anywhere-build-tooling.git`
+- Change directory into image-builder project at `eks-anywhere-build-tooling/projects/kubernetes-sigs/image-builder`
+- Download the base image to the current working path
+- Setup KVM on the builder machine
+  ```
+  sudo apt update -y
+  sudo apt install qemu-kvm libvirt-daemon-system libvirt-clients virtinst cpu-checker libguestfs-tools libosinfo-bin unzip ansible -y
+  sudo usermod -a -G kvm ubuntu
+  sudo chown root:kvm /dev/kvm
+  sudo snap install yq
+  sudo apt install jq
+  ```
+- Setup exports
+  * export BASE_IMAGE=<file name of base image>
+  * export RELEASE_BRANCH=<1-21 or 1-20>
+  * export RHSM_USER=<RedHat username>
+  * export RHSM_PASS=<RedHat password>
+  * export ARTIFACTS_BUCKET=s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f
+- Run the local build make command. This command will verify required build dependencies and run the image building process.
+    ```
+    make build-qemu-rhel-local
+    ```

--- a/projects/kubernetes-sigs/image-builder/README.md
+++ b/projects/kubernetes-sigs/image-builder/README.md
@@ -54,10 +54,10 @@ Currently this process only supports building RHEL images for KVM hypervisor.
   sudo apt install jq
   ```
 - Setup exports
-  * export BASE_IMAGE=<file name of base image>
-  * export RELEASE_BRANCH=<1-21 or 1-20>
-  * export RHSM_USER=<RedHat username>
-  * export RHSM_PASS=<RedHat password>
+  * export BASE_IMAGE=&lt;file name of base image&gt;
+  * export RELEASE_BRANCH=&lt;1-21 or 1-20&gt;
+  * export RHSM_USER=&lt;RedHat username&gt;
+  * export RHSM_PASS=&lt;RedHat password&gt;
   * export ARTIFACTS_BUCKET=s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f
 - Run the local build make command. This command will verify required build dependencies and run the image building process.
     ```

--- a/projects/kubernetes-sigs/image-builder/build/build_qemu_rhel_local.sh
+++ b/projects/kubernetes-sigs/image-builder/build/build_qemu_rhel_local.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -xe
+set -o errexit
+set -o nounset
+
+BUILDER_ROOT="${1?Specify first argument - builder root}"
+BASE_IMAGE="${2?Specify second argument - base rhel 8 image}"
+IMAGE_BUILDER_DIR="${3?Specify third argument - Image builder directory}"
+PACKER_VAR_FILES="${4?Specify fourth argument - Packer var files}"
+
+# Validate env vars
+if [ -z $BASE_IMAGE ]; then
+  echo "BASE_IMAGE env variable not set. Please set and re-try"
+  exit 1
+fi
+if [ -z $RHSM_USER ]; then
+  echo "RHSM_USER env variable not set. Please set and re-try"
+  exit 1
+fi
+if [ -z $RHSM_PASS ]; then
+  echo "RHSM_PASS env variable not set. Please set and re-try"
+  exit 1
+fi
+
+RHEL_QEMU_CONFIG_FILE=$IMAGE_BUILDER_DIR/packer/qemu/qemu-rhel-8.json
+
+echo "Generating base image sha256sum"
+BASE_IMAGE_CHECKSUM=$(sha256sum $BASE_IMAGE| awk '{print $1}')
+
+echo "Base Image Checksum - $BASE_IMAGE_CHECKSUM"
+
+cat <<< $(jq '.iso_url="$(BUILDER_ROOT)/$(BASE_IMAGE)"|.iso_checksum="$(BASE_IMAGE_CHECKSUM)"' $RHEL_QEMU_CONFIG_FILE) > $RHEL_QEMU_CONFIG_FILE
+
+PACKER_FLAGS="-force" PACKER_LOG=1 PACKER_VAR_FILES="$PACKER_VAR_FILES" make -C $IMAGE_BUILDER_DIR build-qemu-rhel-8
+
+echo "The output image is located at $IMAGE_BUILDER_DIR/output"


### PR DESCRIPTION
*Description of changes:*
This PR adds a make target to build a RHEL based qcow2 image for kvm/qemu locally. Also adds readme instructions for setting up the builder machine, and running the image build process.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
