### PR TITLE
Install reboot in tink-docker

### DIFF
--- a/projects/tinkerbell/hook/docker/linux/tink-docker/Dockerfile
+++ b/projects/tinkerbell/hook/docker/linux/tink-docker/Dockerfile
@@ -7,7 +7,9 @@ WORKDIR /newroot
 RUN set -x && \
     amazon-linux-extras enable docker && \
     cp /etc/yum.repos.d/amzn2-extras.repo /newroot/etc/yum.repos.d/amzn2-extras.repo && \
-    clean_install "systemd" true true && \
+    # TODO (pokearu): check and remove unwanted binaries from systemd
+    # example bootctl, journalctl etc.
+    clean_install "systemd" true true true && \
     clean_install "docker procps e2fsprogs" && \
     remove_package "bash coreutils gawk info sed shadow-utils grep" && \
     remove_package "systemd" true && \


### PR DESCRIPTION
*Description of changes:*
tink-docker has a reboot watch, that calls `/sbin/reboot`.  `reboot` is a symlnk to `systemctl` and its dependencies.
Hence installing `systemd` fully on tink-docker.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
