### PR TITLE
troubleshoot: fix gather-licenses target

### DIFF
--- a/projects/replicatedhq/troubleshoot/Makefile
+++ b/projects/replicatedhq/troubleshoot/Makefile
@@ -20,7 +20,7 @@ include $(BASE_DIRECTORY)/Common.mk
 
 $(GATHER_LICENSES_TARGETS): $(FIX_LICENSES_GO_SPIN_TARGET)
 
-$(FIX_LICENSES_GO_SPIN_TARGET):
+$(FIX_LICENSES_GO_SPIN_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
 # The tj/go-spin dependency github repo has a license file however it does not have a go.mod file
 # checked in to the repo. Hence we need to manually download the license from Github and place
 # it in the respective folder under vendor directory so that they is available for go-licenses


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

With the recent changes to the go mod handling and changing some of the common.mk targets to be % based, the ordering got shifted a bit. The normal build target is working fine, but when running gather-licenses directly there is an issue, which is breaking the attribution job.

This target should have always been dependent on the GO_MOD_DOWNLOAD_TARGETS, most of the other projects in this repo were already handling this proper except for troubleshoot. This was previously working because the GATHER_LICENSES_TARGETS which we were adding this as a pre-req for matched exactly the target in Common.mk, ie there were % usage. Now that the gather licenses target is % based, the one in the project [makefile](https://github.com/aws/eks-distro/pull/900/files#diff-a2d191cda2c98aa90c7236d7f431bf4224774a861c083b05cd881a181b032942R26) is taking a higher priority and triggering the fix-licenses target to run before go mod download, whereas it used to run after. Add the expect pre-req is the way to go.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
