### PR TITLE
Use proper git tag for overriden artifacts

### DIFF
--- a/build/lib/fetch_binaries.sh
+++ b/build/lib/fetch_binaries.sh
@@ -38,6 +38,10 @@ ARCH="$(cut -d '-' -f2 <<< ${OS_ARCH})"
 CODEBUILD_CI="${CODEBUILD_CI:-false}"
 
 S3_ARTIFACTS_FOLDER=${S3_ARTIFACTS_FOLDER_OVERRIDE:-$LATEST_TAG}
+GIT_COMMIT_OVERRIDE=false
+if [ -n "$S3_ARTIFACTS_FOLDER_OVERRIDE" ]; then
+    GIT_COMMIT_OVERRIDE=true
+fi
 
 OUTPUT_DIR_FILE=$BINARY_DEPS_DIR/linux-$ARCH/$PRODUCT/$REPO_OWNER/$REPO
 if [[ $REPO == *.tar.gz ]]; then
@@ -57,7 +61,7 @@ if [[ $PRODUCT = 'eksd' ]]; then
     fi
 else
     TARBALL="$REPO-linux-$ARCH.tar.gz"
-    URL=$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET $REPO_OWNER/$REPO $ARCH $S3_ARTIFACTS_FOLDER)
+    URL=$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET $REPO_OWNER/$REPO $ARCH $S3_ARTIFACTS_FOLDER $GIT_COMMIT_OVERRIDE)
 fi
 
 if [ "$CODEBUILD_CI" = "true" ]; then


### PR DESCRIPTION
In case of downloading artifacts from an older commit instead of latest, we need to use the git tag of the artifact from that commit.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
