### PR TITLE
Tweak helm chart semantic version generation.

### DIFF
--- a/build/lib/helm_require.sh
+++ b/build/lib/helm_require.sh
@@ -47,7 +47,10 @@ SEDFILE=${OUTPUT_DIR}/helm/sedfile
 export IMAGE_TAG
 export HELM_REGISTRY
 envsubst <helm/sedfile.template >${SEDFILE}
+# Semver requires that our version begin with a digit, so strip the v.
 echo "s,version: v,version: ,g" >>${SEDFILE}
+# Semver requires that we use a + before the git hash to denote build info.
+echo "/^version:/s,-,+," >>${SEDFILE}
 for IMAGE in ${HELM_IMAGE_LIST:-}
 do
   IMAGE_SHASUM=$(${SCRIPT_ROOT}/image_shasum.sh ${HELM_REGISTRY} ${IMAGE} ${LATEST})

--- a/projects/aws/eks-anywhere-test/eks-anywhere-test/Chart.yaml
+++ b/projects/aws/eks-anywhere-test/eks-anywhere-test/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: eks-anywhere-test
 description: EKS Anywhere Packages Test Application
 type: application
-version: {{IMAGE_TAG}}-helm
+version: {{IMAGE_TAG}}
 appVersion: {{IMAGE_TAG}}


### PR DESCRIPTION
In commit e09f316 we allowed helm charts to use semantic versioning,
however we made the wrong version semantic. It's not appVersion that
matters, but rather version. This also changes the generated filename.

I also escaped a shell echo that failed when it tried to run on my
machine.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
