### PR TITLE
Remove RHEL builds in CI

### DIFF
--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -72,7 +72,7 @@ ifeq ($(IMAGE_FORMAT),ova)
 	RELEASE_TARGETS=release-ova-ubuntu-2004 release-ova-bottlerocket upload-artifacts-ova
 else ifeq ($(IMAGE_FORMAT),raw)
 	S3_TARGET_PREREQUISITES=$(FINAL_UBUNTU_RAW_IMAGE_PATH)
-	RELEASE_TARGETS=release-raw-ubuntu-2004-efi release-raw-rhel-8 upload-artifacts-raw
+	RELEASE_TARGETS=release-raw-ubuntu-2004-efi upload-artifacts-raw
 endif
 
 include $(BASE_DIRECTORY)/Common.mk


### PR DESCRIPTION
This is causing Ubuntu and RHEL to be built in the same pipeline. We need better logic around this.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
