### PR TITLE
Bump up hegel git tag to latest

### DIFF
--- a/projects/tinkerbell/hegel/CHECKSUMS
+++ b/projects/tinkerbell/hegel/CHECKSUMS
@@ -1,2 +1,2 @@
-006ac3acbf7e3c4e207865c77d546aabe6c8f6f62a981fdae8b493de7156eef0  _output/bin/hegel/linux-amd64/hegel
-00ffd832a35445f5cc4b83c014e26d61dca3f6be5060d7b619621cbbd27d4e2f  _output/bin/hegel/linux-arm64/hegel
+f115cfd72871d9f025780225a150268d359646aa2e1dead8be7235c040ef173f  _output/bin/hegel/linux-amd64/hegel
+0fa2ddc8d6617e6fb6e8834f951af27bfbfc417956f4008a43bff8437edc4ccc  _output/bin/hegel/linux-arm64/hegel

--- a/projects/tinkerbell/hegel/GIT_TAG
+++ b/projects/tinkerbell/hegel/GIT_TAG
@@ -1,1 +1,1 @@
-v0.6.0
+7b286fdc8e8fa91a6e9a179a5494b6ee29fce17b

--- a/projects/tinkerbell/hegel/Makefile
+++ b/projects/tinkerbell/hegel/Makefile
@@ -1,6 +1,6 @@
 BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
 GIT_TAG:=$(shell cat GIT_TAG)
-GOLANG_VERSION?="1.15"
+GOLANG_VERSION?="1.17"
 
 REPO=hegel
 REPO_OWNER=tinkerbell


### PR DESCRIPTION
*Description of changes:*
Bump up hegel GIT_TAG to the latest commit

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
