### PR TITLE
Use rsync to exclude git files in helm copy

### DIFF
--- a/build/lib/helm_copy.sh
+++ b/build/lib/helm_copy.sh
@@ -34,5 +34,5 @@ source "${SCRIPT_ROOT}/common.sh"
 # Copy
 #
 mkdir -p ${DEST_DIR}
-cp -r ${SOURCE_DIR} ${DEST_DIR}
+rsync -a --exclude .git "${SOURCE_DIR}" "${DEST_DIR}"
 build::non-golang::copy_licenses ${HELM_SOURCE_REPOSITORY} $DEST_DIR/LICENSES/github.com/${HELM_SOURCE_REPOSITORY}


### PR DESCRIPTION
When make images was re-run (like after a build failure somewhere in
the process), this step would try to replace existing files in the
destination .git directory that were read-only, and so it would fail.

Rather than using cp's -f flag or similar, I figured, why not just
exclude .git entirely? We don't want that going into the helm chart
anyway.

If rsync isn't available in the builder base, this could be a problem
I guess, but I think rsync is pretty standard, and the flags I'm using
have been around for a long time.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
