### PR TITLE
retries docker pull and use builder base tag

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -145,6 +145,9 @@ BUILD_OCI_TARS?=false
 
 LOCAL_IMAGE_TARGETS=$(foreach image,$(IMAGE_NAMES),$(image)/images/amd64) $(if $(filter true,$(HAS_HELM_CHART)),helm/build,) 
 IMAGE_TARGETS=$(foreach image,$(IMAGE_NAMES),$(if $(filter true,$(BUILD_OCI_TARS)),$(call IMAGE_TARGETS_FOR_NAME,$(image)),$(image)/images/push)) $(if $(filter true,$(HAS_HELM_CHART)),helm/push,) 
+
+# If running in the builder base on prow or codebuild, grab the current tag to be used when building with cgo
+CURRENT_BUILDER_BASE_TAG=$(or $(CODEBUILD_BUILD_IMAGE),$(and $(wildcard /config/BUILDER_BASE_TAG_FILE),$(shell cat /config/BUILDER_BASE_TAG_FILE)),latest)
 ####################################################
 
 #################### HELM ##########################
@@ -606,7 +609,7 @@ prepare-cgo-folder:
 %/cgo/amd64 %/cgo/arm64: IMAGE_NAME=binary-builder
 %/cgo/amd64 %/cgo/arm64: IMAGE_BUILD_ARGS?=GOPROXY COMPONENT
 %/cgo/amd64 %/cgo/arm64: IMAGE_CONTEXT_DIR?=$(CGO_SOURCE)
-%/cgo/amd64 %/cgo/arm64: BUILDER_IMAGE=$(BASE_IMAGE_REPO)/builder-base:latest
+%/cgo/amd64 %/cgo/arm64: BUILDER_IMAGE=$(BASE_IMAGE_REPO)/builder-base:$(CURRENT_BUILDER_BASE_TAG)
 
 %/cgo/amd64: IMAGE_PLATFORMS=linux/amd64
 %/cgo/arm64: IMAGE_PLATFORMS=linux/arm64

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ stop-docker-builder:
 
 .PHONY: run-buildkit-and-registry
 run-buildkit-and-registry:
-	docker run -d --name buildkitd --net host --privileged moby/buildkit:v0.9.0-rootless
+	docker run -d --name buildkitd --net host --privileged moby/buildkit:v0.10.3-rootless
 	docker run -d --name registry  --net host registry:2
 
 .PHONY: stop-buildkit-and-registry

--- a/build/lib/setup.sh
+++ b/build/lib/setup.sh
@@ -22,4 +22,7 @@ git config ${GIT_CONFIG_SCOPE} credential.UseHttpPath true
 
 start::dockerd
 wait::for::dockerd
+
+for i in {1..5}; do docker pull public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0 && break || sleep 15; done
+
 docker run --privileged --rm public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0 --install aarch64


### PR DESCRIPTION
Mitali ran into a couple issues during the staging build.

We got hit by the random tls handshake timeout when trying to pull
the qemu image and since the builder base had been updated with new
golang versions, the source controller build pulled the latest
builder base and the checksums did not match. Abhay had added the
builder base tag env var and config file, for code build and prow
respectively, but we never implemented using them. With this change
the source controller cgo build should always pull the same builder
base that the current build is running in, instead of the latest.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
