### PR TITLE
Add helm patch to allow push to insecure OCI registry

### DIFF
--- a/projects/helm/helm/CHECKSUMS
+++ b/projects/helm/helm/CHECKSUMS
@@ -1,2 +1,2 @@
-a3d92e4f6f4d3d85bf0f12b87ad892d0957c4b2f664408c0043ec0dad98e3c85  _output/bin/helm/linux-amd64/helm
-8f5c1216f9376be7c0d2775ec0749effb5022ccc17010fc8338cc9e44fc435be  _output/bin/helm/linux-arm64/helm
+a361154395369dc8423a167657ec0396841f2cdd07eb53ebbf56172809486002  _output/bin/helm/linux-amd64/helm
+ffef5419f8dcc1f4ac5a79ccd18b4bcc7c84d6bd06ddc469571515aa7ea028ba  _output/bin/helm/linux-arm64/helm

--- a/projects/helm/helm/patches/0001-Push-to-OCI-insecure-registry.patch
+++ b/projects/helm/helm/patches/0001-Push-to-OCI-insecure-registry.patch
@@ -1,0 +1,151 @@
+From bf6b45a01cb63a4ddb72d94ce5bfec86d317e334 Mon Sep 17 00:00:00 2001
+From: Rajashree Mandaogane <mandaor@amazon.com>
+Date: Tue, 22 Mar 2022 09:32:29 -0700
+Subject: [PATCH] Push to OCI insecure registry
+
+---
+ cmd/helm/flags.go                        |  1 +
+ cmd/helm/push.go                         |  4 +++
+ internal/experimental/action/push.go     | 12 +++++++--
+ internal/experimental/registry/client.go | 31 ++++++++++++++++++++++++
+ pkg/action/install.go                    |  1 +
+ pkg/action/pull.go                       |  6 +++++
+ 6 files changed, 53 insertions(+), 2 deletions(-)
+
+diff --git a/cmd/helm/flags.go b/cmd/helm/flags.go
+index aefa836c..13ad906f 100644
+--- a/cmd/helm/flags.go
++++ b/cmd/helm/flags.go
+@@ -58,6 +58,7 @@ func addChartPathOptionsFlags(f *pflag.FlagSet, c *action.ChartPathOptions) {
+ 	f.BoolVar(&c.InsecureSkipTLSverify, "insecure-skip-tls-verify", false, "skip tls certificate checks for the chart download")
+ 	f.StringVar(&c.CaFile, "ca-file", "", "verify certificates of HTTPS-enabled servers using this CA bundle")
+ 	f.BoolVar(&c.PassCredentialsAll, "pass-credentials", false, "pass credentials to all domains")
++	f.BoolVar(&c.PlainHTTP, "plain-http", false, "use plain http to connect oci registry")
+ }
+ 
+ // bindOutputFlag will add the output flag to the given command and bind the
+diff --git a/cmd/helm/push.go b/cmd/helm/push.go
+index 7daa6656..136e1c28 100644
+--- a/cmd/helm/push.go
++++ b/cmd/helm/push.go
+@@ -57,5 +57,9 @@ func newPushCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
+ 		},
+ 	}
+ 
++	f := cmd.Flags()
++	f.BoolVar(&client.InsecureSkipTLSverify, "insecure-skip-tls-verify", false, "skip tls certificate checks for the chart upload")
++	f.BoolVar(&client.PlainHTTP, "plain-http", false, "use plain http and not https to connect oci registry")
++
+ 	return cmd
+ }
+diff --git a/internal/experimental/action/push.go b/internal/experimental/action/push.go
+index b125ae1f..4e2cc35a 100644
+--- a/internal/experimental/action/push.go
++++ b/internal/experimental/action/push.go
+@@ -30,8 +30,10 @@ import (
+ //
+ // It provides the implementation of 'helm push'.
+ type Push struct {
+-	Settings *cli.EnvSettings
+-	cfg      *action.Configuration
++	Settings              *cli.EnvSettings
++	cfg                   *action.Configuration
++	InsecureSkipTLSverify bool
++	PlainHTTP             bool
+ }
+ 
+ // PushOpt is a type of function that sets options for a push action.
+@@ -57,6 +59,12 @@ func NewPushWithOpts(opts ...PushOpt) *Push {
+ func (p *Push) Run(chartRef string, remote string) (string, error) {
+ 	var out strings.Builder
+ 
++	if p.InsecureSkipTLSverify || p.PlainHTTP {
++		if err := p.cfg.RegistryClient.WithResolver(p.InsecureSkipTLSverify, p.PlainHTTP); err != nil {
++			return out.String(), err
++		}
++	}
++
+ 	c := uploader.ChartUploader{
+ 		Out:     &out,
+ 		Pushers: pusher.All(p.Settings),
+diff --git a/internal/experimental/registry/client.go b/internal/experimental/registry/client.go
+index cc9e1fe7..4757f9bb 100644
+--- a/internal/experimental/registry/client.go
++++ b/internal/experimental/registry/client.go
+@@ -17,6 +17,7 @@ limitations under the License.
+ package registry // import "helm.sh/helm/v3/internal/experimental/registry"
+ 
+ import (
++	"crypto/tls"
+ 	"encoding/json"
+ 	"fmt"
+ 	"io"
+@@ -105,6 +106,36 @@ func ClientOptCredentialsFile(credentialsFile string) ClientOption {
+ 	}
+ }
+ 
++func (c *Client) newResolver(insecure, plainHTTP bool) (remotes.Resolver, error) {
++	headers := http.Header{}
++	headers.Set("User-Agent", version.GetUserAgent())
++	opts := []auth.ResolverOption{auth.WithResolverHeaders(headers)}
++
++	if insecure {
++		httpClient := http.DefaultClient
++		httpClient.Transport = &http.Transport{
++			TLSClientConfig: &tls.Config{
++				InsecureSkipVerify: true,
++			},
++		}
++		opts = append(opts, auth.WithResolverClient(httpClient))
++	}
++	if plainHTTP {
++		opts = append(opts, auth.WithResolverPlainHTTP())
++	}
++
++	return c.authorizer.ResolverWithOpts(opts...)
++}
++
++func (c *Client) WithResolver(insecure, plainHTTP bool) error {
++	resolver, err := c.newResolver(insecure, plainHTTP)
++	if err != nil {
++		return err
++	}
++	c.resolver = resolver
++	return nil
++}
++
+ type (
+ 	// LoginOption allows specifying various settings on login
+ 	LoginOption func(*loginOperation)
+diff --git a/pkg/action/install.go b/pkg/action/install.go
+index b84a5727..bdd3408c 100644
+--- a/pkg/action/install.go
++++ b/pkg/action/install.go
+@@ -124,6 +124,7 @@ type ChartPathOptions struct {
+ 	Username              string // --username
+ 	Verify                bool   // --verify
+ 	Version               string // --version
++	PlainHTTP             bool   // --plain-http
+ }
+ 
+ // NewInstall creates a new Install object with the given configuration.
+diff --git a/pkg/action/pull.go b/pkg/action/pull.go
+index 2f5127ea..87ec6532 100644
+--- a/pkg/action/pull.go
++++ b/pkg/action/pull.go
+@@ -76,6 +76,12 @@ func NewPullWithOpts(opts ...PullOpt) *Pull {
+ func (p *Pull) Run(chartRef string) (string, error) {
+ 	var out strings.Builder
+ 
++	if p.InsecureSkipTLSverify || p.PlainHTTP {
++		if err := p.cfg.RegistryClient.WithResolver(p.InsecureSkipTLSverify, p.PlainHTTP); err != nil {
++			return out.String(), err
++		}
++	}
++
+ 	c := downloader.ChartDownloader{
+ 		Out:     &out,
+ 		Keyring: p.Keyring,
+-- 
+2.30.1
+


### PR DESCRIPTION
*Issue #, if available:* https://github.com/helm/helm/issues/6324

*Description of changes:*
Adding commits from this upstream PR: https://github.com/helm/helm/pull/10408/commits
Tested locally and helm pull/push works as expected

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
