### PR TITLE
Fix kcp components.yaml to include BR

### DIFF
--- a/projects/kubernetes-sigs/cluster-api/patches/0001-Adding-capi-support-for-Bottlerocket.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0001-Adding-capi-support-for-Bottlerocket.patch
@@ -1,4 +1,4 @@
-From 2d884cff2e4fc8e31a873f6745e47e9a91e2e8c7 Mon Sep 17 00:00:00 2001
+From 22faf5bfb146a34685f2de9e64c3c66f1fabf943 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Fri, 11 Jun 2021 10:43:09 -0700
 Subject: [PATCH 01/18] Adding capi support for Bottlerocket
@@ -32,9 +32,9 @@ Remove userdata logging for bottlerocket
  api/v1alpha3/zz_generated.deepcopy.go         |   5 +
  .../api/v1alpha3/kubeadmconfig_types.go       |   5 +-
  .../kubeadm/api/v1beta1/kubeadm_types.go      |  53 +++++
- .../api/v1beta1/kubeadmconfig_types.go        |   3 +
- ...strap.cluster.x-k8s.io_kubeadmconfigs.yaml | 173 ++++++++++++++++
- ...uster.x-k8s.io_kubeadmconfigtemplates.yaml | 185 ++++++++++++++++++
+ .../api/v1beta1/kubeadmconfig_types.go        |   5 +-
+ ...strap.cluster.x-k8s.io_kubeadmconfigs.yaml | 174 ++++++++++++++++
+ ...uster.x-k8s.io_kubeadmconfigtemplates.yaml | 186 ++++++++++++++++++
  .../internal/bottlerocket/bootstrap.go        |  45 +++++
  .../internal/bottlerocket/bottlerocket.go     | 179 +++++++++++++++++
  .../bottlerocket/controlplane_init.go         |  49 +++++
@@ -47,10 +47,10 @@ Remove userdata logging for bottlerocket
  .../controllers/kubeadmconfig_controller.go   |  73 +++++++
  .../kubeadm/types/upstreamv1beta1/types.go    |  55 +++++-
  .../upstreamv1beta1/zz_generated.deepcopy.go  |  58 ++++++
- ...cluster.x-k8s.io_kubeadmcontrolplanes.yaml | 158 +++++++++++++++
- ...x-k8s.io_kubeadmcontrolplanetemplates.yaml |  71 +++++++
+ ...cluster.x-k8s.io_kubeadmcontrolplanes.yaml | 159 +++++++++++++++
+ ...x-k8s.io_kubeadmcontrolplanetemplates.yaml |  72 +++++++
  go.mod                                        |   1 +
- 21 files changed, 1222 insertions(+), 3 deletions(-)
+ 21 files changed, 1227 insertions(+), 4 deletions(-)
  create mode 100644 bootstrap/kubeadm/internal/bottlerocket/bootstrap.go
  create mode 100644 bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go
  create mode 100644 bootstrap/kubeadm/internal/bottlerocket/controlplane_init.go
@@ -176,9 +176,18 @@ index 354d777d5..5f525f692 100644
  	// When used in the context of control plane nodes, NodeRegistration should remain consistent
  	// across both InitConfiguration and JoinConfiguration
 diff --git a/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_types.go b/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_types.go
-index 5ec772643..45b05ea43 100644
+index 5ec772643..737fec9a2 100644
 --- a/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_types.go
 +++ b/bootstrap/kubeadm/api/v1beta1/kubeadmconfig_types.go
