### PR TITLE
Add 1.22 builds for Bottlerocket

### DIFF
--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_OVA_RELEASES
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_OVA_RELEASES
@@ -1,6 +1,6 @@
 1-20:
-    releaseVersion: v1.6.0
+    releaseVersion: v1.6.2
 1-21:
-    releaseVersion: v1.6.0
+    releaseVersion: v1.6.2
 1-22:
     releaseVersion: v1.6.2

--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_OVA_RELEASES
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_OVA_RELEASES
@@ -2,3 +2,5 @@
     releaseVersion: v1.6.0
 1-21:
     releaseVersion: v1.6.0
+1-22:
+    releaseVersion: v1.6.2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bottlerocket released their latest ova with 1.22 support 🎉 
Also added latest BR version for the other versions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
