### PR TITLE
Make glibc base image for writefile

### DIFF
--- a/projects/tinkerbell/hub/Makefile
+++ b/projects/tinkerbell/hub/Makefile
@@ -39,6 +39,9 @@ $(call IMAGE_TARGETS_FOR_NAME, writefile): $(call FULL_FETCH_BINARIES_TARGETS, $
 # We are using eks-distro-minimal-base-glibc as the base to install touch
 reboot/images/%: BASE_IMAGE_NAME=eks-distro-minimal-base-glibc
 
+# bootconfig is dependency included in the writefile image, and bootconfig
+# is not a static binary. It requires libs on the glibc image
+writefile/images/%: BASE_IMAGE_NAME=eks-distro-minimal-base-glibc
 
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block


### PR DESCRIPTION
*Description of changes:*
Bootconfig is a dependency for Writefile action. This is not a static binary and requires libraries that are found in the glibc base image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
