### PR TITLE
Patch writefile to pull user-data from hegel & write to disk

### DIFF
--- a/projects/tinkerbell/hub/CHECKSUMS
+++ b/projects/tinkerbell/hub/CHECKSUMS
@@ -2,4 +2,4 @@
 0ed984d123871b2956511745b3890e69a5d4a2b8daef3e8a8a11d5eea03e7136  _output/bin/hub/linux-amd64/image2disk
 9e1d5ec3c1bf6d2f848885634c1e5d68a53e3410469f3aa5d3803a5d205a6900  _output/bin/hub/linux-amd64/kexec
 ffda2691bc30596cb851fd1f95fca90036c19cb48dcf00b182cf7dab50250c26  _output/bin/hub/linux-amd64/oci2disk
-6402dc6524a7bb705f1fe999a7488293df2d6ac428f3e1d0285262a9456f16bd  _output/bin/hub/linux-amd64/writefile
+b133a716da1ea0464d391e097f8407a13da1b83398c5d2ccd3c53c29088ee8f2  _output/bin/hub/linux-amd64/writefile

--- a/projects/tinkerbell/hub/patches/0001-Get-user-data-from-Hegel-and-write-to-disk.patch
+++ b/projects/tinkerbell/hub/patches/0001-Get-user-data-from-Hegel-and-write-to-disk.patch
@@ -1,0 +1,92 @@
+From c1c0cc0dec41e6dacea3e2fffa3bfa37a9a60679 Mon Sep 17 00:00:00 2001
+From: Vignesh Goutham Ganesh <vgg@amazon.com>
+Date: Thu, 19 May 2022 12:56:33 -0700
+Subject: [PATCH] Get user-data from Hegel and write to disk
+
+Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
+---
+ actions/writefile/v1/main.go | 38 ++++++++++++++++++++++++++++++++++--
+ 1 file changed, 36 insertions(+), 2 deletions(-)
+
+diff --git a/actions/writefile/v1/main.go b/actions/writefile/v1/main.go
+index 5e91045..83562d4 100644
+--- a/actions/writefile/v1/main.go
++++ b/actions/writefile/v1/main.go
+@@ -4,8 +4,11 @@ import (
+ 	"errors"
+ 	"fmt"
+ 	"io/ioutil"
++	"net/http"
++	"net/url"
+ 	"os"
+ 	"os/exec"
++	"path"
+ 	"path/filepath"
+ 	"strconv"
+ 	"strings"
+@@ -17,6 +20,7 @@ import (
+ const (
+ 	mountAction = "/mountAction"
+ 	bootConfigAction = "/usr/bin/bootconfig"
++	hegelUserDataVersion = "2009-04-04"
+ )
+ 
+ func main() {
+@@ -28,6 +32,7 @@ func main() {
+ 
+ 	contents := os.Getenv("CONTENTS")
+ 	bootconfig := os.Getenv("BOOTCONFIG_CONTENTS")
++	hegelUrl := os.Getenv("HEGEL_URL")
+ 	uid := os.Getenv("UID")
+ 	gid := os.Getenv("GID")
+ 	mode := os.Getenv("MODE")
+@@ -47,8 +52,15 @@ func main() {
+ 		log.Fatalf("Could not parse mode: %v", err)
+ 	}
+ 
+-	if bootconfig != "" && contents != "" {
+-		log.Fatal("Both BOOTCONFIG_CONTENTS and CONTENTS cannot be set.")
++	// Only set one of contents, bootconfig or hegelUrl
++	validationCount := 0
++	for _, envVar := range []string{contents, bootconfig, hegelUrl} {
++		if envVar != "" {
++			validationCount++
++		}
++	}
++	if validationCount != 1 {
++		log.Fatal("Only one environment vars of CONTENTS, BOOTCONFIG_CONTENTS, HEGEL_URL can be set")
+ 	}
+ 
+ 	fileMode := os.FileMode(modePrime)
+@@ -91,6 +103,28 @@ func main() {
+ 		log.Fatalf("Failed to ensure directory exists: %v", err)
+ 	}
+ 
++	// If hegelUrl is set, get the user-data from hegel and set it to contents
++	if hegelUrl != "" {
++		userDataServiceUrl, err := url.Parse(hegelUrl)
++		if err != nil {
++			log.Fatalf("Error parsing hegel url: %v", err)
++		}
++		userDataServiceUrl.Path = path.Join(userDataServiceUrl.Path, hegelUserDataVersion, "user-data")
++		resp, err := http.Get(userDataServiceUrl.String())
++		if err != nil {
++			log.Fatalf("Error with HTTP GET call: %v", err)
++		}
++		defer resp.Body.Close()
++
++		respBody, err := ioutil.ReadAll(resp.Body)
++		if err != nil {
++			log.Fatalf("Error reading HTTP GET response body: %v", err)
++		}
++
++		// Set contents to be the user-data
++		contents = string(respBody)
++	}
++
+ 	// If bootconfig is set, contents will be empty and will serve as output initrd file provided
+ 	// to bootconfig tool
+ 	fqFilePath := filepath.Join(mountAction, filePath)
+-- 
+2.24.3 (Apple Git-128)
+


### PR DESCRIPTION
*Description of changes:*
If Hegel URL is set, while contents and bootconfig are not, this action will get the user-data from Hegel service and write it to file on the specified path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
