### PR TITLE
Consume prod release of EKS-D 1.22

### DIFF
--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -12,7 +12,6 @@ releases:
   number: 9
   kubeVersion: v1.21.5
 - branch: 1-22
-  number: 6
+  number: 1
   kubeVersion: v1.22.6
-  dev: true
 latest: 1-21


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The production release is out for EKS-D now, so changing links to consume that for our bundles.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
