### PR TITLE
Add target to build latest snow raw admin image

### DIFF
--- a/projects/aws/eks-a-admin-image/Makefile
+++ b/projects/aws/eks-a-admin-image/Makefile
@@ -45,7 +45,7 @@ PACKER=$(BINARY_DEPS_DIR)/packer
 build-%: export PKR_VAR_eks-a-version=$(EKSA_VERSION)
 build-%: export PKR_VAR_eks-a-release-manifest-url=$(EKSA_RELEASE_MANIFEST_URL)
 build-%: export PKR_VAR_build-version=$(shell echo $(GIT_HASH) | cut -c1-7)
-build-%: KUBECTL_URL?=$(shell ./build/get_kubectl_url.sh)
+build-%: KUBECTL_URL:=$(shell ./build/get_kubectl_url.sh)
 build-%: export PKR_VAR_kubectl-url=$(KUBECTL_URL)
 
 
@@ -65,12 +65,16 @@ $(AMI_OUTPUT_DIR): $(FULL_OUTPUT_DIR)
 $(OVA_OUTPUT_DIR): $(FULL_OUTPUT_DIR)
 	mkdir -p $@
 
-.PHONY: build-raw-image
-build-raw-image: build-ami export-to-raw
+.PHONY: latest-snow-raw-image
+latest-snow-raw-image: EKSA_VERSION:=$(shell EKSA_RELEASE_MANIFEST_URL=$(EKSA_RELEASE_MANIFEST_URL) ./build/get_latest_eksa_version_by_date.sh)
+latest-snow-raw-image: snow-raw-image
 
-.PHONY: build-ami
-build-ami: export PKR_VAR_manifest-output=$(AMI_MANIFEST_PATH)
-build-ami: $(PACKER) init clean-ami $(AMI_OUTPUT_DIR)
+.PHONY: snow-raw-image
+snow-raw-image: build-snow-ami export-to-raw
+
+.PHONY: build-snow-ami
+build-snow-ami: export PKR_VAR_manifest-output=$(AMI_MANIFEST_PATH)
+build-snow-ami: $(PACKER) init clean-ami $(AMI_OUTPUT_DIR)
 	$(PACKER) build -only='*.amazon-ebs.*' .
 
 .PHONY: export-to-raw
@@ -88,7 +92,7 @@ build-ova: export PKR_VAR_vsphere_cluster = $(VSPHERE_CLUSTER)
 build-ova: export PKR_VAR_vsphere_network = $(VSPHERE_NETWORK)
 build-ova: export PKR_VAR_build-password = $(BUILD_PASSWORD)
 build-ova: export PKR_VAR_build-output = $(OVA_OUTPUT_DIR)
-build-ova: KIND_URL=$(shell ./build/get_kind_url.sh $(ARTIFACTS_BUCKET) )
+build-ova: KIND_URL:=$(shell ./build/get_kind_url.sh $(ARTIFACTS_BUCKET) )
 build-ova: export PKR_VAR_kind-url=$(KIND_URL)
 build-ova: $(PACKER) init clean-ova $(OVA_OUTPUT_DIR)
 	$(PACKER) build -only='*.vsphere-iso.*' -var-file=ova/linux/ubuntu/vsphere.ubuntu.pkrvars.hcl .

--- a/projects/aws/eks-a-admin-image/build/get_latest_eksa_version_by_date.sh
+++ b/projects/aws/eks-a-admin-image/build/get_latest_eksa_version_by_date.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -x
+set -o errexit
+set -o nounset
+set -o pipefail
+
+RELEASES_MANIFEST=$(curl --silent -L $EKSA_RELEASE_MANIFEST_URL)
+
+newest_release_date=0
+newest_release_version=""
+
+while IFS=$'\t' read -r date version _; do
+	# date is something like '2022-05-05 13:05:34.038243612 +0000 UTC'
+	# I can't get `date` to parse this format, so deleting the extra timezone first
+	parsed_date=$(date -d "$(echo $date | awk '{print $1,$2,$3}')" +"%s")
+
+	if [ $parsed_date -gt $newest_release_date ];
+	then
+		newest_release_date=$parsed_date
+		newest_release_version=$version
+	fi  
+done < <(echo "$RELEASES_MANIFEST" | yq e '.spec.releases[] | [.date, .version] | @tsv' -)
+
+if [ -z "${newest_release_version}" ]; then
+	echo "Not valid release found"
+	exit 1
+fi
+
+echo -n "$newest_release_version"

--- a/projects/aws/eks-a-admin-image/common.pkr.hcl
+++ b/projects/aws/eks-a-admin-image/common.pkr.hcl
@@ -1,7 +1,7 @@
 
 locals {
   timestamp  = regex_replace(timestamp(), "[- TZ:]", "")
-  image_name = "eks-a-admin-${var.eks-a-version}-${var.build-version}-${local.timestamp}"
+  image_name = "eks-a-admin-${replace(var.eks-a-version, "+", "-")}-${var.build-version}-${local.timestamp}"
 }
 
 variable "build-username" {


### PR DESCRIPTION
Part of https://github.com/aws/eks-anywhere/issues/1166

## Description of changes
This image will be built from a pipeline. Such pipeline will run whenever the release manifest file in S3 changes (this happens every time we build a new version). But that doesn't tell us which is the version that just got built.

We could use the `latestVersion` in the manifest but that will be pointing to the latest release for the latest minor version. If we build a new patch release for the previous minor version (eg. `latestVersion` is `v0.8.2` and we build `v0.7.5` due to some vulnerability) then the `latestVersion` field won't change.

Instead, this just iterates over all the releases and picks the latest one, by date.

This is not ideal. If we trigger two releases in parallel very close in time, it's possible that we will build only one image for whichever release finishes last. We haven't done this before and probably ever won't, so this mechanism should work for now. But something to take into consideration in the future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
