### PR TITLE
avoid assign shell calls in makefile macros

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -6,7 +6,7 @@ SHELL=bash
 
 RELEASE_ENVIRONMENT?=development
 
-GIT_HASH=$(shell git -C $(BASE_DIRECTORY) rev-parse HEAD)
+GIT_HASH:=$(shell git -C $(BASE_DIRECTORY) rev-parse HEAD)
 
 COMPONENT?=$(REPO_OWNER)/$(REPO)
 MAKE_ROOT=$(BASE_DIRECTORY)/projects/$(COMPONENT)
@@ -51,7 +51,7 @@ else
 	ifeq ($(CI),true)
 		BUILD_IDENTIFIER=$(PROW_JOB_ID)
 	else
-		BUILD_IDENTIFIER=$(shell date "+%F-%s")
+		BUILD_IDENTIFIER:=$(shell date "+%F-%s")
 	endif
 endif
 ####################################################
@@ -67,7 +67,7 @@ PATCHES_DIR=$(or $(wildcard $(PROJECT_ROOT)/patches),$(wildcard $(MAKE_ROOT)/pat
 #################### RELEASE BRANCHES ##############
 HAS_RELEASE_BRANCHES?=false
 RELEASE_BRANCH?=
-SUPPORTED_K8S_VERSIONS=$(shell cat $(BASE_DIRECTORY)/release/SUPPORTED_RELEASE_BRANCHES)
+SUPPORTED_K8S_VERSIONS:=$(shell cat $(BASE_DIRECTORY)/release/SUPPORTED_RELEASE_BRANCHES)
 BINARIES_ARE_RELEASE_BRANCHED?=true
 IS_RELEASE_BRANCH_BUILD=$(filter true,$(HAS_RELEASE_BRANCHES))
 IS_UNRELEASE_BRANCH_TARGET=$(and $(filter false,$(BINARIES_ARE_RELEASE_BRANCHED)),$(filter binaries attribution checksums,$(MAKECMDGOALS)))
@@ -169,8 +169,8 @@ SOURCE_PATTERNS_BUILD_TOGETHER=$(filter-out $(SOURCE_PATTERNS_BUILD_ALONE),$(SOU
 #### CGO ############
 CGO_CREATE_BINARIES?=false
 CGO_SOURCE=$(OUTPUT_DIR)/source
-IS_ON_BUILDER_BASE=$(shell if [ -f /buildkit.sh ]; then echo true; fi;)
-BUILDER_PLATFORM=$(shell echo $$(go env GOHOSTOS)/$$(go env GOHOSTARCH))
+IS_ON_BUILDER_BASE:=$(shell if [ -f /buildkit.sh ]; then echo true; fi;)
+BUILDER_PLATFORM:=$(shell echo $$(go env GOHOSTOS)/$$(go env GOHOSTARCH))
 needs-cgo-builder=$(and $(if $(filter true,$(CGO_CREATE_BINARIES)),true,),$(if $(filter-out $(1),$(BUILDER_PLATFORM)),true,))
 ######################
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
 BUILD_LIB=${BASE_DIRECTORY}/build/lib
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 AWS_REGION?=us-west-2
@@ -14,7 +14,7 @@ EKSA_TOOLS_PREREQS_BUILD_TARGETS=$(addprefix build-project-, $(EKSA_TOOLS_PREREQ
 ALL_PROJECTS=$(PROJECTS) $(EKSA_TOOLS_PREREQS) aws_bottlerocket-bootstrap aws_eks-anywhere-build-tooling kubernetes-sigs_image-builder
 
 RELEASE_BRANCH?=
-GIT_HASH=$(shell git -C $(BASE_DIRECTORY) rev-parse HEAD)
+GIT_HASH:=$(shell git -C $(BASE_DIRECTORY) rev-parse HEAD)
 
 .PHONY: build-all-projects
 build-all-projects: $(BUILD_TARGETS) aws_bottlerocket-bootstrap aws_eks-anywhere-build-tooling

--- a/projects/apache/cloudstack-cloudmonkey/Makefile
+++ b/projects/apache/cloudstack-cloudmonkey/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.16"
 
 REPO=cloudstack-cloudmonkey

--- a/projects/aws-containers/hello-eks-anywhere/Makefile
+++ b/projects/aws-containers/hello-eks-anywhere/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.17"
 
 REPO=hello-eks-anywhere

--- a/projects/aws/bottlerocket-bootstrap/Makefile
+++ b/projects/aws/bottlerocket-bootstrap/Makefile
@@ -1,5 +1,5 @@
 # avoid finding the local fake git repo by looking one level up when looking for base_directory
-BASE_DIRECTORY=$(shell git -C .. rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(shell git -C .. rev-parse --show-toplevel)
 GOLANG_VERSION?=1.16
 
 REPO=bottlerocket-bootstrap

--- a/projects/aws/cluster-api-provider-aws-snow/Makefile
+++ b/projects/aws/cluster-api-provider-aws-snow/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 
 REPO=cluster-api-provider-aws-snow
 REPO_OWNER=aws

--- a/projects/aws/cluster-api-provider-cloudstack/Makefile
+++ b/projects/aws/cluster-api-provider-cloudstack/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.17"
 
 REPO=cluster-api-provider-cloudstack

--- a/projects/aws/eks-anywhere-build-tooling/Makefile
+++ b/projects/aws/eks-anywhere-build-tooling/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 
 REPO=eks-anywhere-build-tooling
 REPO_OWNER=aws

--- a/projects/aws/eks-anywhere-packages/Makefile
+++ b/projects/aws/eks-anywhere-packages/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.17"
 
 REPO=eks-anywhere-packages

--- a/projects/aws/eks-anywhere/Makefile
+++ b/projects/aws/eks-anywhere/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 
 REPO=eks-anywhere
 REPO_OWNER=aws

--- a/projects/brancz/kube-rbac-proxy/Makefile
+++ b/projects/brancz/kube-rbac-proxy/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.13"
 
 REPO=kube-rbac-proxy

--- a/projects/cilium/cilium/Makefile
+++ b/projects/cilium/cilium/Makefile
@@ -1,6 +1,6 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
-CHART_TAG=$(shell echo $(GIT_TAG) | sed 's/^v//')
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
+CHART_TAG:=$(shell echo $(GIT_TAG) | sed 's/^v//')
 
 REGISTRY=public.ecr.aws/isovalent
 CILIUM_IMAGE=cilium

--- a/projects/cloudflare/cfssl/Makefile
+++ b/projects/cloudflare/cfssl/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.14"
 
 REPO=cfssl
@@ -18,7 +18,7 @@ RICE_EMBED_TARGET=$(REPO)/cli/serve/rice-box.go
 
 GIT_CLONE_DEPENDENCY=$(GIT_DEPS_DIR)/cfssl_trust/LICENSE
 
-STATIC_FILES=$(shell git -C cfssl ls-tree -r -t --name-only HEAD ./cli/serve/static)
+STATIC_FILES=$(shell git -C $(REPO) ls-tree -r -t --name-only HEAD ./cli/serve/static)
 
 include $(BASE_DIRECTORY)/Common.mk
 

--- a/projects/distribution/distribution/Makefile
+++ b/projects/distribution/distribution/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.17"
 
 REPO=distribution

--- a/projects/fluxcd/flux2/Makefile
+++ b/projects/fluxcd/flux2/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.17"
 
 REPO=flux2

--- a/projects/fluxcd/helm-controller/Makefile
+++ b/projects/fluxcd/helm-controller/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.17"
 
 REPO=helm-controller

--- a/projects/fluxcd/kustomize-controller/Makefile
+++ b/projects/fluxcd/kustomize-controller/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.17"
 
 REPO=kustomize-controller

--- a/projects/fluxcd/notification-controller/Makefile
+++ b/projects/fluxcd/notification-controller/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.17"
 
 REPO=notification-controller

--- a/projects/fluxcd/source-controller/Makefile
+++ b/projects/fluxcd/source-controller/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.17"
 
 REPO=source-controller

--- a/projects/goharbor/harbor/Makefile
+++ b/projects/goharbor/harbor/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.17"
 REGISTRYVERSION=2.8.0-patch-2819-2553-redis
 NOTARYVERSION=v0.6.1

--- a/projects/grpc-ecosystem/grpc-health-probe/Makefile
+++ b/projects/grpc-ecosystem/grpc-health-probe/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.17"
 
 REPO=grpc-health-probe

--- a/projects/helm/helm/Makefile
+++ b/projects/helm/helm/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.17"
 
 REPO=helm

--- a/projects/jetstack/cert-manager/Makefile
+++ b/projects/jetstack/cert-manager/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.16"
 
 REPO=cert-manager

--- a/projects/kubernetes-sigs/cluster-api-provider-aws/Makefile
+++ b/projects/kubernetes-sigs/cluster-api-provider-aws/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.13"
 
 REPO=cluster-api-provider-aws

--- a/projects/kubernetes-sigs/cluster-api-provider-vsphere/Makefile
+++ b/projects/kubernetes-sigs/cluster-api-provider-vsphere/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.17"
 
 REPO=cluster-api-provider-vsphere

--- a/projects/kubernetes-sigs/cluster-api/Makefile
+++ b/projects/kubernetes-sigs/cluster-api/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.17"
 
 REPO=cluster-api

--- a/projects/kubernetes-sigs/cri-tools/Makefile
+++ b/projects/kubernetes-sigs/cri-tools/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.14"
 
 REPO=cri-tools

--- a/projects/kubernetes-sigs/etcdadm/Makefile
+++ b/projects/kubernetes-sigs/etcdadm/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.16"
 
 REPO=etcdadm

--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 
 REPO=image-builder
 REPO_OWNER=kubernetes-sigs

--- a/projects/kubernetes-sigs/kind/Makefile
+++ b/projects/kubernetes-sigs/kind/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.17"
 
 REPO=kind

--- a/projects/kubernetes-sigs/vsphere-csi-driver/Makefile
+++ b/projects/kubernetes-sigs/vsphere-csi-driver/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.15"
 
 REPO=vsphere-csi-driver

--- a/projects/kubernetes/cloud-provider-vsphere/Makefile
+++ b/projects/kubernetes/cloud-provider-vsphere/Makefile
@@ -1,6 +1,6 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat ./$(RELEASE_BRANCH)/GIT_TAG)
-GOLANG_VERSION?=$(shell cat ./$(RELEASE_BRANCH)/GOLANG_VERSION)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat ./$(RELEASE_BRANCH)/GIT_TAG)
+GOLANG_VERSION:=$(shell cat ./$(RELEASE_BRANCH)/GOLANG_VERSION)
 
 REPO=cloud-provider-vsphere
 REPO_OWNER=kubernetes

--- a/projects/mrajashree/etcdadm-bootstrap-provider/Makefile
+++ b/projects/mrajashree/etcdadm-bootstrap-provider/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.16"
 
 REPO=etcdadm-bootstrap-provider

--- a/projects/mrajashree/etcdadm-controller/Makefile
+++ b/projects/mrajashree/etcdadm-controller/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.16"
 
 REPO=etcdadm-controller

--- a/projects/plunder-app/kube-vip/Makefile
+++ b/projects/plunder-app/kube-vip/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.16"
 
 REPO=kube-vip

--- a/projects/rancher/local-path-provisioner/Makefile
+++ b/projects/rancher/local-path-provisioner/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.13"
 
 REPO=local-path-provisioner

--- a/projects/redis/redis/Makefile
+++ b/projects/redis/redis/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 
 REPO=redis
 REPO_OWNER=redis

--- a/projects/replicatedhq/troubleshoot/Makefile
+++ b/projects/replicatedhq/troubleshoot/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.17"
 
 REPO=troubleshoot

--- a/projects/tinkerbell/boots/Makefile
+++ b/projects/tinkerbell/boots/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.16"
 
 REPO=boots

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/Makefile
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.16"
 
 REPO=cluster-api-provider-tinkerbell

--- a/projects/tinkerbell/hegel/Makefile
+++ b/projects/tinkerbell/hegel/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.15"
 
 REPO=hegel

--- a/projects/tinkerbell/hook/Makefile
+++ b/projects/tinkerbell/hook/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.15"
 
 REPO=hook

--- a/projects/tinkerbell/hub/Makefile
+++ b/projects/tinkerbell/hub/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.15"
 
 REPO=hub

--- a/projects/tinkerbell/pbnj/Makefile
+++ b/projects/tinkerbell/pbnj/Makefile
@@ -1,7 +1,7 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 IPMITOOL_CLONE_URL=$(call GET_CLONE_URL,ipmitool,ipmitool)
-IPMITOOL_GIT_TAG=$(shell cat IPMITOOL_GIT_TAG)
+IPMITOOL_GIT_TAG:=$(shell cat IPMITOOL_GIT_TAG)
 GOLANG_VERSION?="1.16"
 
 REPO=pbnj

--- a/projects/tinkerbell/tink/Makefile
+++ b/projects/tinkerbell/tink/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.17"
 
 REPO=tink

--- a/projects/vmware/govmomi/Makefile
+++ b/projects/vmware/govmomi/Makefile
@@ -1,5 +1,5 @@
-BASE_DIRECTORY=$(shell git rev-parse --show-toplevel)
-GIT_TAG?=$(shell cat GIT_TAG)
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION="1.17"
 
 REPO=govmomi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`:=` in makefiles creates a "real" variable who's value is determine at the time of assignment.  `=` or `?=` creates a macro in the makfile who's value is not determined until the time that it is to be used.  We use this intentionally all over to ensure we can set variables during the flow through make targets.  When calling `$(shell...)` via a macro, make shells out everytime the value is requested.  For something like `BASE_DIRECTORY` or `GIT_TAG` this could be a number of times.  This changes as many of the calls to shell as possible to use `:=` instead of `=`.  There are still some instances throughout the code base of `=$(shell ..)` which are completely acceptable and necessary.  For example, any time the shell needs the value of a var which may not have been set yet or needs to access the REPO which hasnt been cloned yet.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
