### PR TITLE
Export EKS-D AMI to raw format after build

### DIFF
--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -149,8 +149,14 @@ build-ami-ubuntu-2004: setup-ami-share deps-ami setup-packer-configs-ami
 release-ami-ubuntu-2004: MAKEFLAGS=
 release-ami-ubuntu-2004: FULL_OUTPUT_DIR=$(MAKE_ROOT)/$(OUTPUT_DIR)/ami
 release-ami-ubuntu-2004: PACKER_TYPE_VAR_FILES=$(PACKER_AMI_VAR_FILES)
+release-ami-ubuntu-2004: export MANIFEST_OUTPUT=$(FULL_OUTPUT_DIR)/manifest.json
+release-ami-ubuntu-2004: EXPORT_AMI_BUCKET?=$(ARTIFACTS_BUCKET)
+release-ami-ubuntu-2004: AMI_S3_DST=$(EXPORT_AMI_BUCKET)/$(ARTIFACTS_UPLOAD_PATH)/ami
+release-ami-ubuntu-2004: EXPORT_AMI_DST=$(AMI_S3_DST)/$(GIT_HASH)
+release-ami-ubuntu-2004: LATEST_AMI_S3_URL=$(AMI_S3_DST)/$(LATEST)/ubuntu.raw
 release-ami-ubuntu-2004: setup-ami-share deps-ami setup-packer-configs-ami
 	PACKER_LOG=1 PACKER_VAR_FILES="$(PACKER_VAR_FILES)" $(MAKE) -C $(IMAGE_BUILDER_DIR) build-ami-ubuntu-2004
+	build/export-ami-to-s3.sh $(RELEASE_BRANCH) $(MANIFEST_OUTPUT) raw $(EXPORT_AMI_DST) $(LATEST_AMI_S3_URL)
 
 .PHONY: release-ova-ubuntu-2004
 release-ova-ubuntu-2004: MAKEFLAGS=

--- a/projects/kubernetes-sigs/image-builder/build/export-ami-to-s3.sh
+++ b/projects/kubernetes-sigs/image-builder/build/export-ami-to-s3.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+
+EKSD_RELEASE_BRANCH="${1?Specify first argument - EKS-D release branch}"
+AMI_MANIFEST_OUTPUT="${2?Specify second argument - AMI manifest output file from packer}"
+IMAGE_FORMAT="${3?Specify third argument - Format for exported image \(vmdk\|raw\|vhd\)}"
+S3_DST_EXPORT_PATH="${4?Specify fourth argument - Destination S3 path}"
+REPLICAS="${5?Specify fourth argument - Comma separated list of s3 destinations for exported image copies}"
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd -P)"
+source "${SCRIPT_ROOT}/build/lib/common.sh"
+
+ARTIFACT_ID=$(cat $AMI_MANIFEST_OUTPUT | jq -r '.builds[0].artifact_id')
+ARTIFACT_ID_SPLIT=(${ARTIFACT_ID//:/ })
+AMI_ID=${ARTIFACT_ID_SPLIT[1]}
+
+REPLICAS_SPLIT=(${REPLICAS//,/ })
+
+DST_BUCKET_PATH=${S3_DST_EXPORT_PATH#"s3://"}
+DST_BUCKET_NAME=${DST_BUCKET_PATH%%/*}
+DST_PATH=${DST_BUCKET_PATH#"$DST_BUCKET_NAME/"}
+
+EKSD_RELEASE=$(build::eksd_releases::get_eksd_release_name $EKSD_RELEASE_BRANCH)
+EXPORTED_IMAGE_PREFIX="$DST_PATH/$EKSD_RELEASE-"
+
+EXPORT_RESPONSE=$(aws ec2 export-image --disk-image-format $IMAGE_FORMAT --s3-export-location S3Bucket=$DST_BUCKET_NAME,S3Prefix=$EXPORTED_IMAGE_PREFIX --image-id $AMI_ID)
+echo $EXPORT_RESPONSE | jq
+
+EXPORT_TASK_ID=$(echo $EXPORT_RESPONSE | jq -r '.ExportImageTaskId')
+EXPORTED_IMAGE_LOCATION="s3://${DST_BUCKET_NAME}/${EXPORTED_IMAGE_PREFIX}${EXPORT_TASK_ID}.${IMAGE_FORMAT}"
+
+FINAL_STATUSES=(completed deleted)
+STATUS=$(echo $EXPORT_RESPONSE | jq -r '.Status')
+STATUS_MESSAGE=$(echo $EXPORT_RESPONSE | jq -r '.StatusMessage')
+PROGRESS=$(echo $EXPORT_RESPONSE | jq -r '.Progress')
+
+until [[ "${FINAL_STATUSES[*]}" =~ "${STATUS}" ]]; do
+  echo "Image import is $STATUS: $STATUS_MESSAGE $PROGRESS%"
+  sleep 30
+
+  DESCRIBE_RESPONSE=$(aws ec2 describe-export-image-tasks --export-image-task-ids $EXPORT_TASK_ID)
+  STATUS=$(echo $DESCRIBE_RESPONSE | jq -r '.ExportImageTasks[0].Status')
+  STATUS_MESSAGE=$(echo $DESCRIBE_RESPONSE | jq -r '.ExportImageTasks[0].StatusMessage')
+  PROGRESS=$(echo $DESCRIBE_RESPONSE | jq -r '.ExportImageTasks[0].Progress')
+done
+
+if [[ "$STATUS" != "completed" ]]; then
+    echo "Image import failed: $STATUS - $STATUS_MESSAGE"
+    exit 1
+fi
+
+echo "Image import for ami $AMI_ID succeed"
+
+for dst in "${REPLICAS_SPLIT[@]}"
+do
+  echo "Copying exported image to $dst"
+  aws s3 cp --no-progress $EXPORTED_IMAGE_LOCATION $dst 
+done

--- a/projects/kubernetes-sigs/image-builder/packer/ami/packer.json
+++ b/projects/kubernetes-sigs/image-builder/packer/ami/packer.json
@@ -6,5 +6,6 @@
   "custom_role": "true",
   "custom_role_names": "{{env `BUILDER_ROOT`}}/ansible/roles/load_additional_files",
   "ansible_extra_vars": "@{{env `BUILDER_ROOT`}}/packer/ami/ansible_extra_vars.yaml",
-  "volume_size": "25"
+  "volume_size": "25",
+  "manifest_output": "{{env `MANIFEST_OUTPUT`}}"
 }


### PR DESCRIPTION
*Description of changes:*
This uses the AWS export image service to convert from AMI to raw
format. It then copies the generated raw image into the 'latest' folder
for easy consumption.

The export service creates the image in somewhere like `projects/kubernetes-sigs/image-builder/1-21/ami/d0e81f009fd0268afdb1525ff6e67335cc5ad452/kubernetes-1-21-eks-9-export-ami-0c41703223e6e598e.raw` and after the exporting is done we copy it to `projects/kubernetes-sigs/image-builder/1-21/ami/latest/ubuntu.raw` (overwriting whatever was the latest build).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
