### PR TITLE
Build tink project as prequisite to CLI tools

### DIFF
--- a/release/staging-build.yml
+++ b/release/staging-build.yml
@@ -136,6 +136,12 @@ batch:
       variables:
        PROJECT_PATH: projects/replicatedhq/troubleshoot
        CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/replicatedhq.troubleshoot
+  - identifier: tink
+    buildspec: buildspec.yml
+    env:
+      variables:
+       PROJECT_PATH: projects/tinkerbell/tink
+       CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/tinkerbell.tink
   - identifier: helm
     buildspec: buildspec.yml
     env:


### PR DESCRIPTION
CLI tools depends on tink CLI.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
