### PR TITLE
Adds new target to create ecr repos

### DIFF
--- a/build/lib/buildkit.sh
+++ b/build/lib/buildkit.sh
@@ -45,5 +45,15 @@ if [ -f "/buildkit.sh" ]; then
     (exit $s)
 else
     # skip retry when running locally
-    $CMD "$@"
+    log_file=$(mktemp)
+    trap "rm -f $log_file" EXIT
+    if ! $CMD "$@" 2>&1 | tee $log_file; then        
+        if grep -q "blobs/uploads/\": EOF" $log_file ; then
+            echo "******************************************************"
+            echo "Ensure container registry and repository exists!!"
+            echo "Try running make create-ecr-repos to create ecr repositories in your aws account."
+            echo "******************************************************"
+        fi
+        exit 1
+    fi
 fi


### PR DESCRIPTION
*Description of changes:*
When building locally it can be useful to push built images to ecr
in our aws accounts to make testing easier. create-ecr-repos target
will create repos for each image defined in the project's IMAGE_NAMES.
This also adds a check during buildctl calls running locally for a
common EOF error that typically indicates a missing repo.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
