### PR TITLE
Select Availability zone randomly for EC2 instance creation

### DIFF
--- a/projects/kubernetes-sigs/image-builder/build/build_raw_image.sh
+++ b/projects/kubernetes-sigs/image-builder/build/build_raw_image.sh
@@ -81,9 +81,14 @@ MAX_RETRIES=15
 for i in $(seq 1 $MAX_RETRIES); do
     echo "Attempt $(($i))"
 
+    AZ_LIST="us-west-2a,us-west-2b,us-west-2c,us-west-2d"
+    AZ_COUNT=$(echo $AZ_LIST | awk -F\, '{print NF}')
+    INDEX=$((($RANDOM % $AZ_COUNT) + 1))
+    AZ=$(cut -d',' -f${INDEX} <<< $AZ_LIST)
+
     # Create a single EC2 instance with provided instance type and AMI
     # Query the instance ID for use in future commands
-    INSTANCE_ID=$(aws ec2 run-instances --count 1 --image-id=$AMI_ID --instance-type $INSTANCE_TYPE --key-name $KEY_NAME $RUN_INSTANCE_EXTRA_ARGS --query "Instances[0].InstanceId" --output text) && break
+    INSTANCE_ID=$(aws ec2 run-instances --count 1 --image-id=$AMI_ID --instance-type $INSTANCE_TYPE --key-name $KEY_NAME --placement "AvailabilityZone=$AZ" $RUN_INSTANCE_EXTRA_ARGS --query "Instances[0].InstanceId" --output text) && break
 
     if [ "$i" = "$MAX_RETRIES" ]; then
         exit 1


### PR DESCRIPTION
It always chooses us-west-2b, which causes InsufficientCapacity issue as below
```
An error occurred (InsufficientInstanceCapacity) when calling the RunInstances operation (reached max retries: 2): We currently do not have sufficient i3en.metal capacity in the Availability Zone you requested (us-west-2b). Our system will be working on provisioning additional capacity. You can currently get i3en.metal capacity by not specifying an Availability Zone in your request or choosing us-west-2a, us-west-2c, us-west-2d.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