+@@ -23,7 +23,7 @@ import (
+ )
+ 
+ // Format specifies the output format of the bootstrap data
+-// +kubebuilder:validation:Enum=cloud-config;ignition
++// +kubebuilder:validation:Enum=cloud-config;ignition;bottlerocket
+ type Format string
+ 
+ const (
 @@ -32,6 +32,9 @@ const (
  
  	// Ignition make the bootstrap data to be of Ignition format.
@@ -190,7 +199,7 @@ index 5ec772643..45b05ea43 100644
  
  // KubeadmConfigSpec defines the desired state of KubeadmConfig.
 diff --git a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
-index 19f22af25..26b93edb0 100644
+index 19f22af25..2edad1c42 100644
 --- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
 +++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
 @@ -102,6 +102,21 @@ spec:
@@ -372,7 +381,15 @@ index 19f22af25..26b93edb0 100644
                    scheduler:
                      description: Scheduler contains extra settings for the scheduler
                        control plane component
-@@ -2677,6 +2807,21 @@ spec:
+@@ -2469,6 +2599,7 @@ spec:
+                 enum:
+                 - cloud-config
+                 - ignition
++                - bottlerocket
+                 type: string
+               ignition:
+                 description: Ignition contains Ignition specific configuration.
+@@ -2677,6 +2808,21 @@ spec:
                        schemas to the latest internal value, and may reject unrecognized
                        values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                      type: string
@@ -394,7 +411,7 @@ index 19f22af25..26b93edb0 100644
                    caCertPath:
                      description: 'CACertPath is the path to the SSL certificate authority
                        used to secure comunications between node and control-plane.
-@@ -2869,6 +3014,34 @@ spec:
+@@ -2869,6 +3015,34 @@ spec:
                            content inline or by referencing a secret.
                          type: string
                      type: object
@@ -430,7 +447,7 @@ index 19f22af25..26b93edb0 100644
                mounts:
                  description: Mounts specifies a list of mount points to be setup.
 diff --git a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
-index a8a05eb5b..ad0353ddb 100644
+index a8a05eb5b..76f6a2ee3 100644
 --- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
 +++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
 @@ -111,6 +111,22 @@ spec:
@@ -621,7 +638,15 @@ index a8a05eb5b..ad0353ddb 100644
                            scheduler:
                              description: Scheduler contains extra settings for the
                                scheduler control plane component
-@@ -2709,6 +2848,22 @@ spec:
+@@ -2484,6 +2623,7 @@ spec:
+                         enum:
+                         - cloud-config
+                         - ignition
++                        - bottlerocket
+                         type: string
+                       ignition:
+                         description: Ignition contains Ignition specific configuration.
+@@ -2709,6 +2849,22 @@ spec:
                                convert recognized schemas to the latest internal value,
                                and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                              type: string
@@ -644,7 +669,7 @@ index a8a05eb5b..ad0353ddb 100644
                            caCertPath:
                              description: 'CACertPath is the path to the SSL certificate
                                authority used to secure comunications between node
-@@ -2916,6 +3071,36 @@ spec:
+@@ -2916,6 +3072,36 @@ spec:
                                    content inline or by referencing a secret.
                                  type: string
                              type: object
@@ -1403,7 +1428,7 @@ index 2eebc2402..e924a4a4b 100644
 +	return out
 +}
 diff --git a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
-index bdd6b0cef..e3ebcd8c3 100644
+index bdd6b0cef..8adfcd777 100644
 --- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
 +++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
 @@ -177,6 +177,22 @@ spec:
@@ -1611,7 +1636,15 @@ index bdd6b0cef..e3ebcd8c3 100644
                        scheduler:
                          description: Scheduler contains extra settings for the scheduler
                            control plane component
-@@ -3146,6 +3288,22 @@ spec:
+@@ -2929,6 +3071,7 @@ spec:
+                     enum:
+                     - cloud-config
+                     - ignition
++                    - bottlerocket
+                     type: string
+                   ignition:
+                     description: Ignition contains Ignition specific configuration.
+@@ -3146,6 +3289,22 @@ spec:
                            schemas to the latest internal value, and may reject unrecognized
                            values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                          type: string
@@ -1635,7 +1668,7 @@ index bdd6b0cef..e3ebcd8c3 100644
                          description: 'CACertPath is the path to the SSL certificate
                            authority used to secure comunications between node and
 diff --git a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
-index fabde6b0f..18ae007e8 100644
+index fabde6b0f..dbefec39a 100644
 --- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
 +++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
 @@ -549,6 +549,7 @@ spec:
@@ -1719,7 +1752,15 @@ index fabde6b0f..18ae007e8 100644
                                scheduler:
                                  description: Scheduler contains extra settings for
                                    the scheduler control plane component
-@@ -1948,6 +2001,24 @@ spec:
+@@ -1713,6 +1766,7 @@ spec:
+                             enum:
+                             - cloud-config
+                             - ignition
++                            - bottlerocket
+                             type: string
+                           ignition:
+                             description: Ignition contains Ignition specific configuration.
+@@ -1948,6 +2002,24 @@ spec:
                                    value, and may reject unrecognized values. More
                                    info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                                  type: string

--- a/projects/kubernetes-sigs/cluster-api/patches/0002-Add-unstacked-etcd-support.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0002-Add-unstacked-etcd-support.patch
@@ -1,4 +1,4 @@
-From 5cee30360de812ece0757370686edf1e4b4e48c8 Mon Sep 17 00:00:00 2001
+From 3cdc3fa661f6681634ac9b205045df5b8b516e16 Mon Sep 17 00:00:00 2001
 From: Rajashree Mandaogane <mandaor@amazon.com>
 Date: Mon, 28 Jun 2021 13:44:50 -0700
 Subject: [PATCH 02/18] Add unstacked etcd support
@@ -551,7 +551,7 @@ index 896ef5d0e..9d5e58664 100644
  		{spec, kubeadmConfigSpec, clusterConfiguration, "dns", "imageTag"},
  		{spec, kubeadmConfigSpec, clusterConfiguration, "imageRepository"},
 diff --git a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
-index e3ebcd8c3..0a7eb1726 100644
+index 8adfcd777..03da30b18 100644
 --- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
 +++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
 @@ -2177,6 +2177,20 @@ spec:
@@ -597,7 +597,7 @@ index e3ebcd8c3..0a7eb1726 100644
                          description: Scheduler contains extra settings for the scheduler
                            control plane component
 diff --git a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
-index 18ae007e8..69168476a 100644
+index dbefec39a..7cba0aa10 100644
 --- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
 +++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
 @@ -947,6 +947,20 @@ spec:

--- a/projects/kubernetes-sigs/cluster-api/patches/0003-Unstacked-etcd-and-controlplane-upgrade.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0003-Unstacked-etcd-and-controlplane-upgrade.patch
@@ -1,4 +1,4 @@
-From cf032ba262d5620e0b9627399a7a480c0d431ffb Mon Sep 17 00:00:00 2001
+From b4f04634b5ab59a22ca0f6f8e5961648ac805c53 Mon Sep 17 00:00:00 2001
 From: Rajashree Mandaogane <mandaor@amazon.com>
 Date: Fri, 6 Aug 2021 17:16:39 -0700
 Subject: [PATCH 03/18] Unstacked etcd and controlplane upgrade

--- a/projects/kubernetes-sigs/cluster-api/patches/0004-Patch-config-path-in-kubevip-manifest-for-kubeadm-co.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0004-Patch-config-path-in-kubevip-manifest-for-kubeadm-co.patch
@@ -1,4 +1,4 @@
-From dc27a0564486345e5eec7db46ded0c90ab917d47 Mon Sep 17 00:00:00 2001
+From 395985c75ced5a5b84c677c7635eb3a4b2c774d1 Mon Sep 17 00:00:00 2001
 From: Guillermo Gaston <gaslor@amazon.com>
 Date: Thu, 19 Aug 2021 21:52:52 +0000
 Subject: [PATCH 04/18] Patch config path in kubevip manifest for kubeadm

--- a/projects/kubernetes-sigs/cluster-api/patches/0005-Make-pause-and-bottlerocket-bootstrap-images-updatab.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0005-Make-pause-and-bottlerocket-bootstrap-images-updatab.patch
@@ -1,4 +1,4 @@
-From f1df2e2c87327038721727bbd72fdc90b48f7052 Mon Sep 17 00:00:00 2001
+From 8b101538960b41e9fad0f1778d68879b02843ace Mon Sep 17 00:00:00 2001
 From: Guillermo Gaston <gaslor@amazon.com>
 Date: Tue, 31 Aug 2021 15:56:28 +0000
 Subject: [PATCH 05/18] Make pause and bottlerocket bootstrap images updatable

--- a/projects/kubernetes-sigs/cluster-api/patches/0006-add-support-for-registry-mirror-for-bottlerocket.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0006-add-support-for-registry-mirror-for-bottlerocket.patch
@@ -1,4 +1,4 @@
-From cc3f29d07f234bb9fe783e7e55d5420f18482876 Mon Sep 17 00:00:00 2001
+From 5ef8da8dbb6780a0a4c2bd4ff8cc2654d2b06e9c Mon Sep 17 00:00:00 2001
 From: Abhinav Pandey <abhnvp@amazon.com>
 Date: Tue, 21 Sep 2021 08:57:56 -0700
 Subject: [PATCH 06/18] add support for registry mirror for bottlerocket
@@ -1076,7 +1076,7 @@ index 5f525f692..16f240a05 100644
  	// When used in the context of control plane nodes, NodeRegistration should remain consistent
  	// across both InitConfiguration and JoinConfiguration
 diff --git a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
-index 26b93edb0..c20e96c67 100644
+index 2edad1c42..a5438d46f 100644
 --- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
 +++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
 @@ -348,6 +348,18 @@ spec:
@@ -1137,7 +1137,7 @@ index 26b93edb0..c20e96c67 100644
                      description: Scheduler contains extra settings for the scheduler
                        control plane component
 diff --git a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
-index ad0353ddb..20260febc 100644
+index 76f6a2ee3..715e5532c 100644
 --- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
 +++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
 @@ -373,6 +373,19 @@ spec:
@@ -1406,7 +1406,7 @@ index e924a4a4b..71e769f0f 100644
 +	return out
 +}
 diff --git a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
