### PR TITLE
Add RHEL 8 to RHEL versions list in image-builder Makefile

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0009-Add-support-for-RHEL-8-OVA-builds.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0009-Add-support-for-RHEL-8-OVA-builds.patch
@@ -1,18 +1,27 @@
-From 213fdd45f96292c49c29dd1db690a363ecc15998 Mon Sep 17 00:00:00 2001
+From 920f8dc17bb7c710fe9744dfa880591deac8cd2f Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
-Date: Fri, 1 Apr 2022 14:49:35 -0700
+Date: Thu, 14 Apr 2022 10:35:07 -0700
 Subject: [PATCH] Add support for RHEL 8 OVA builds
 
 ---
- images/capi/Makefile               |  1 +
+ images/capi/Makefile               |  3 ++-
  images/capi/packer/ova/rhel-8.json | 19 +++++++++++++++++++
- 2 files changed, 20 insertions(+)
+ 2 files changed, 21 insertions(+), 1 deletion(-)
  create mode 100644 images/capi/packer/ova/rhel-8.json
 
 diff --git a/images/capi/Makefile b/images/capi/Makefile
-index f04f93021..5e4c9d5bd 100644
+index f04f93021..114812beb 100644
 --- a/images/capi/Makefile
 +++ b/images/capi/Makefile
+@@ -213,7 +213,7 @@ PACKER_WINDOWS_NODE_FLAGS := $(foreach f,$(abspath $(COMMON_WINDOWS_VAR_FILES)),
+ CENTOS_VERSIONS			:=	centos-7
+ FLATCAR_VERSIONS		:=	flatcar
+ PHOTON_VERSIONS			:=	photon-3
+-RHEL_VERSIONS			:=	rhel-7
++RHEL_VERSIONS			:=	rhel-7 rhel-8
+ ROCKYLINUX_VERSIONS     :=  rockylinux-8
+ UBUNTU_VERSIONS			:=	ubuntu-1804 ubuntu-2004 ubuntu-2004-efi
+ WINDOWS_VERSIONS		:=	windows-2019 windows-2004 windows-2022
 @@ -510,6 +510,7 @@ build-haproxy-ova-esx-photon-3: ## Builds Photon 3 HAProxy OVA w remote hypervis
  build-node-ova-vsphere-centos-7: ## Builds CentOS 7 Node OVA and template on vSphere
  build-node-ova-vsphere-photon-3: ## Builds Photon 3 Node OVA and template on vSphere
@@ -23,7 +32,7 @@ index f04f93021..5e4c9d5bd 100644
  build-node-ova-vsphere-ubuntu-2004: ## Builds Ubuntu 20.04 Node OVA and template on vSphere
 diff --git a/images/capi/packer/ova/rhel-8.json b/images/capi/packer/ova/rhel-8.json
 new file mode 100644
-index 000000000..f4f49dc91
+index 000000000..e60d924fd
 --- /dev/null
 +++ b/images/capi/packer/ova/rhel-8.json
 @@ -0,0 +1,19 @@


### PR DESCRIPTION
We need to add rhel-8 to RHEL_VERSIONS list to be able to call the new RHEL 8 ova target.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
