### PR TITLE
Adding CAPT patch to update PBNJ version

### DIFF
--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/ATTRIBUTION.txt
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/ATTRIBUTION.txt
@@ -50,22 +50,19 @@ https://github.com/prometheus/procfs
 ** github.com/tinkerbell/cluster-api-provider-tinkerbell; version v0.1.0 --
 https://github.com/tinkerbell/cluster-api-provider-tinkerbell
 
-** github.com/tinkerbell/pbnj; version v0.0.0-20211027151347-2fb19ffbe7ad --
+** github.com/tinkerbell/pbnj; version v0.0.0-20220204202246-b98856895e1c --
 https://github.com/tinkerbell/pbnj
 
 ** github.com/tinkerbell/tink; version v0.0.0-20210910200746-3743d31e0cf0 --
 https://github.com/tinkerbell/tink
 
-** go.opentelemetry.io/contrib; version v0.22.0 --
+** go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc; version v0.26.1 --
 https://github.com/open-telemetry/opentelemetry-go-contrib
 
-** go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc; version v0.22.0 --
-https://github.com/open-telemetry/opentelemetry-go-contrib
-
-** go.opentelemetry.io/otel; version v1.0.0-RC2 --
+** go.opentelemetry.io/otel; version v1.1.0 --
 https://github.com/open-telemetry/opentelemetry-go
 