-index 0a7eb1726..eca4acb00 100644
+index 03da30b18..571ca9fb5 100644
 --- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
 +++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
 @@ -432,6 +432,19 @@ spec:
@@ -1470,7 +1470,7 @@ index 0a7eb1726..eca4acb00 100644
                          description: Scheduler contains extra settings for the scheduler
                            control plane component
 diff --git a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
-index 69168476a..273de4726 100644
+index 7cba0aa10..eb67c830d 100644
 --- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
 +++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
 @@ -1590,6 +1590,19 @@ spec:

--- a/projects/kubernetes-sigs/cluster-api/patches/0007-Fix-proxy-template-for-bottlerocket-bootstrap.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0007-Fix-proxy-template-for-bottlerocket-bootstrap.patch
@@ -1,4 +1,4 @@
-From 7842126023499afe378089cdbe61420412e821fa Mon Sep 17 00:00:00 2001
+From 6b7cd75a5380f6233346f786a88b7463508b5b86 Mon Sep 17 00:00:00 2001
 From: Rajashree Mandaogane <mandaor@amazon.com>
 Date: Thu, 30 Sep 2021 14:04:36 -0700
 Subject: [PATCH 07/18] Fix proxy template for bottlerocket bootstrap

--- a/projects/kubernetes-sigs/cluster-api/patches/0008-Update-core-conversion-spoke-versions.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0008-Update-core-conversion-spoke-versions.patch
@@ -1,4 +1,4 @@
-From 4ad00f95ec88fa2471fd2c3bcfafc8c644ef1c8b Mon Sep 17 00:00:00 2001
+From 0b7bdd3011ba38cde793eab419b2a85f477e6043 Mon Sep 17 00:00:00 2001
 From: Rajashree Mandaogane <mandaor@amazon.com>
 Date: Sun, 21 Nov 2021 01:16:11 -0800
 Subject: [PATCH 08/18] Update core conversion spoke versions

