### PR TITLE
Use S3 URL for downloading RHEL ISO

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0009-Add-support-for-RHEL-8-OVA-builds.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0009-Add-support-for-RHEL-8-OVA-builds.patch
@@ -48,7 +48,7 @@ index 000000000..e60d924fd
 +  "guest_os_type": "rhel8-64",
 +  "iso_checksum": "48f955712454c32718dcde858dea5aca574376a1d7a4b0ed6908ac0b85597811",
 +  "iso_checksum_type": "sha256",
-+  "iso_url": "rhel-8.4-x86_64-dvd.iso",
++  "iso_url": "https://redhat-iso-images.s3.amazonaws.com/8.4/rhel-8.4-x86_64-dvd.iso",
 +  "os_display_name": "RHEL 8",
 +  "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm",
 +  "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8",


### PR DESCRIPTION
Using S3 URL for downloading RHEL ISO for image builds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