-** go.opentelemetry.io/otel/trace; version v1.0.0-RC2 --
+** go.opentelemetry.io/otel/trace; version v1.1.0 --
 https://github.com/open-telemetry/opentelemetry-go
 
 ** gomodules.xyz/jsonpatch/v2; version v2.2.0 --

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/CHECKSUMS
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/CHECKSUMS
@@ -1,2 +1,2 @@
-3cd816af1b8eeb69c2f21a84e184676ba49dd9c20e20575b443581ac228f2bc1  _output/bin/cluster-api-provider-tinkerbell/linux-amd64/manager
-41302903024d443b3952e0183aebe8b72d693687e0d93d09444a13cf522d33c4  _output/bin/cluster-api-provider-tinkerbell/linux-arm64/manager
+fa645922840e3101be0858bacb476f21e3375ab304a058c1de1e7956d63be1f1  _output/bin/cluster-api-provider-tinkerbell/linux-amd64/manager
+1d6298f4e2737fb55cb29f70643dab13f82f8d20efce81ef0bb4eaa924a673d5  _output/bin/cluster-api-provider-tinkerbell/linux-arm64/manager

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0013-Updating-PBNJ-commit-version.patch
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0013-Updating-PBNJ-commit-version.patch
@@ -1,0 +1,105 @@
+From 2ed4f239a06aba89408a474f05eaec17bf52f7cb Mon Sep 17 00:00:00 2001
+From: Aravind Ramalingam <ramaliar@amazon.com>
+Date: Fri, 1 Apr 2022 12:28:59 -0700
+Subject: [PATCH] Updating PBNJ commit version
+
+---
+ go.mod |  2 +-
+ go.sum | 24 ++++++++++++++++--------
+ 2 files changed, 17 insertions(+), 9 deletions(-)
+
+diff --git a/go.mod b/go.mod
+index 8b29351..9b74fb5 100644
+--- a/go.mod
++++ b/go.mod
+@@ -8,7 +8,7 @@ require (
+ 	github.com/onsi/gomega v1.16.0
+ 	github.com/prometheus/common v0.30.0 // indirect
+ 	github.com/spf13/pflag v1.0.5
+-	github.com/tinkerbell/pbnj v0.0.0-20211027151347-2fb19ffbe7ad
++	github.com/tinkerbell/pbnj v0.0.0-20220204202246-b98856895e1c
+ 	github.com/tinkerbell/tink v0.0.0-20210910200746-3743d31e0cf0
+ 	go.uber.org/atomic v1.9.0 // indirect
+ 	golang.org/x/net v0.0.0-20210825183410-e898025ed96a // indirect
+diff --git a/go.sum b/go.sum
+index 715aeb6..1899b52 100644
+--- a/go.sum
++++ b/go.sum
+@@ -203,7 +203,7 @@ github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb/go.mod h1:PkYb9DJNAw
+ github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+ github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+-github.com/bmc-toolbox/bmclib v0.4.13/go.mod h1:0WeM06Sacej9UMbt6yFtIRfrwmsl5IK2f4sAUMaNN+4=
++github.com/bmc-toolbox/bmclib v0.4.14-0.20211027184927-2f9a20e0a479/go.mod h1:9YhAIIwp9tQtlo1LZtN5Qd89e+RfvgQ62ikbreEKOs0=
+ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
+ github.com/bombsimon/logrusr v1.0.0/go.mod h1:Jq0nHtvxabKE5EMwAAdgTaz7dfWE8C4i11NOltxGQpc=
+ github.com/bombsimon/wsl/v3 v3.3.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
+@@ -411,6 +411,7 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
+ github.com/envoyproxy/protoc-gen-validate v0.0.14/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+ github.com/equinix-labs/otel-init-go v0.0.1/go.mod h1:Zprvqw70JGsTRLbj6bCtndooCAgg4mY4H2MF3KC/AS0=
++github.com/equinix-labs/otel-init-go v0.0.4/go.mod h1:VRq/cZQoGSeSEcw5M0Xn/oY23nrBzDp7rtVD+tYNvPg=
+ github.com/esimonov/ifshort v1.0.2/go.mod h1:yZqNJUrNn20K8Q9n2CrjTKYyVEmX209Hgu+M1LBpeZE=
+ github.com/ettle/strcase v0.1.1/go.mod h1:hzDLsPC7/lwKyBOywSHEP89nt2pDgdy+No1NBA9o9VY=
+ github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
+@@ -1248,7 +1249,7 @@ github.com/spf13/viper v1.9.0/go.mod h1:+i6ajR7OX2XaiBkrcZJFK21htRk7eDeLg7+O6bhU
+ github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
+ github.com/ssgreg/nlreturn/v2 v2.1.0/go.mod h1:E/iiPB78hV7Szg2YfRgyIrk1AD6JVMTRkkxBiELzh2I=
+ github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
+-github.com/stmcginnis/gofish v0.8.0/go.mod h1:BGtQsY16q48M2K6KDAs38QXtNoHrkXaY/WZ/mmyMgNc=
++github.com/stmcginnis/gofish v0.12.0/go.mod h1:BGtQsY16q48M2K6KDAs38QXtNoHrkXaY/WZ/mmyMgNc=
+ github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
+ github.com/stormcat24/protodep v0.0.0-20200505140716-b02c9ba62816/go.mod h1:mBd5PI4uI6NkqJpCyiWiYzWyTFs4QRDss/JTMC2b4kc=
+ github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
+@@ -1278,8 +1279,8 @@ github.com/testcontainers/testcontainers-go v0.11.1/go.mod h1:/V0UVq+1e7NWYoqTPo
+ github.com/tetafro/godot v1.4.7/go.mod h1:LR3CJpxDVGlYOWn3ZZg1PgNZdTUvzsZWu8xaEohUpn8=
+ github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+ github.com/timakin/bodyclose v0.0.0-20200424151742-cb6215831a94/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
+-github.com/tinkerbell/pbnj v0.0.0-20211027151347-2fb19ffbe7ad h1:H/eCXoJe/afB40QT+xgSP2C93wGgESDHsqLwdrSZp9I=
+-github.com/tinkerbell/pbnj v0.0.0-20211027151347-2fb19ffbe7ad/go.mod h1:Yuwln3oSjwgLSbTSwdlmkt61JqIMD8NlCOE0oUZxkUQ=
++github.com/tinkerbell/pbnj v0.0.0-20220204202246-b98856895e1c h1:sRQfN0NLGrZe+dO9mQVds56y92HkXhK0Qt8p7B/WUHc=
++github.com/tinkerbell/pbnj v0.0.0-20220204202246-b98856895e1c/go.mod h1:U9OpZXYQA3+lPNh/Z4+E8gSevGKvmj6By7OcWpxDtQU=
+ github.com/tinkerbell/tink v0.0.0-20210910200746-3743d31e0cf0 h1:R5V5FByhJ9Mevm5KPZHUwggMoyV0SSJbsi/4yKIxt1Y=
+ github.com/tinkerbell/tink v0.0.0-20210910200746-3743d31e0cf0/go.mod h1:y+G7nfazn6ue2Vkjx6hoVV+8WZ1XjYtkuy4xw8qnIKE=
+ github.com/tj/assert v0.0.0-20171129193455-018094318fb0/go.mod h1:mZ9/Rh9oLWpLLDRpvE+3b7gP/C2YyLFYxNmcLnPTMe0=
+@@ -1380,26 +1381,33 @@ go.opentelemetry.io/contrib v0.20.0/go.mod h1:G/EtFaa6qaN7+LxqfIAT3GiZa7Wv5DTBUz
+ go.opentelemetry.io/contrib v0.22.0 h1:0F7gDEjgb1WGn4ODIjaCAg75hmqF+UN0LiVgwxsCodc=
+ go.opentelemetry.io/contrib v0.22.0/go.mod h1:EH4yDYeNoaTqn/8yCWQmfNB78VHfGX2Jt2bvnvzBlGM=
+ go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.20.0/go.mod h1:oVGt1LRbBOBq1A5BQLlUg9UaU/54aiHw8cgjV3aWZ/E=
+-go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.22.0 h1:TjqELdtCtlOJQrTnXd2y+RP6wXKZUnnJer0HR0CSo18=
+ go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.22.0/go.mod h1:KjqwX4uJNaj479ZjFpADOMJKOM4rBXq4kN7nbeuGKrY=
++go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.26.1 h1:puWrOArBwWlr5dq6vyZ6fKykHyS8JgMIVhTBA8XsGuU=
++go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.26.1/go.mod h1:4wsfAAW5N9wUHM0QTmZS8z7fvYZ1rv3m+sVeSpf8NhU=
+ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.20.0/go.mod h1:2AboqHi0CiIZU0qwhtUfCYD1GeUzvvIXWNkhDt7ZMG4=
+ go.opentelemetry.io/otel v0.20.0/go.mod h1:Y3ugLH2oa81t5QO+Lty+zXf8zC9L26ax4Nzoxm/dooo=
+-go.opentelemetry.io/otel v1.0.0-RC2 h1:SHhxSjB+omnGZPgGlKe+QMp3MyazcOHdQ8qwo89oKbg=
+ go.opentelemetry.io/otel v1.0.0-RC2/go.mod h1:w1thVQ7qbAy8MHb0IFj8a5Q2QU0l2ksf8u/CN8m3NOM=
++go.opentelemetry.io/otel v1.0.0/go.mod h1:AjRVh9A5/5DE7S+mZtTR6t8vpKKryam+0lREnfmS4cg=
++go.opentelemetry.io/otel v1.1.0 h1:8p0uMLcyyIx0KHNTgO8o3CW8A1aA+dJZJW6PvnMz0Wc=
++go.opentelemetry.io/otel v1.1.0/go.mod h1:7cww0OW51jQ8IaZChIEdqLwgh+44+7uiTdWsAL0wQpA=
+ go.opentelemetry.io/otel/exporters/otlp v0.20.0/go.mod h1:YIieizyaN77rtLJra0buKiNBOm9XQfkPEKBeuhoMwAM=
+ go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.0.0-RC2/go.mod h1:T+s8GKi1OqMwPuZ+ouDtZW4vWYpJuzIzh2Matq4Jo9k=
++go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.0.0/go.mod h1:3VqVbIbjAycfL1C7sIu/Uh/kACIUPWHztt8ODYwR3oM=
+ go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.0.0-RC2/go.mod h1:3shayJIFcDqHi9/GT2fAHyMI/bRgc6FO0CAkhaDkhi0=
++go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.0.0/go.mod h1:zhEt6O5GGJ3NCAICr4hlCPoDb2GQuh4Obb4gZBgkoQQ=
+ go.opentelemetry.io/otel/metric v0.20.0/go.mod h1:598I5tYlH1vzBjn+BTuhzTCSb/9debfNp6R3s7Pr1eU=
+ go.opentelemetry.io/otel/oteltest v0.20.0/go.mod h1:L7bgKf9ZB7qCwT9Up7i9/pn0PWIa9FqQ2IQ8LoxiGnw=
+-go.opentelemetry.io/otel/oteltest v1.0.0-RC2 h1:xNKqMhlZYkASSyvF4JwObZFMq0jhFN3c3SP+2rCzVPk=
+ go.opentelemetry.io/otel/oteltest v1.0.0-RC2/go.mod h1:kiQ4tw5tAL4JLTbcOYwK1CWI1HkT5aiLzHovgOVnz/A=
+ go.opentelemetry.io/otel/sdk v0.20.0/go.mod h1:g/IcepuwNsoiX5Byy2nNV0ySUF1em498m7hBWC279Yc=
+ go.opentelemetry.io/otel/sdk v1.0.0-RC2/go.mod h1:fgwHyiDn4e5k40TD9VX243rOxXR+jzsWBZYA2P5jpEw=
++go.opentelemetry.io/otel/sdk v1.0.0/go.mod h1:PCrDHlSy5x1kjezSdL37PhbFUMjrsLRshJ2zCzeXwbM=
+ go.opentelemetry.io/otel/sdk/export/metric v0.20.0/go.mod h1:h7RBNMsDJ5pmI1zExLi+bJK+Dr8NQCh0qGhm1KDnNlE=
+ go.opentelemetry.io/otel/sdk/metric v0.20.0/go.mod h1:knxiS8Xd4E/N+ZqKmUPf3gTTZ4/0TjTXukfxjzSTpHE=
+ go.opentelemetry.io/otel/trace v0.20.0/go.mod h1:6GjCW8zgDjwGHGa6GkyeB8+/5vjT16gUEi0Nf1iBdgw=
+-go.opentelemetry.io/otel/trace v1.0.0-RC2 h1:dunAP0qDULMIT82atj34m5RgvsIK6LcsXf1c/MsYg1w=
+ go.opentelemetry.io/otel/trace v1.0.0-RC2/go.mod h1:JPQ+z6nNw9mqEGT8o3eoPTdnNI+Aj5JcxEsVGREIAy4=
++go.opentelemetry.io/otel/trace v1.0.0/go.mod h1:PXTWqayeFUlJV1YDNhsJYB184+IvAH814St6o6ajzIs=
++go.opentelemetry.io/otel/trace v1.1.0 h1:N25T9qCL0+7IpOT8RrRy0WYlL7y6U0WiUJzXcVdXY/o=
++go.opentelemetry.io/otel/trace v1.1.0/go.mod h1:i47XtdcBQiktu5IsrPqOHe8w+sBmnLwwHt8wiUsWGTI=
+ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
+ go.opentelemetry.io/proto/otlp v0.9.0/go.mod h1:1vKfU9rv61e9EVGthD1zNvUbiwPcimSsOPU9brfSHJg=
+ go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5/go.mod h1:nmDLcffg48OtT/PSW0Hg7FvpRQsQh5OSqIylirxKC7o=
+-- 
+2.34.1
+


### PR DESCRIPTION
*Description of changes:*
CAPT was using an older version of PBNJ that had a different proto API.
Update fixes issues with wrong API calls being triggered.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
