### PR TITLE
Increases build stability when wget licenses and docker pull

### DIFF
--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -332,3 +332,24 @@ function build::common::get_clone_url() {
     echo "https://github.com/${org}/${repo}.git"
   fi
 }
+
+function retry() {
+  local n=1
+  local max=120
+  local delay=5
+  while true; do
+    "$@" && break || {
+      if [[ $n -lt $max ]]; then
+        ((n++))
+        echo "Command failed. Attempt $n/$max:"
+        sleep $delay;
+      else
+        fail "The command has failed after $n attempts."
+      fi
+    }
+  done
+}
+
+function build::docker::retry_pull() {
+  retry docker pull "$@"
+}

--- a/build/lib/setup.sh
+++ b/build/lib/setup.sh
@@ -4,6 +4,9 @@ set -x
 set -e
 set -o pipefail
 
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_ROOT}/common.sh"
+
 source /docker.sh 
 
 CODEBUILD_CI="${CODEBUILD_CI:-false}"
@@ -23,6 +26,6 @@ git config ${GIT_CONFIG_SCOPE} credential.UseHttpPath true
 start::dockerd
 wait::for::dockerd
 
-for i in {1..5}; do docker pull public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0 && break || sleep 15; done
+build::docker::retry_pull public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0
 
 docker run --privileged --rm public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0 --install aarch64

