### PR TITLE
cli-tools: remove clusterawsadm

### DIFF
--- a/projects/aws/eks-anywhere-build-tooling/Makefile
+++ b/projects/aws/eks-anywhere-build-tooling/Makefile
@@ -15,7 +15,7 @@ HAS_LICENSES=false
 BUILD_TARGETS=local-images
 RELEASE_TARGETS=images
 
-FETCH_BINARIES_TARGETS=eksa/fluxcd/flux2 eksa/kubernetes-sigs/cluster-api eksa/kubernetes-sigs/cluster-api-provider-aws \
+FETCH_BINARIES_TARGETS=eksa/fluxcd/flux2 eksa/kubernetes-sigs/cluster-api \
 	eksa/kubernetes-sigs/kind eksa/replicatedhq/troubleshoot eksa/vmware/govmomi eksd/kubernetes/client eksa/helm/helm eksa/tinkerbell/tink \
 	eksa/apache/cloudstack-cloudmonkey
 

--- a/projects/aws/eks-anywhere-build-tooling/build/organize_binaries.sh
+++ b/projects/aws/eks-anywhere-build-tooling/build/organize_binaries.sh
@@ -33,7 +33,6 @@ mkdir -p $EKS_A_TOOL_LICENSE_DIR
 
 declare -A project_bin_licenses=(["eksa/fluxcd/flux2"]="flux FLUX2"
                                  ["eksa/kubernetes-sigs/cluster-api"]="clusterctl CAPI"
-                                 ["eksa/kubernetes-sigs/cluster-api-provider-aws"]="clusterawsadm CAPA"
                                  ["eksa/kubernetes-sigs/kind"]="kind KIND"
                                  ["eksd/kubernetes"]="client/bin/kubectl KUBERNETES"
                                  ["eksa/replicatedhq/troubleshoot"]="support-bundle TROUBLESHOOT"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We havent support capa in a while and arent updating it anymore.  This shouldnt be necessary in the cli tools image any more.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
