### PR TITLE
Check the 'State' field of Hardware object is set to 'HardwareAvailable"

### DIFF
--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/CHECKSUMS
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/CHECKSUMS
@@ -1,2 +1,2 @@
-cada504318be95acd8000390e6c8a5de88ce1d76e1bac650b3df120640c6bda6  _output/bin/cluster-api-provider-tinkerbell/linux-amd64/manager
-94df408d3342c4bbb0f8c6861dd9de0f00dfcb17c89e8f0e06e65cd278052964  _output/bin/cluster-api-provider-tinkerbell/linux-arm64/manager
+9e669010996d8b41469c166f58e1993f479c38e44a705421aaa74c2b6c37ed5e  _output/bin/cluster-api-provider-tinkerbell/linux-amd64/manager
+32064984cb1cf10f384b3f1318cfca0e6a41a5a0bab191db487ed0ef99741ea0  _output/bin/cluster-api-provider-tinkerbell/linux-arm64/manager

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0014-When-checking-availability-while-picking-hardware-to.patch
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0014-When-checking-availability-while-picking-hardware-to.patch
@@ -1,0 +1,38 @@
+From 0df6637c5bbbeb2470841c558dfc553ed4f29668 Mon Sep 17 00:00:00 2001
+From: Pooja Trivedi <poojatrivedi@gmail.com>
+Date: Thu, 14 Apr 2022 20:38:39 +0000
+Subject: [PATCH] When checking availability while picking hardware to assign
+ to machines, check the 'State' field of the Hardware along with checking the
+ ownerName label
+
+---
+ controllers/tinkerbellcluster_controller.go | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/controllers/tinkerbellcluster_controller.go b/controllers/tinkerbellcluster_controller.go
+index 04cd3c9..7e855e6 100644
+--- a/controllers/tinkerbellcluster_controller.go
++++ b/controllers/tinkerbellcluster_controller.go
+@@ -198,7 +198,18 @@ func nextHardware(ctx context.Context, k8sClient client.Client, selectors []stri
+ 		return nil, nil
+ 	}
+ 
+-	return &availableHardwares.Items[0], nil
++	var i int
++	for i = 0; i < len(availableHardwares.Items); i++ {
++		if availableHardwares.Items[i].Status.State == tinkv1.HardwareAvailable {
++			break
++		}
++	}
++
++	if i >= len(availableHardwares.Items) {
++		return nil, nil
++	}
++
++	return &availableHardwares.Items[i], nil
+ }
+ 
+ func hardwareIP(hardware *tinkv1.Hardware) (string, error) {
+-- 
+2.25.1
+


### PR DESCRIPTION
when assigning hardware to machines, along with checking the ownerName label

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
