### PR TITLE
Adding busybox reboot to tink-docker

### DIFF
--- a/projects/tinkerbell/hook/docker/linux/tink-docker/Dockerfile
+++ b/projects/tinkerbell/hook/docker/linux/tink-docker/Dockerfile
@@ -7,13 +7,14 @@ WORKDIR /newroot
 RUN set -x && \
     amazon-linux-extras enable docker && \
     cp /etc/yum.repos.d/amzn2-extras.repo /newroot/etc/yum.repos.d/amzn2-extras.repo && \
-    # TODO (pokearu): check and remove unwanted binaries from systemd
-    # example bootctl, journalctl etc.
-    clean_install "systemd" true true true && \
+    clean_install "systemd" true true && \
     clean_install "docker procps e2fsprogs" && \
     remove_package "bash coreutils gawk info sed shadow-utils grep" && \
     remove_package "systemd" true && \
     cleanup "tink-docker" && \
+    curl https://busybox.net/downloads/binaries/1.35.0-x86_64-linux-musl/busybox -o /newroot/usr/bin/busybox && \
+    chmod +x /newroot/usr/bin/busybox && \
+    ln -sf /usr/bin/busybox /newroot/usr/sbin/reboot && \
     ln -sf /usr/bin/docker-init /newroot/usr/local/bin/docker-init && \
     ln -sf /usr/bin/dockerd /newroot/usr/local/bin/dockerd
 

--- a/projects/tinkerbell/hook/docker/linux/tink-docker/Dockerfile
+++ b/projects/tinkerbell/hook/docker/linux/tink-docker/Dockerfile
@@ -2,6 +2,8 @@ ARG BASE_IMAGE # https://gallery.ecr.aws/eks-distro-build-tooling/eks-distro-min
 ARG BUILDER_IMAGE
 FROM $BUILDER_IMAGE as docker-builder
 
+ARG TARGETARCH
+
 WORKDIR /newroot
 
 RUN set -x && \
@@ -12,7 +14,8 @@ RUN set -x && \
     remove_package "bash coreutils gawk info sed shadow-utils grep" && \
     remove_package "systemd" true && \
     cleanup "tink-docker" && \
-    curl https://busybox.net/downloads/binaries/1.35.0-x86_64-linux-musl/busybox -o /newroot/usr/bin/busybox && \
+    if [ $TARGETARCH = "amd64" ]; then BUSYBOX_ARCH="x86_64"; else BUSYBOX_ARCH="armv81"; fi && \
+    curl https://busybox.net/downloads/binaries/1.31.0-defconfig-multiarch-musl/busybox-$BUSYBOX_ARCH -o /newroot/usr/bin/busybox && \
     chmod +x /newroot/usr/bin/busybox && \
     ln -sf /usr/bin/busybox /newroot/usr/sbin/reboot && \
     ln -sf /usr/bin/docker-init /newroot/usr/local/bin/docker-init && \


### PR DESCRIPTION
*Description of changes:*
We need the reboot call from busybox binary instead of the systemctl. This enables reboots without an init daemon.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
