### PR TITLE
Make Kubeadm bootstrap controller join token ttl configurable

### DIFF
--- a/projects/kubernetes-sigs/cluster-api/patches/0019-Expose-kubeadm-bootstrap-controller-bootstrap-token-ttl.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0019-Expose-kubeadm-bootstrap-controller-bootstrap-token-ttl.patch
@@ -1,0 +1,30 @@
+From c0633e8ed5ec0cb7187b8775b786675f9cc3680c Mon Sep 17 00:00:00 2001
+From: Chris Doherty <chris.doherty4@gmail.com>
+Date: Wed, 1 Jun 2022 21:56:09 -0400
+Subject: [PATCH] Expose kubeadm bootstrap controller bootstrap token ttl
+ config.
+
+The kubeadm bootstrap token ttl defines the time to live for nodes to
+join the cluster. The change exposes the configuration as a variable for
+`clusterctl init`.
+
+:seedling:
+---
+ bootstrap/kubeadm/config/manager/manager.yaml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/bootstrap/kubeadm/config/manager/manager.yaml b/bootstrap/kubeadm/config/manager/manager.yaml
+index b006f1b00..4b4fbd90c 100644
+--- a/bootstrap/kubeadm/config/manager/manager.yaml
++++ b/bootstrap/kubeadm/config/manager/manager.yaml
+@@ -22,6 +22,7 @@ spec:
+         - "--leader-elect"
+         - "--metrics-bind-addr=localhost:8080"
+         - "--feature-gates=MachinePool=${EXP_MACHINE_POOL:=false},KubeadmBootstrapFormatIgnition=${EXP_KUBEADM_BOOTSTRAP_FORMAT_IGNITION:=false}"
++        - "--bootstrap-token-ttl=${BOOTSTRAP_TOKEN_TTL:=0}"
+         image: controller:latest
+         name: manager
+         ports:
+-- 
+2.36.0
+


### PR DESCRIPTION
The kubeadm bootstrap controller defines a default token TTL of 15m. In bare metal provisioning this timeout isn't always sufficient. This change lets us supply variable configuration to the `clusterctl init` command when installing CAPI and optionally bump the token TTL.

_[My hands are typing words](https://xkcd.com/1296/): I have no idea how to generate the patches in the same way as the others, please halp._