### PR TITLE
CAPT patches mutex lock and error return

### DIFF
--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/CHECKSUMS
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/CHECKSUMS
@@ -1,2 +1,2 @@
-f69065f80f794cf684a7f4544afff693498f96c0f22431bf8dcafb0a2910cf55  _output/bin/cluster-api-provider-tinkerbell/linux-amd64/manager
-9b9a7eca5347d808c0ce217831e10b752cde74b3ab5d80904675c99990a404c7  _output/bin/cluster-api-provider-tinkerbell/linux-arm64/manager
+cb670550ea33a46ab6f638ba785ed529651fec230d4a96cf558b5d6381c0decf  _output/bin/cluster-api-provider-tinkerbell/linux-amd64/manager
+9f0b01ba009404875c4ac90cad12e0430b10c6c7f1351f47379b6549e5f22dfc  _output/bin/cluster-api-provider-tinkerbell/linux-arm64/manager

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0010-Adding-mutex-to-lock-hardware-selection.patch
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0010-Adding-mutex-to-lock-hardware-selection.patch
@@ -1,0 +1,46 @@
+From 36a26aa62022d263b37605fe52de72087483ff13 Mon Sep 17 00:00:00 2001
+From: Aravind Ramalingam <ramaliar@amazon.com>
+Date: Fri, 11 Mar 2022 10:06:34 -0800
+Subject: [PATCH] Adding mutex to lock hardware selection
+
+---
+ controllers/machine.go | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/controllers/machine.go b/controllers/machine.go
+index aeac2b1..23d9728 100644
+--- a/controllers/machine.go
++++ b/controllers/machine.go
+@@ -23,6 +23,7 @@ import (
+ 	"os"
+ 	"regexp"
+ 	"strings"
++	"sync"
+ 	"text/template"
+ 
+ 	corev1 "k8s.io/api/core/v1"
+@@ -49,6 +50,9 @@ type machineReconcileContext struct {
+ 	bootstrapCloudConfig string
+ }
+ 
++// Add mutex lock for picking up a hardware for the nodes.
++var lock sync.Mutex
++
+ // ErrHardwareMissingDiskConfiguration is returned when the referenced hardware is missing
+ // disk configuration.
+ var ErrHardwareMissingDiskConfiguration = fmt.Errorf("disk configuration is required")
+@@ -328,6 +332,11 @@ func (mrc *machineReconcileContext) ensureHardwareUserData(hardware *tinkv1.Hard
+ }
+ 
+ func (mrc *machineReconcileContext) ensureHardware() (*tinkv1.Hardware, error) {
++	// lock the process of picking up the hardware and updating it's ownership.
++	// This avoids picking up same hardware for the machines.
++	lock.Lock()
++	defer lock.Unlock()
++
+ 	hardware, err := mrc.hardwareForMachine()
+ 	if err != nil {
+ 		return nil, fmt.Errorf("getting hardware: %w", err)
+-- 
+2.34.1
+

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0011-Temporary-comment-error-return.patch
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0011-Temporary-comment-error-return.patch
@@ -1,0 +1,27 @@
+From eaa5811ede0e998454fd3b8be2c1813f9082ad7d Mon Sep 17 00:00:00 2001
+From: Aravind Ramalingam <ramaliar@amazon.com>
+Date: Fri, 11 Mar 2022 10:53:25 -0800
+Subject: [PATCH] Temporary comment error return
+
+---
+ pbnj/controllers/controller.go | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/pbnj/controllers/controller.go b/pbnj/controllers/controller.go
+index 591b55f..4ecbfad 100644
+--- a/pbnj/controllers/controller.go
++++ b/pbnj/controllers/controller.go
+@@ -75,7 +75,9 @@ func (r *Reconciler) reconcileNormal(ctx context.Context, bmc *pbnjv1alpha1.BMC)
+ 		if err != nil {
+ 			logger.Error(err, "Failed to set boot device", "BootDevice", bmc.Spec.BootDevice)
+ 
+-			return ctrl.Result{}, fmt.Errorf("failed to set boot device: %s", bmc.Spec.BootDevice) //nolint:goerr113
++			// TODO: Temporary fix to not error out on boot set failure.
++			// This change will be reverted when we have better error propagations
++			// return ctrl.Result{}, fmt.Errorf("failed to set boot device: %s", bmc.Spec.BootDevice) //nolint:goerr113
+ 		}
+ 	}
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
*Description of changes:*
Adding patches to CAPT for

1. Mutex lock for allocating hardware to machines in controller
2. Temporarily commenting error return for set boot dev

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