--- a/projects/kubernetes-sigs/cluster-api/patches/0009-Add-bottlerocket-changes-to-capbk-v1alpha4-api.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0009-Add-bottlerocket-changes-to-capbk-v1alpha4-api.patch
@@ -1,4 +1,4 @@
-From 599fe4f7203902e6d620cbb4d7b79d721b476090 Mon Sep 17 00:00:00 2001
+From e68e59c9d63200cfb2abf81244884ee12a9ca028 Mon Sep 17 00:00:00 2001
 From: Rajashree Mandaogane <mandaor@amazon.com>
 Date: Sun, 21 Nov 2021 20:59:58 -0800
 Subject: [PATCH 09/18] Add bottlerocket changes to capbk v1alpha4 api
@@ -319,7 +319,7 @@ index 5af4c0d9f..0d4e4692d 100644
  func (in *SecretFileSource) DeepCopyInto(out *SecretFileSource) {
  	*out = *in
 diff --git a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
-index c20e96c67..5a6012568 100644
+index a5438d46f..39884d271 100644
 --- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
 +++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
 @@ -1206,6 +1206,21 @@ spec:
@@ -460,7 +460,7 @@ index c20e96c67..5a6012568 100644
                  type: object
                mounts:
                  description: Mounts specifies a list of mount points to be setup.
-@@ -3078,6 +3188,18 @@ spec:
+@@ -3079,6 +3189,18 @@ spec:
                            type: string
                          type: array
                      type: object
@@ -480,7 +480,7 @@ index c20e96c67..5a6012568 100644
                mounts:
                  description: Mounts specifies a list of mount points to be setup.
 diff --git a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
-index 20260febc..f5a240665 100644
+index 715e5532c..bb61caf43 100644
 --- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
 +++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
 @@ -1212,6 +1212,22 @@ spec:
@@ -629,7 +629,7 @@ index 20260febc..f5a240665 100644
                          type: object
                        mounts:
                          description: Mounts specifies a list of mount points to be
-@@ -3140,6 +3258,19 @@ spec:
+@@ -3141,6 +3259,19 @@ spec:
                                    type: string
                                  type: array
                              type: object

--- a/projects/kubernetes-sigs/cluster-api/patches/0010-Update-capbk-converions-spoke-version.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0010-Update-capbk-converions-spoke-version.patch
@@ -1,4 +1,4 @@
-From ffec7ee9b08763f7a2899367e6b7a1f12ba420d3 Mon Sep 17 00:00:00 2001
+From 0a4c8033fdd8fa6e2b9d00c40fd6494d89813f84 Mon Sep 17 00:00:00 2001
 From: Rajashree Mandaogane <mandaor@amazon.com>
 Date: Sun, 21 Nov 2021 21:00:31 -0800
 Subject: [PATCH 10/18] Update capbk converions spoke version

--- a/projects/kubernetes-sigs/cluster-api/patches/0011-Add-generated-manifest-changes-for-KCP.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0011-Add-generated-manifest-changes-for-KCP.patch
@@ -1,4 +1,4 @@
-From 2ecc201a494d81b1c2c7bff0bf0d9f33d26a5f83 Mon Sep 17 00:00:00 2001
+From c3521a88ee732dfb4d2b70503c80a1656fdf887f Mon Sep 17 00:00:00 2001
 From: Rajashree Mandaogane <mandaor@amazon.com>
 Date: Sat, 27 Nov 2021 14:18:00 -0800
 Subject: [PATCH 11/18] Add generated manifest changes for KCP
@@ -9,7 +9,7 @@ Subject: [PATCH 11/18] Add generated manifest changes for KCP
  2 files changed, 268 insertions(+), 2 deletions(-)
 
 diff --git a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
-index eca4acb00..7c7cfde1d 100644
+index 571ca9fb5..d62aae8d3 100644
 --- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
 +++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
 @@ -1435,6 +1435,22 @@ spec:
@@ -136,7 +136,7 @@ index eca4acb00..7c7cfde1d 100644
                      type: object
                    mounts:
                      description: Mounts specifies a list of mount points to be setup.
-@@ -3572,6 +3659,49 @@ spec:
+@@ -3573,6 +3660,49 @@ spec:
                                or by referencing a secret.
                              type: string
                          type: object
@@ -187,7 +187,7 @@ index eca4acb00..7c7cfde1d 100644
                    mounts:
                      description: Mounts specifies a list of mount points to be setup.
 diff --git a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
-index 273de4726..cc02d2f93 100644
+index eb67c830d..10df1a7ae 100644
 --- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
 +++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
 @@ -125,6 +125,24 @@ spec:
@@ -319,7 +319,7 @@ index 273de4726..cc02d2f93 100644
                              type: object
                            mounts:
                              description: Mounts specifies a list of mount points to
-@@ -2276,6 +2368,50 @@ spec:
+@@ -2277,6 +2369,50 @@ spec:
                                        by referencing a secret.
                                      type: string
                                  type: object

--- a/projects/kubernetes-sigs/cluster-api/patches/0012-Add-status.version-to-list-of-fields-to-ignore-for-u.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0012-Add-status.version-to-list-of-fields-to-ignore-for-u.patch
@@ -1,4 +1,4 @@
-From aaec7ec5a91375e977514e2b93463ef9f34063f8 Mon Sep 17 00:00:00 2001
+From 08b8b95689356a55843c96d42d83e6aabf7ed7b2 Mon Sep 17 00:00:00 2001
 From: Vivek Koppuru <koppv@amazon.com>
 Date: Wed, 12 Jan 2022 19:04:15 -0800
 Subject: [PATCH 12/18] Add status.version to list of fields to ignore for

--- a/projects/kubernetes-sigs/cluster-api/patches/0013-Add-node-labels-support-for-bottlerocket.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0013-Add-node-labels-support-for-bottlerocket.patch
@@ -1,4 +1,4 @@
-From c8b8788a35635f0cdc422a8b94606f18147afb95 Mon Sep 17 00:00:00 2001
+From d1f755f0ef427f13489b49b0447be1334fa75eac Mon Sep 17 00:00:00 2001
 From: Vivek Koppuru <koppv@amazon.com>
 Date: Mon, 24 Jan 2022 00:46:44 -0800
 Subject: [PATCH 13/18] Add node labels support for bottlerocket

--- a/projects/kubernetes-sigs/cluster-api/patches/0014-Support-worker-node-taints.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0014-Support-worker-node-taints.patch
@@ -1,4 +1,4 @@
-From 25ee27775cb4bc63d592934d2b1077aed2ea3c8d Mon Sep 17 00:00:00 2001
+From d2bf73365c54666fd748f250cca7024149c2a082 Mon Sep 17 00:00:00 2001
 From: Daniel Budris <budris@amazon.com>
 Date: Fri, 17 Dec 2021 13:38:39 -0800
 Subject: [PATCH 14/18] Support worker node taints

--- a/projects/kubernetes-sigs/cluster-api/patches/0015-support-bottle-rocket-control-plane-taints.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0015-support-bottle-rocket-control-plane-taints.patch
@@ -1,4 +1,4 @@
-From 8211075338ec8bac5e285de78f7bcb39a924e3a4 Mon Sep 17 00:00:00 2001
+From 32b817c339751bd92e2d4e673441d308c38c3cfa Mon Sep 17 00:00:00 2001
 From: danbudris <budris@amazon.com>
 Date: Fri, 18 Feb 2022 09:24:32 -0500
 Subject: [PATCH 15/18] support bottle rocket control plane taints

--- a/projects/kubernetes-sigs/cluster-api/patches/0016-Support-configuring-bottlerocket-control-container-u.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0016-Support-configuring-bottlerocket-control-container-u.patch
@@ -1,4 +1,4 @@
-From 5cbb33986235a0a76fccccb1d3aafd7e4a9fb610 Mon Sep 17 00:00:00 2001
+From 365d8905d2b5081fb67d255e481e21e4e6cc2a89 Mon Sep 17 00:00:00 2001
 From: Michael Chu <chumich@amazon.com>
 Date: Mon, 28 Feb 2022 09:51:25 -0800
 Subject: [PATCH 16/18] Support configuring bottlerocket control container uri
@@ -329,7 +329,7 @@ index 0d4e4692d..341b00474 100644
  	out.RegistryMirror = in.RegistryMirror
  	in.NodeRegistration.DeepCopyInto(&out.NodeRegistration)
 diff --git a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
-index 5a6012568..f1a273b55 100644
+index 39884d271..67abfc66d 100644
 --- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
 +++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigs.yaml
 @@ -117,6 +117,21 @@ spec:
@@ -442,7 +442,7 @@ index 5a6012568..f1a273b55 100644
                    certificatesDir:
                      description: 'CertificatesDir specifies where to store or look
                        for all required certificates. NB: if not provided, this will
-@@ -2968,6 +3043,21 @@ spec:
+@@ -2969,6 +3044,21 @@ spec:
                            the version of the above components during upgrades.
                          type: string
                      type: object
@@ -465,7 +465,7 @@ index 5a6012568..f1a273b55 100644
                      description: 'CACertPath is the path to the SSL certificate authority
                        used to secure comunications between node and control-plane.
 diff --git a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
-index f5a240665..17f1f8f46 100644
+index bb61caf43..15d4c5aa9 100644
 --- a/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
 +++ b/bootstrap/kubeadm/config/crd/bases/bootstrap.cluster.x-k8s.io_kubeadmconfigtemplates.yaml
 @@ -127,6 +127,22 @@ spec:
@@ -583,7 +583,7 @@ index f5a240665..17f1f8f46 100644
                            certificatesDir:
                              description: 'CertificatesDir specifies where to store
                                or look for all required certificates. NB: if not provided,
-@@ -3021,6 +3101,22 @@ spec:
+@@ -3022,6 +3102,22 @@ spec:
                                    components during upgrades.
                                  type: string
                              type: object
@@ -1606,7 +1606,7 @@ index 88d383643..3be940664 100644
          type: object
      served: true
 diff --git a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
-index 7c7cfde1d..0983729c8 100644
+index d62aae8d3..a71635141 100644
 --- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
 +++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanes.yaml
 @@ -193,6 +193,22 @@ spec:
@@ -1724,7 +1724,7 @@ index 7c7cfde1d..0983729c8 100644
                        certificatesDir:
                          description: 'CertificatesDir specifies where to store or
                            look for all required certificates. NB: if not provided,
-@@ -3458,6 +3538,22 @@ spec:
+@@ -3459,6 +3539,22 @@ spec:
                                upgrades.
                              type: string
                          type: object
@@ -1748,7 +1748,7 @@ index 7c7cfde1d..0983729c8 100644
                          description: 'CACertPath is the path to the SSL certificate
                            authority used to secure comunications between node and
 diff --git a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
-index cc02d2f93..96a94b5a0 100644
+index 10df1a7ae..b60dcae96 100644
 --- a/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
 +++ b/controlplane/kubeadm/config/crd/bases/controlplane.cluster.x-k8s.io_kubeadmcontrolplanetemplates.yaml
 @@ -143,6 +143,23 @@ spec:
@@ -1823,7 +1823,7 @@ index cc02d2f93..96a94b5a0 100644
                                certificatesDir:
                                  description: 'CertificatesDir specifies where to store
                                    or look for all required certificates. NB: if not
-@@ -2152,6 +2203,23 @@ spec:
+@@ -2153,6 +2204,23 @@ spec:
                                        the above components during upgrades.
                                      type: string
                                  type: object

--- a/projects/kubernetes-sigs/cluster-api/patches/0017-update-coredns-corefile-migration-to-support-1.8.7.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0017-update-coredns-corefile-migration-to-support-1.8.7.patch
@@ -1,4 +1,4 @@
-From 2fa939f6acb0b903c839c530e9fa87d7eeaa79d1 Mon Sep 17 00:00:00 2001
+From f8423451a82b6f15806ce383d07921171046a1af Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Sat, 5 Mar 2022 18:16:29 -0600
 Subject: [PATCH 17/18] update coredns/corefile-migration to support 1.8.7

--- a/projects/kubernetes-sigs/cluster-api/patches/0018-Change-format-for-storing-etcd-machine-address.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0018-Change-format-for-storing-etcd-machine-address.patch
@@ -1,4 +1,4 @@
-From 37f879c32ec7157eb325c514e01a807531bceb2a Mon Sep 17 00:00:00 2001
+From 35680d53faae230f531498ee2c915404722a0a15 Mon Sep 17 00:00:00 2001
 From: Rajashree Mandaogane <mandaor@amazon.com>
 Date: Thu, 3 Mar 2022 15:01:35 -0800
 Subject: [PATCH 18/18] Change format for storing etcd machine address


### PR DESCRIPTION
*Description of changes:*
Updates the patch adding BR support to include `bottlerocket` in the enum for `Format`. This got removed accidentally when updating capi tag to 1.1.3

*Testing*:
Generated components.yaml for clusterApi, controlplane and bootstrap. Used these components.yaml files in the latest bundle-release.yaml. Created BR cluster with bundles-override flag pointing to the modified bundle-release.yaml

```
kustomize build config/default | ./hack/tools/bin/envsubst > capi.yaml
➜  cluster-api git:(eksa-113) ✗ diff capi.yaml core-components.yaml
9844c9844,9845
<         - --feature-gates=MachinePool=false,ClusterResourceSet=false,ClusterTopology=false
---
>         - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},ClusterResourceSet=${EXP_CLUSTER_RESOURCE_SET:=false},ClusterTopology=${CLUSTER_TOPOLOGY:=false}
>         - --namespace=eksa-system
9847,9848c9848,9849
<         image: gcr.io/k8s-staging-cluster-api/cluster-api-controller:main
<         imagePullPolicy: Always
---
>         image: public.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api/cluster-api-controller:v1.1.3-eks-a-v0.0.0-dev-build.2278
>         imagePullPolicy: IfNotPresent
```

```
 kustomize build controlplane/kubeadm/config/default | ./hack/tools/bin/envsubst > kcp.yaml
➜  cluster-api git:(eksa-113) ✗ diff control-plane-components.yaml kcp.yaml
3331a3332
>                     - bottlerocket
6134a6136
>                             - bottlerocket
7040,7041c7042
<         - --feature-gates=ClusterTopology=${CLUSTER_TOPOLOGY:=false},KubeadmBootstrapFormatIgnition=${EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION:=false}
<         - --namespace=eksa-system
---
>         - --feature-gates=ClusterTopology=false,KubeadmBootstrapFormatIgnition=false
7044,7045c7045,7046
<         image: public.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api/kubeadm-control-plane-controller:v1.1.3-eks-a-v0.0.0-dev-build.2278
<         imagePullPolicy: IfNotPresent
---
>         image: gcr.io/k8s-staging-cluster-api/kubeadm-control-plane-controller:main
>         imagePullPolicy: Always
```

```
kustomize build bootstrap/kubeadm/config/default | ./hack/tools/bin/envsubst > bootstrap.yaml
➜  cluster-api git:(eksa-113) ✗ diff bootstrap.yaml bootstrap-components.yaml
2847d2846
<                 - bottlerocket
6374d6372
<                         - bottlerocket
7154c7152,7153
<         - --feature-gates=MachinePool=false,KubeadmBootstrapFormatIgnition=false
---
>         - --feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},KubeadmBootstrapFormatIgnition=${EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION:=false}
>         - --namespace=eksa-system
7157,7158c7156,7157
<         image: gcr.io/k8s-staging-cluster-api/kubeadm-bootstrap-controller:main
<         imagePullPolicy: Always
---
>         image: public.ecr.aws/l0g8r8j6/kubernetes-sigs/cluster-api/kubeadm-bootstrap-controller:v1.1.3-eks-a-v0.0.0-dev-build.2278
>         imagePullPolicy: IfNotPresent
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
