### PR TITLE
capv + cpi: add user agents to vcenter api calls

### DIFF
--- a/projects/kubernetes-sigs/cluster-api-provider-vsphere/CHECKSUMS
+++ b/projects/kubernetes-sigs/cluster-api-provider-vsphere/CHECKSUMS
@@ -1,2 +1,2 @@
-1810b20b7ce23e9fe26a329e4f0f4f28ce8b8499d75618a61a11f437b9c5c9ff  _output/bin/cluster-api-provider-vsphere/linux-amd64/manager
-b1f3c9a0afdca8af0c858dc553d82119d64856a7b0a71a034a19eac24dcd6aea  _output/bin/cluster-api-provider-vsphere/linux-arm64/manager
+a6b4c7c168d595a3de00e20a5a94e0202109c9f5a440b7cfae6a9b502e3cc052  _output/bin/cluster-api-provider-vsphere/linux-amd64/manager
+b90bde319e56d8170b46dc13d1bbb784dcb45e1ecbf6fb9cdd8b7e73962c2dd4  _output/bin/cluster-api-provider-vsphere/linux-arm64/manager

--- a/projects/kubernetes-sigs/cluster-api-provider-vsphere/patches/0003-set-user-agent-for-vsphere-api-calls.patch
+++ b/projects/kubernetes-sigs/cluster-api-provider-vsphere/patches/0003-set-user-agent-for-vsphere-api-calls.patch
@@ -1,0 +1,26 @@
+From 15575f1e76c8ec8172c15f558d2bd9e4dc9e6ab8 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Thu, 17 Mar 2022 09:08:52 -0500
+Subject: [PATCH] set user-agent for vsphere api calls
+
+Signed-off-by: Prow Bot <prow@amazonaws.com>
+---
+ pkg/session/session.go | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/pkg/session/session.go b/pkg/session/session.go
+index 28ee585c..073c0ff9 100644
+--- a/pkg/session/session.go
++++ b/pkg/session/session.go
+@@ -177,6 +177,8 @@ func newClient(ctx context.Context, logger logr.Logger, sessionKey string, url *
+ 	if err != nil {
+ 		return nil, err
+ 	}
++	
++	vimClient.UserAgent = "k8s-capv-useragent"
+ 
+ 	c := &govmomi.Client{
+ 		Client:         vimClient,
+-- 
+2.35.1
+

--- a/projects/kubernetes/cloud-provider-vsphere/1-20/CHECKSUMS
+++ b/projects/kubernetes/cloud-provider-vsphere/1-20/CHECKSUMS
@@ -1,2 +1,2 @@
-053cac210b6e3cd589be505b1cf81cf7f05b5ca9004af879bedd32ac445efea1  _output/1-20/bin/cloud-provider-vsphere/linux-amd64/vsphere-cloud-controller-manager
-ef9b8ae70637e87947eb2ce2822773246776cfb381c6d0a505e9609de91ef7fe  _output/1-20/bin/cloud-provider-vsphere/linux-arm64/vsphere-cloud-controller-manager
+ecdb498f6f6ae5c6c0319e9d6cc7d7a25a08b1f698824ed11ec5863cd663a081  _output/1-20/bin/cloud-provider-vsphere/linux-amd64/vsphere-cloud-controller-manager
+0a36ef5cd33dc21747a36927f1408af57a8537906067375c121e20beae4b1921  _output/1-20/bin/cloud-provider-vsphere/linux-arm64/vsphere-cloud-controller-manager

--- a/projects/kubernetes/cloud-provider-vsphere/1-20/patches/0001-set-user-agent-for-vsphere-api-calls.patch
+++ b/projects/kubernetes/cloud-provider-vsphere/1-20/patches/0001-set-user-agent-for-vsphere-api-calls.patch
@@ -1,0 +1,25 @@
+From 6e18a787952060e92a8ec9c6b3342660dd4812ad Mon Sep 17 00:00:00 2001
+From: Jackson West <jgw@amazon.com>
+Date: Thu, 17 Mar 2022 09:18:52 -0500
+Subject: [PATCH] set user-agent for vsphere api calls
+
+Signed-off-by: Jackson West <jgw@amazon.com>
+---
+ pkg/common/vclib/connection.go | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/pkg/common/vclib/connection.go b/pkg/common/vclib/connection.go
+index 6938a69..4b74410 100644
+--- a/pkg/common/vclib/connection.go
++++ b/pkg/common/vclib/connection.go
+@@ -177,6 +177,7 @@ func (connection *VSphereConnection) NewClient(ctx context.Context) (*vim25.Clie
+ 		klog.Errorf("Failed to create new client. err: %+v", err)
+ 		return nil, err
+ 	}
++	client.UserAgent="k8s-vsphere-cpi-1-20-useragent"
+ 	err = connection.login(ctx, client)
+ 	if err != nil {
+ 		return nil, err
+-- 
+2.35.1
+

--- a/projects/kubernetes/cloud-provider-vsphere/1-21/CHECKSUMS
+++ b/projects/kubernetes/cloud-provider-vsphere/1-21/CHECKSUMS
@@ -1,2 +1,2 @@
-199700aa3dc3a8a1bff6ffebf5b61661d487b964ef48b65ea1faab63b06c3ec5  _output/1-21/bin/cloud-provider-vsphere/linux-amd64/vsphere-cloud-controller-manager
-634e05e058565bbe6572f09ac0c46b767c3668baa2b2be389eab1fcf21b28ddd  _output/1-21/bin/cloud-provider-vsphere/linux-arm64/vsphere-cloud-controller-manager
+0c2b9a800ccdd0c0c05194348b0125278d1ee4d4cf2950b178960173189a612b  _output/1-21/bin/cloud-provider-vsphere/linux-amd64/vsphere-cloud-controller-manager
+28d63bcab7f5313512173414756c5a83a504590fdfac2b03ac1bcb0d8ed40d49  _output/1-21/bin/cloud-provider-vsphere/linux-arm64/vsphere-cloud-controller-manager

--- a/projects/kubernetes/cloud-provider-vsphere/1-21/patches/0001-set-user-agent-for-vsphere-api-calls.patch
+++ b/projects/kubernetes/cloud-provider-vsphere/1-21/patches/0001-set-user-agent-for-vsphere-api-calls.patch
@@ -1,0 +1,25 @@
+From 0fca4734d63662af128286fbf34f70e0f100e35c Mon Sep 17 00:00:00 2001
+From: Jackson West <jgw@amazon.com>
+Date: Thu, 17 Mar 2022 09:18:52 -0500
+Subject: [PATCH] set user-agent for vsphere api calls
+
+Signed-off-by: Jackson West <jgw@amazon.com>
+---
+ pkg/common/vclib/connection.go | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/pkg/common/vclib/connection.go b/pkg/common/vclib/connection.go
+index 6938a69..a06e4a3 100644
+--- a/pkg/common/vclib/connection.go
++++ b/pkg/common/vclib/connection.go
+@@ -177,6 +177,7 @@ func (connection *VSphereConnection) NewClient(ctx context.Context) (*vim25.Clie
+ 		klog.Errorf("Failed to create new client. err: %+v", err)
+ 		return nil, err
+ 	}
++	client.UserAgent="k8s-vsphere-cpi-1-21-useragent"
+ 	err = connection.login(ctx, client)
+ 	if err != nil {
+ 		return nil, err
+-- 
+2.35.1
+

--- a/projects/kubernetes/cloud-provider-vsphere/1-22/CHECKSUMS
+++ b/projects/kubernetes/cloud-provider-vsphere/1-22/CHECKSUMS
@@ -1,2 +1,2 @@
-83f0464ec7556f6310bea58183288aeb8f601b1edde9bbea8b43e211d8b8c0dc  _output/1-22/bin/cloud-provider-vsphere/linux-amd64/vsphere-cloud-controller-manager
-ccb67c80bd63e9e5604e5fb6f97381277d273dec72529d17fbbbeba770edc457  _output/1-22/bin/cloud-provider-vsphere/linux-arm64/vsphere-cloud-controller-manager
+f800e783f06e16eca2e966ce595a601f62782f033835643415a83b22d53e54e1  _output/1-22/bin/cloud-provider-vsphere/linux-amd64/vsphere-cloud-controller-manager
+d3c4b9c46e781610378f6a609cc433834125c207ccf6aeff693c27400570125f  _output/1-22/bin/cloud-provider-vsphere/linux-arm64/vsphere-cloud-controller-manager

--- a/projects/kubernetes/cloud-provider-vsphere/1-22/patches/0001-set-user-agent-for-vsphere-api-calls.patch
+++ b/projects/kubernetes/cloud-provider-vsphere/1-22/patches/0001-set-user-agent-for-vsphere-api-calls.patch
@@ -1,0 +1,25 @@
+From 00947b45c6796177d8a0f9e1196d89ae884e87ae Mon Sep 17 00:00:00 2001
+From: Jackson West <jgw@amazon.com>
+Date: Thu, 17 Mar 2022 09:18:52 -0500
+Subject: [PATCH] set user-agent for vsphere api calls
+
+Signed-off-by: Jackson West <jgw@amazon.com>
+---
+ pkg/common/vclib/connection.go | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/pkg/common/vclib/connection.go b/pkg/common/vclib/connection.go
+index 6938a69..25f04b5 100644
+--- a/pkg/common/vclib/connection.go
++++ b/pkg/common/vclib/connection.go
+@@ -177,6 +177,7 @@ func (connection *VSphereConnection) NewClient(ctx context.Context) (*vim25.Clie
+ 		klog.Errorf("Failed to create new client. err: %+v", err)
+ 		return nil, err
+ 	}
++	client.UserAgent="k8s-vsphere-cpi-1-22-useragent"
+ 	err = connection.login(ctx, client)
+ 	if err != nil {
+ 		return nil, err
+-- 
+2.35.1
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

While trying to debug vsphere connections in CI we are seeing lots of requests with the generic go-client user agent. The [csi-driver](https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/v2.2.0/pkg/common/cns-lib/vsphere/virtualcenter.go#L155) and gov properly set a useragent. This patches capv and cpi to set a user agent on the vm25client as well. As a note, capv is setting the useragent on some other session in their code, but that does not seem to come thru and it is after the login call.

Since we have patch directories for the specific versions of cpi, i went ahead and hardcoded the version in the source. I think longer term we could change that to be more dynamic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
