### PR TITLE
Implement retry logic for tink-worker docker image pull...

### DIFF
--- a/projects/tinkerbell/hook/CHECKSUMS
+++ b/projects/tinkerbell/hook/CHECKSUMS
@@ -1,4 +1,4 @@
-3cf80c815715d223df7537e955e1fa278d0b693ef0bcc2f85b5078a34667fc17  _output/bin/hook/linux-amd64/bootkit
+21b8241e049cf47bc878d8ef5ccc707398f003064271f451c3303d9bf48dd965  _output/bin/hook/linux-amd64/bootkit
 374264fa41018f37ec129f41eb7fa84f07d5698098e342122dbfe5ec6e59eb5f  _output/bin/hook/linux-amd64/tink-docker
-906375c5e62841ebaa89c59e41b2f0fe15a288b881810708350dfc95435d3276  _output/bin/hook/linux-arm64/bootkit
+2cab898ecdecba41bde9446205aea58d58c87dfd6e726616c378213e556c54c8  _output/bin/hook/linux-arm64/bootkit
 09554c74190c8fcb35da552332d7438259a0f2b7ff74d0b70ab6a6bc3d6b5c6b  _output/bin/hook/linux-arm64/tink-docker

--- a/projects/tinkerbell/hook/patches/0002-Implement-retry-for-tink-worker-docker-image-pull-to.patch
+++ b/projects/tinkerbell/hook/patches/0002-Implement-retry-for-tink-worker-docker-image-pull-to.patch
@@ -1,0 +1,47 @@
+From f5130587c14ba6f319c1435a132f0ca31d8aad0a Mon Sep 17 00:00:00 2001
+From: Pooja Trivedi <poojatrivedi@gmail.com>
+Date: Mon, 4 Apr 2022 22:21:23 +0000
+Subject: [PATCH] Implement retry for tink-worker docker image pull to allow
+ for races where linuxkit network or dns may not have been fully set up and
+ functional yet.
+
+---
+ bootkit/main.go | 22 +++++++++++++++++++---
+ 1 file changed, 19 insertions(+), 3 deletions(-)
+
+diff --git a/bootkit/main.go b/bootkit/main.go
+index bc8f3f5..742c115 100644
+--- a/bootkit/main.go
++++ b/bootkit/main.go
+@@ -137,9 +137,25 @@ func main() {
+ 
+ 	fmt.Printf("Pulling image [%s]", imageName)
+ 
+-	out, err := cli.ImagePull(ctx, imageName, pullOpts)
+-	if err != nil {
+-		panic(err)
++	// TODO: should remove all this hardcoding or move it to a const at some point
++	attempts := 10
++	sleepSeconds := 5
++
++	failedImagePull := true
++
++	var out io.ReadCloser
++	for i := 0; i < attempts; i++ {
++		out, err = cli.ImagePull(ctx, imageName, pullOpts)
++		if err == nil {
++			failedImagePull = false  
++			break; 
++		}
++		fmt.Printf("Error pulling image [%s] [%v]. Retrying after %d seconds...\n", imageName, err, sleepSeconds)
++		time.Sleep(time.Second * 5)
++	}
++
++	if failedImagePull {
++		panic(err)	
+ 	}
+ 
+ 	_, err = io.Copy(os.Stdout, out)
+-- 
+2.25.1
+


### PR DESCRIPTION
 ...to allow for races where linuxkit network or dns may not have been fully set up and functional yet.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
