### PR TITLE
Support compressed user-data for Snow

### DIFF
--- a/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/bootstrap-after.sh
+++ b/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/bootstrap-after.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -euxo pipefail
+
 source /etc/eks/logging.sh
 
 SCRIPT_LOG=/var/log/eks-bootstrap.log
@@ -13,9 +16,9 @@ KUBE_VIP_IMAGE=$1
 VIP=$2
 
 # if it's control plane node to join, generate the manifest after `kubeadm join` command complete successfully
-if grep -q "kubeadm join --config /run/kubeadm/kubeadm-join-config.yaml" /var/lib/cloud/instance/user-data.txt && grep -q success /run/cluster-api/bootstrap-success.complete ; then
+if zgrep -q "kubeadm join --config /run/kubeadm/kubeadm-join-config.yaml" /var/lib/cloud/instance/user-data.txt && grep -q success /run/cluster-api/bootstrap-success.complete ; then
   log::info "Joining as control plane node, not the first control plane node to join"
-  /etc/eks/generate-kube-vip-manifest.sh $KUBE_VIP_IMAGE $VIP
+  /etc/eks/generate-kube-vip-manifest.sh "$KUBE_VIP_IMAGE" "$VIP"
 fi
 
 # restore stdout and stderr

--- a/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/generate-kube-vip-manifest.sh
+++ b/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/generate-kube-vip-manifest.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -euxo pipefail
+
 source /etc/eks/logging.sh
 
 SCRIPT_LOG=/var/log/eks-bootstrap.log
@@ -12,7 +15,7 @@ exec 3>&1 4>&2 >>$SCRIPT_LOG 2>&1
 KUBE_VIP_IMAGE=$1
 VIP=$2
 
-DNI=$(ip -br link | egrep -v 'lo|ens3|docker0' | awk '{print $1}')
+DNI=$(ip -br link | grep -Ev 'lo|ens3|docker0' | awk '{print $1}')
 log::info "Generating kube-vip manifest"
 log::info "Using DNI: $DNI"
 log::info "Using kube-vip: $VIP"

--- a/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/logging.sh
+++ b/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/logging.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euxo pipefail
+
 log::error() {
   local message="${1}"
   timestamp=$(date --iso-8601=seconds)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Support reading compressed user-data in bootstrap scripts.
Related capas pr: https://github.com/aws/cluster-api-provider-aws-snow/pull/63

*Testing:*
Manually modified scripts and successfully provisioned a cluster using compressed user-data

```
[ec2-user@ip-34-223-14-194 ~]$ kubectl get machines -o wide
NAME                                     CLUSTER            NODENAME                PROVIDERID                                        PHASE     AGE     VERSION
capas-quickstart-control-plane-4p228     capas-quickstart   s-i-878f2d65582d41242   aws-snow:///10.111.60.195/s.i-878f2d65582d41242   Running   96m     v1.21.2-eks-1-21-3
capas-quickstart-md-0-7886fb76bf-l2zgl   capas-quickstart   s-i-81f717145fb7c1447   aws-snow:///10.111.60.195/s.i-81f717145fb7c1447   Running   96m     v1.21.2-eks-1-21-3
capas-quickstart-md-0-7886fb76bf-sj4c8   capas-quickstart   s-i-8cb0394da9ff39384   aws-snow:///10.111.60.195/s.i-8cb0394da9ff39384   Running   5m48s   v1.21.2-eks-1-21-3
capas-quickstart-md-0-7886fb76bf-xtr26   capas-quickstart   s-i-8f4e2abcffcb0329a   aws-snow:///10.111.60.195/s.i-8f4e2abcffcb0329a   Running   85m     v1.21.2-eks-1-21-3
```

```
I0520 17:01:36.519749       9 instances.go:134] controller/awssnowmachine "msg"="Creating an instance for a machine" "cluster"="capas-quickstart" "machine"="capas-quickstart-control-plane-4p228" "name"="capas-quickstart-control-plane-8nnhh" "namespace"="default" "reconciler group"="infrastructure.cluster.x-k8s.io" "reconciler kind"="AWSSnowMachine" 
I0520 17:01:36.520792       9 instances.go:208] controller/awssnowmachine "msg"="original userData size" "cluster"="capas-quickstart" "machine"="capas-quickstart-control-plane-4p228" "name"="capas-quickstart-control-plane-8nnhh" "namespace"="default" "reconciler group"="infrastructure.cluster.x-k8s.io" "reconciler kind"="AWSSnowMachine" "bytes"=37536 "role"="control-plane"
I0520 17:01:36.524065       9 instances.go:216] controller/awssnowmachine "msg"="compressed userData size" "cluster"="capas-quickstart" "machine"="capas-quickstart-control-plane-4p228" "name"="capas-quickstart-control-plane-8nnhh" "namespace"="default" "reconciler group"="infrastructure.cluster.x-k8s.io" "reconciler kind"="AWSSnowMachine" "bytes"=21780 "role"="control-plane"
I0520 17:01:36.524129       9 instances.go:236] controller/awssnowmachine "msg"="Running instance" "cluster"="capas-quickstart" "machine"="capas-quickstart-control-plane-4p228" "name"="capas-quickstart-control-plane-8nnhh" "namespace"="default" "reconciler group"="infrastructure.cluster.x-k8s.io" "reconciler kind"="AWSSnowMachine" "machine-role"="control-plane"
I0520 17:01:36.524172       9 instances.go:357] controller/awssnowmachine "msg"="userData size" "cluster"="capas-quickstart" "machine"="capas-quickstart-control-plane-4p228" "name"="capas-quickstart-control-plane-8nnhh" "namespace"="default" "reconciler group"="infrastructure.cluster.x-k8s.io" "reconciler kind"="AWSSnowMachine" "bytes"=21780 "role"="control-plane"
I0520 17:01:36.658615       9 instances.go:450] controller/awssnowmachine "msg"="Waiting for instance to be in running state" "cluster"="capas-quickstart" "machine"="capas-quickstart-control-plane-4p228" "name"="capas-quickstart-control-plane-8nnhh" "namespace"="default" "reconciler group"="infrastructure.cluster.x-k8s.io" "reconciler kind"="AWSSnowMachine" "instance-id"="s.i-878f2d65582d41242" "timeout"="3m0s"
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
