### PR TITLE
Supprt custom tar file prefixes when fetching dep binaries

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -200,7 +200,7 @@ IF_OVERRIDE_VARIABLE=$(if $(filter undefined,$(origin $1)),$(2),$(value $(1)))
 IMAGE_TARGETS_FOR_NAME=$(addsuffix /images/push, $(1)) $(addsuffix /images/amd64, $(1)) $(addsuffix /images/arm64, $(1))
 
 # $1 - binary file name
-FULL_FETCH_BINARIES_TARGETS=$(addprefix $(BINARY_DEPS_DIR)/linux-amd64/, $(1)) $(addprefix $(BINARY_DEPS_DIR)/linux-arm64/, $(1))
+FULL_FETCH_BINARIES_TARGETS=$(foreach platform,$(BINARY_PLATFORMS),$(addprefix $(BINARY_DEPS_DIR)/$(subst /,-,$(platform))/, $(1)))
 
 # $1 - targets
 # $2 - platforms
@@ -733,3 +733,7 @@ generate: # Update UPSTREAM_PROJECTS.yaml
 .PHONY: create-ecr-repos
 create-ecr-repos: # Create repos in ECR for project images for local testing
 create-ecr-repos: $(foreach image,$(IMAGE_NAMES),$(image)/create-ecr-repo) $(if $(filter true,$(HAS_HELM_CHART)),__helm__/create-ecr-repo,)
+
+.PHONY: var-value-%
+var-value-%:
+	@echo $($*)

--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -272,8 +272,10 @@ function build::common::get_latest_eksa_asset_url() {
     git_tag=$(git show $commit_hash:projects/${project}/GIT_TAG)
     s3artifactfolder=$s3downloadpath/artifacts
   fi
-  
-  local -r url="https://$(basename $artifact_bucket).s3-us-west-2.amazonaws.com/projects/$project/$s3artifactfolder/$(basename $project)-linux-$arch-${git_tag}.tar.gz"
+
+  local -r tar_file_prefix=$(make --no-print-directory -C $BUILD_ROOT/../../projects/${project} var-value-TAR_FILE_PREFIX)
+ 
+  local -r url="https://$(basename $artifact_bucket).s3-us-west-2.amazonaws.com/projects/$project/$s3artifactfolder/$tar_file_prefix-linux-$arch-${git_tag}.tar.gz"
 
   local -r http_code=$(curl -I -L -s -o /dev/null -w "%{http_code}" $url)
   if [[ "$http_code" == "200" ]]; then 

--- a/build/lib/fetch_binaries.sh
+++ b/build/lib/fetch_binaries.sh
@@ -60,7 +60,6 @@ if [[ $PRODUCT = 'eksd' ]]; then
         URL=$(build::eksd_releases::get_eksd_component_url $REPO_OWNER $RELEASE_BRANCH $ARCH)
     fi
 else
-    TARBALL="$REPO-linux-$ARCH.tar.gz"
     URL=$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET $REPO_OWNER/$REPO $ARCH $S3_ARTIFACTS_FOLDER $GIT_COMMIT_OVERRIDE)
 fi
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

For some projects, like bootconfig, we use a custom name for the tarball. Currently the fetch binaries helper script is unaware of this support and assumes it named a certain way.  This adds support for fetching these custom names tarballs.

In cases where we are not building arm versions, which should be avoided but is currently the case for bootconfig, we need to not try and pull arm tars.  This changes that to use the BINARY_PLATFORMS var as the source of truth for which tars to pull.  Instead we may want/need to introduce a FETCH_BINARIES_PLATFORMS, but id rather avoid it if we dont need it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
