### PR TITLE
Specify commit for tink-cli binary instead of using latest

### DIFF
--- a/build/lib/fetch_binaries.sh
+++ b/build/lib/fetch_binaries.sh
@@ -33,8 +33,11 @@ OS_ARCH="$(cut -d '/' -f1 <<< ${DEP})"
 PRODUCT=$(cut -d '/' -f2 <<< ${DEP})
 REPO_OWNER=$(cut -d '/' -f3 <<< ${DEP})
 REPO=$(cut -d '/' -f4 <<< ${DEP})
+S3_ARTIFACTS_FOLDER_OVERRIDE=$(cut -d '/' -f5 <<< ${DEP})
 ARCH="$(cut -d '-' -f2 <<< ${OS_ARCH})"
 CODEBUILD_CI="${CODEBUILD_CI:-false}"
+
+S3_ARTIFACTS_FOLDER=${S3_ARTIFACTS_FOLDER_OVERRIDE:-$LATEST_TAG}
 
 OUTPUT_DIR_FILE=$BINARY_DEPS_DIR/linux-$ARCH/$PRODUCT/$REPO_OWNER/$REPO
 if [[ $REPO == *.tar.gz ]]; then
@@ -54,7 +57,7 @@ if [[ $PRODUCT = 'eksd' ]]; then
     fi
 else
     TARBALL="$REPO-linux-$ARCH.tar.gz"
-    URL=$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET $REPO_OWNER/$REPO $ARCH $LATEST_TAG)
+    URL=$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET $REPO_OWNER/$REPO $ARCH $S3_ARTIFACTS_FOLDER)
 fi
 
 if [ "$CODEBUILD_CI" = "true" ]; then

--- a/projects/aws/eks-anywhere-build-tooling/Makefile
+++ b/projects/aws/eks-anywhere-build-tooling/Makefile
@@ -16,7 +16,7 @@ BUILD_TARGETS=local-images
 RELEASE_TARGETS=images
 
 FETCH_BINARIES_TARGETS=eksa/fluxcd/flux2 eksa/kubernetes-sigs/cluster-api \
-	eksa/kubernetes-sigs/kind eksa/replicatedhq/troubleshoot eksa/vmware/govmomi eksd/kubernetes/client eksa/helm/helm eksa/tinkerbell/tink \
+	eksa/kubernetes-sigs/kind eksa/replicatedhq/troubleshoot eksa/vmware/govmomi eksd/kubernetes/client eksa/helm/helm eksa/tinkerbell/tink/94-2b1eddcdf90082499b7663ca3c47e77dc12ad34c \
 	eksa/apache/cloudstack-cloudmonkey
 
 ORGANIZE_BINARIES_TARGETS=$(addsuffix /eks-a-tools,$(addprefix $(BINARY_DEPS_DIR)/linux-,amd64 arm64))


### PR DESCRIPTION
*Description of changes:*
We want to use tink-cli image from a previous commit instead of the latest one because of some of the breaking changes that went in to tink-cli because of the kubification. This is needed to temporarily allow the eks-anywhere workflows to still succeed while we work on updating it to account for kubification changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
