### PR TITLE
Fix CAPAS manager image name

### DIFF
--- a/projects/aws/cluster-api-provider-aws-snow/Makefile
+++ b/projects/aws/cluster-api-provider-aws-snow/Makefile
@@ -8,7 +8,7 @@ HAS_S3_ARTIFACTS=true
 SIMPLE_CREATE_BINARIES=false
 SIMPLE_CREATE_TARBALLS=false
 HAS_LICENSES=false
-IMAGE_NAMES=cluster-api-provider-aws-snow
+IMAGE_COMPONENT=aws/cluster-api-provider-aws-snow/manager
 
 include $(BASE_DIRECTORY)/Common.mk
 


### PR DESCRIPTION
Missed this in #540.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
