### PR TITLE
Fix space issues in harbor presubmit

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -249,6 +249,7 @@ define BUILDCTL
 		--output type=$(IMAGE_OUTPUT_TYPE),oci-mediatypes=true,\"name=$(IMAGE),$(LATEST_IMAGE)\",$(IMAGE_OUTPUT) \
 		$(if $(filter push=true,$(IMAGE_OUTPUT)),--export-cache type=inline,) \
 		$(foreach IMPORT_CACHE,$(IMAGE_IMPORT_CACHE),--import-cache $(IMPORT_CACHE))
+                buildctl prune --all
 
 endef 
 

--- a/Common.mk
+++ b/Common.mk
@@ -249,7 +249,6 @@ define BUILDCTL
 		--output type=$(IMAGE_OUTPUT_TYPE),oci-mediatypes=true,\"name=$(IMAGE),$(LATEST_IMAGE)\",$(IMAGE_OUTPUT) \
 		$(if $(filter push=true,$(IMAGE_OUTPUT)),--export-cache type=inline,) \
 		$(foreach IMPORT_CACHE,$(IMAGE_IMPORT_CACHE),--import-cache $(IMPORT_CACHE))
-                buildctl prune --all
 
 endef 
 

--- a/build/lib/buildkit.sh
+++ b/build/lib/buildkit.sh
@@ -42,3 +42,7 @@ else
     $CMD "$@"
 fi
 
+# space is limited on presubmit nodes, after each image build clear the build cache
+if [ "${JOB_TYPE:-}" == "presubmit" ]; then
+   $CMD "prune --all"
+fi

--- a/build/lib/buildkit.sh
+++ b/build/lib/buildkit.sh
@@ -39,7 +39,7 @@ if [ -f "/buildkit.sh" ]; then
 
     # space is limited on presubmit nodes, after each image build clear the build cache
     if [ "${JOB_TYPE:-}" == "presubmit" ]; then
-        $CMD "prune --all"
+        $CMD prune --all
     fi
 
     (exit $s)

--- a/build/lib/buildkit.sh
+++ b/build/lib/buildkit.sh
@@ -36,13 +36,14 @@ if [ -f "/buildkit.sh" ]; then
         [ $i -gt 1 ] && sleep 15
         $CMD "$@" && s=0 && break || s=$?
     done
+
+    # space is limited on presubmit nodes, after each image build clear the build cache
+    if [ "${JOB_TYPE:-}" == "presubmit" ]; then
+        $CMD "prune --all"
+    fi
+
     (exit $s)
 else
     # skip retry when running locally
     $CMD "$@"
-fi
-
-# space is limited on presubmit nodes, after each image build clear the build cache
-if [ "${JOB_TYPE:-}" == "presubmit" ]; then
-   $CMD "prune --all"
 fi


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

Call buildctl prune between image builds to avoid space issues in presubmit.

Only running prune during presubmit, it would probably be fine to always run it, but going this route to limit the risk of any issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