--- a/projects/distribution/distribution/Makefile
+++ b/projects/distribution/distribution/Makefile
@@ -32,7 +32,7 @@ $(FIX_LICENSES_REDIS_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
 	for package in redis internal ; do \
 		dest=$(REPO)/vendor/github.com/garyburd/redigo/$$package/LICENSE.txt; \
 		mkdir -p $$(dirname $$dest); \
-		wget -q https://raw.githubusercontent.com/garyburd/redigo/master/LICENSE -O \
+		wget -q --retry-connrefused https://raw.githubusercontent.com/garyburd/redigo/master/LICENSE -O \
 				$$dest; \
 	done;
 

--- a/projects/fluxcd/helm-controller/Makefile
+++ b/projects/fluxcd/helm-controller/Makefile
@@ -23,7 +23,7 @@ $(FIX_LICENSES_XEIPUUV_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
 # and place them in the respective folders under vendor directory so that they is available for 
 # go-licenses to pick up	
 	for package in gojsonpointer gojsonreference gojsonschema ; do \
-		wget -q https://raw.githubusercontent.com/xeipuuv/$$package/master/LICENSE-APACHE-2.0.txt -O \
+		wget -q --retry-connrefused https://raw.githubusercontent.com/xeipuuv/$$package/master/LICENSE-APACHE-2.0.txt -O \
 			$(REPO)/vendor/github.com/xeipuuv/$$package/LICENSE.txt; \
 	done;
 

--- a/projects/fluxcd/kustomize-controller/Makefile
+++ b/projects/fluxcd/kustomize-controller/Makefile
@@ -21,7 +21,7 @@ $(FIX_LICENSES_MOZILLA_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
 # The mozilla-services/gopgagent does not have a license file checked into the repo, but there is a currently open PR
 # https://github.com/mozilla-services/gopgagent/pull/4 which adds it. Until this is merged, we need to fetch the license
 # file from the commit and not from main/master.
-	wget -q -O $@ \
+	wget -q --retry-connrefused -O $@ \
 		https://raw.githubusercontent.com/mozilla-services/gopgagent/39936d55b621318e919509000af38573d91c42ad/LICENSE.txt
 
 $(FIX_LICENSES_API_LICENSE_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)

--- a/projects/fluxcd/source-controller/Makefile
+++ b/projects/fluxcd/source-controller/Makefile
@@ -36,7 +36,7 @@ $(FIX_LICENSES_XEIPUUV_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
 	for package in gojsonpointer gojsonreference gojsonschema ; do \
 		dest=$(REPO)/vendor/github.com/xeipuuv/$$package/LICENSE.txt; \
 		mkdir -p $$(dirname $$dest); \
-		wget -q https://raw.githubusercontent.com/xeipuuv/$$package/master/LICENSE-APACHE-2.0.txt -O \
+		wget --retry-connrefused -q https://raw.githubusercontent.com/xeipuuv/$$package/master/LICENSE-APACHE-2.0.txt -O \
 			$$dest; \
 	done;
 

--- a/projects/goharbor/harbor/Makefile
+++ b/projects/goharbor/harbor/Makefile
@@ -137,7 +137,7 @@ $(FIX_LICENSES_XEIPUUV_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
 	for package in gojsonpointer gojsonreference gojsonschema ; do \
 		dest=$(REPO)/vendor/github.com/xeipuuv/$$package/LICENSE.txt; \
 		mkdir -p $$(dirname $$dest); \
-		wget -q https://raw.githubusercontent.com/xeipuuv/$$package/master/LICENSE-APACHE-2.0.txt -O \
+		wget --retry-connrefused -q https://raw.githubusercontent.com/xeipuuv/$$package/master/LICENSE-APACHE-2.0.txt -O \
 			$$dest; \
 	done;
 

--- a/projects/helm/helm/Makefile
+++ b/projects/helm/helm/Makefile
@@ -39,7 +39,7 @@ $(FIX_LICENSES_XEIPUUV_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
 # and place them in the respective folders under vendor directory so that they is available for 
 # go-licenses to pick up	
 	for package in gojsonpointer gojsonreference gojsonschema ; do \
-		wget -q https://raw.githubusercontent.com/xeipuuv/$$package/master/LICENSE-APACHE-2.0.txt -O \
+		wget --retry-connrefused -q https://raw.githubusercontent.com/xeipuuv/$$package/master/LICENSE-APACHE-2.0.txt -O \
 			$(REPO)/vendor/github.com/xeipuuv/$$package/LICENSE.txt; \
 	done;
 

--- a/projects/jetstack/cert-manager/Makefile
+++ b/projects/jetstack/cert-manager/Makefile
@@ -47,7 +47,7 @@ create-manifests:
 
 .PHONY: update-cert-manager-manifest
 update-cert-manager-manifest:
-	wget -q https://github.com/jetstack/cert-manager/releases/download/$(GIT_TAG)/cert-manager.yaml -O build/cert-manager.yaml
+	wget --retry-connrefused -q https://github.com/jetstack/cert-manager/releases/download/$(GIT_TAG)/cert-manager.yaml -O build/cert-manager.yaml
 
 
 ########### DO NOT EDIT #############################

--- a/projects/kubernetes-sigs/cluster-api-provider-vsphere/Makefile
+++ b/projects/kubernetes-sigs/cluster-api-provider-vsphere/Makefile
@@ -33,7 +33,7 @@ $(FIX_LICENSES_VM_OPERATOR_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
 # and place it in the respective folders under vendor directory so that they is available for 
 # go-licenses to pick up	
 	for package in tanzu-topology ncp ; do \
-		wget -q https://raw.githubusercontent.com/vmware-tanzu/vm-operator/main/LICENSE.txt -O \
+		wget --retry-connrefused -q https://raw.githubusercontent.com/vmware-tanzu/vm-operator/main/LICENSE.txt -O \
 			$(REPO)/vendor/github.com/vmware-tanzu/vm-operator/external/$$package/api/v1alpha1/LICENSE.txt; \
 	done;
 

--- a/projects/kubernetes-sigs/cluster-api/Makefile
+++ b/projects/kubernetes-sigs/cluster-api/Makefile
@@ -50,7 +50,7 @@ $(FIX_LICENSES_GO_JSON_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
 # that does have its own license. Hence we need to manually download license from coreos/go-json repo
 # and place it in the ajeddeloh/go-json folder under vendor directory so that it is available for
 # go-licenses to pick up
-	wget -q https://raw.githubusercontent.com/coreos/go-json/main/LICENSE -O \
+	wget --retry-connrefused -q https://raw.githubusercontent.com/coreos/go-json/main/LICENSE -O \
 			$(REPO)/vendor/github.com/ajeddeloh/go-json/LICENSE.txt;
 
 $(FIX_LICENSES_TEST_CONTAINER_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)

--- a/projects/kubernetes-sigs/kind/build/build-kind-node-image.sh
+++ b/projects/kubernetes-sigs/kind/build/build-kind-node-image.sh
@@ -104,7 +104,7 @@ function build::kind::load_images(){
     for image in "${IMAGES[@]}"; do
         # docker pull when passing a platform will pull the image for the given platform
         # and that new image id will "take over" the tag which we can use to trigger the save
-        docker pull --platform linux/$ARCH $image
+        build::docker::retry_pull --platform linux/$ARCH $image
         image_id=$(docker images $image --format "{{.ID}}")
 
         if [ ! -f $IMAGES_FOLDER/$image_id.tar ]; then

--- a/projects/kubernetes-sigs/kind/build/create-kind-cluster.sh
+++ b/projects/kubernetes-sigs/kind/build/create-kind-cluster.sh
@@ -37,7 +37,7 @@ ETCD_VERSION=$(build::eksd_releases::get_eksd_component_version "etcd" $EKSD_REL
 EKSD_IMAGE_REPO=$(build::eksd_releases::get_eksd_image_repo $EKSD_RELEASE_BRANCH)
 
 # Make sure the correct arch image is pulled and tagged
-docker pull --platform linux/$ARCH $IMAGE
+build::docker::retry_pull --platform linux/$ARCH $IMAGE
 
 KIND_PATH="$MAKE_ROOT/_output/bin/kind/$(uname | tr '[:upper:]' '[:lower:]')-$(go env GOHOSTARCH)/kind"
 cat << EOF \

--- a/projects/kubernetes-sigs/kind/images/k8s.io/kubernetes/build/download-images.sh
+++ b/projects/kubernetes-sigs/kind/images/k8s.io/kubernetes/build/download-images.sh
@@ -58,6 +58,10 @@ SOURCE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 # symlink to project root _output to make sure files are properly cleaned up
 # when running make clean
 PROJECT_ROOT="$(cd "$SOURCE_ROOT/../../.." && pwd -P)"
+
+source "${PROJECT_ROOT}/../../../build/lib/common.sh"
+
+
 rm -f $SOURCE_ROOT/_output
 ln -s $PROJECT_ROOT/_output/$EKSD_RELEASE_BRANCH $SOURCE_ROOT/_output
 
@@ -80,7 +84,7 @@ for container in "kube-apiserver" "kube-controller-manager" "kube-scheduler" "ku
     IMAGE_TAG="$EKSD_IMAGE_REPO/kubernetes/$container:$EKSD_TAG"
     FILE="$SOURCE_ROOT/_output/release-images/$KUBE_ARCH/$container.tar"
     if [ ! -f $FILE ]; then
-        docker pull --platform linux/$KUBE_ARCH $IMAGE_TAG
+        build::docker::retry_pull --platform linux/$KUBE_ARCH $IMAGE_TAG
         docker save $IMAGE_TAG -o $FILE
     fi
 done

--- a/projects/kubernetes-sigs/kind/patches/0001-Switch-to-AL2-base-image-for-node-image.patch
+++ b/projects/kubernetes-sigs/kind/patches/0001-Switch-to-AL2-base-image-for-node-image.patch
@@ -1,4 +1,4 @@
-From adccb2a177d292edc76522d585fd30e2bb199a12 Mon Sep 17 00:00:00 2001
+From 5558b3e568682b1f588925ca31697d005cd8d824 Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Sat, 2 Apr 2022 22:00:37 -0500
 Subject: [PATCH 1/2] Switch to AL2 base image for node image
@@ -6,8 +6,8 @@ Subject: [PATCH 1/2] Switch to AL2 base image for node image
 Signed-off-by: Jackson West <jgw@amazon.com>
 ---
  images/base/Dockerfile                        | 166 +++++++-----------
- images/base/files/usr/local/bin/clean-install |   7 +-
- 2 files changed, 69 insertions(+), 104 deletions(-)
+ images/base/files/usr/local/bin/clean-install |   9 +-
+ 2 files changed, 70 insertions(+), 105 deletions(-)
 
 diff --git a/images/base/Dockerfile b/images/base/Dockerfile
 index cedeb949..bad06cd6 100644
@@ -230,7 +230,7 @@ index cedeb949..bad06cd6 100644
  # tell systemd that it is in docker (it will check for the container env)
  # https://systemd.io/CONTAINER_INTERFACE/
 diff --git a/images/base/files/usr/local/bin/clean-install b/images/base/files/usr/local/bin/clean-install
-index bfeff602..3b99ed0f 100755
+index bfeff602..06de894f 100755
 --- a/images/base/files/usr/local/bin/clean-install
 +++ b/images/base/files/usr/local/bin/clean-install
 @@ -25,10 +25,11 @@ if [ $# = 0 ]; then
@@ -248,6 +248,12 @@ index bfeff602..3b99ed0f 100755
     /var/cache/debconf/* \
     /var/lib/apt/lists/* \
     /var/log/* \
+@@ -37,4 +38,4 @@ rm -rf \
+    /usr/share/doc/* \
+    /usr/share/doc-base/* \
+    /usr/share/man/* \
+-   /usr/share/local/*
++   /usr/share/local/* || true
 -- 
 2.35.1
 

--- a/projects/kubernetes/cloud-provider-vsphere/Makefile
+++ b/projects/kubernetes/cloud-provider-vsphere/Makefile
@@ -30,7 +30,7 @@ $(FIX_LICENSES_VSPHERE_AUTOMATION_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
   # folder, otherwise go-licenses will group them all together as vsphere-automation-sdk-go
   # which would be wrong
 	for package in lib runtime services ; do \
-		wget -q https://raw.githubusercontent.com/vmware/vsphere-automation-sdk-go/master/LICENSE.txt -O \
+		wget --retry-connrefused -q https://raw.githubusercontent.com/vmware/vsphere-automation-sdk-go/master/LICENSE.txt -O \
 			$(REPO)/vendor/github.com/vmware/vsphere-automation-sdk-go/$$package/LICENSE.txt; \
 	done;
 

--- a/projects/replicatedhq/troubleshoot/Makefile
+++ b/projects/replicatedhq/troubleshoot/Makefile
@@ -25,7 +25,7 @@ $(FIX_LICENSES_GO_SPIN_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
 # checked in to the repo. Hence we need to manually download the license from Github and place
 # it in the respective folder under vendor directory so that they is available for go-licenses
 # to pick up
-	wget https://raw.githubusercontent.com/tj/go-spin/master/LICENSE -O $@
+	wget --retry-connrefused https://raw.githubusercontent.com/tj/go-spin/master/LICENSE -O $@
 
 
 ########### DO NOT EDIT #############################


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Couple things i notice when looking at recent flaky build failures.

- add retry around docker pulls
- retry wgets that get connection refused
- fix kind build that hasnt been any issue yet because dev/staging are build with a cache

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
