### PR TITLE
Support creating ECR public repos too.

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -717,8 +717,12 @@ generate: # Update UPSTREAM_PROJECTS.yaml
 .PHONY: %/create-ecr-repo
 %/create-ecr-repo: IMAGE_NAME=$*
 %/create-ecr-repo:
-	if ! aws ecr describe-repositories --repository-name $(IMAGE_REPO_COMPONENT) > /dev/null 2>&1; then \
-		aws ecr create-repository --repository-name $(IMAGE_REPO_COMPONENT); \
+	cmd=( ecr ); \
+	if [[ "${IMAGE_REPO}" =~ ^public\.ecr\.aws/ ]]; then \
+	    cmd=( ecr-public --region us-east-1 ); \
+	fi; \
+	if ! aws $${cmd[*]} describe-repositories --repository-name $(IMAGE_REPO_COMPONENT) > /dev/null 2>&1; then \
+		aws $${cmd[*]} create-repository --repository-name $(IMAGE_REPO_COMPONENT); \
 	fi
 
 .PHONY: create-ecr-repos


### PR DESCRIPTION
If $IMAGE_REPO is determined to be a public ECR repo, then the
create-ecr-repos Makefile target will create public repos instead of
private ones.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
