### PR TITLE
Add 'tinkerbell/tink' in the image URI for tink manifest

### DIFF
--- a/projects/tinkerbell/tink/Makefile
+++ b/projects/tinkerbell/tink/Makefile
@@ -37,7 +37,7 @@ s3-artifacts: create-manifests
 
 .PHONY: create-manifests
 create-manifests: tarballs
-	build/create_manifests.sh $(REPO) $(ARTIFACTS_PATH) $(IMAGE_REPO) $(IMAGE_TAG) $(GOLANG_VERSION)
+	build/create_manifests.sh $(REPO) $(ARTIFACTS_PATH) $(IMAGE_REPO) $(TINK_SERVER_IMAGE_COMPONENT) ${TINK_CONTROLLER_IMAGE_COMPONENT} $(IMAGE_TAG) $(GOLANG_VERSION)
 
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block

--- a/projects/tinkerbell/tink/build/create_manifests.sh
+++ b/projects/tinkerbell/tink/build/create_manifests.sh
@@ -21,8 +21,10 @@ set -o pipefail
 REPO="$1"
 ARTIFACTS_PATH="$2"
 IMAGE_REPO="$3"
-IMAGE_TAG="$4"
-GOLANG_VERSION="$5"
+TINK_SERVER_IMAGE_COMPONENT="$4"
+TINK_CONTROLLER_IMAGE_COMPONENT="$5"
+IMAGE_TAG="$6"
+GOLANG_VERSION="$7"
 
 MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 source "${MAKE_ROOT}/../../../build/lib/common.sh"
@@ -34,8 +36,8 @@ cd $REPO
 npm install prettier --global
 
 make release-manifests \
-  TINK_SERVER_IMAGE=${IMAGE_REPO}/tink-server \
-  TINK_CONTROLLER_IMAGE=${IMAGE_REPO}/tink-controller \
+  TINK_SERVER_IMAGE=${IMAGE_REPO}/${TINK_SERVER_IMAGE_COMPONENT} \
+  TINK_CONTROLLER_IMAGE=${IMAGE_REPO}/${TINK_CONTROLLER_IMAGE_COMPONENT} \
   TINK_SERVER_TAG=${IMAGE_TAG} \
   TINK_CONTROLLER_TAG=${IMAGE_TAG}
 


### PR DESCRIPTION
*Description of changes:*
Add `tinkerbell/tink` in the image URI for tink manifest

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
