### PR TITLE
Changing entrypoint for Rufio manager image

### DIFF
--- a/projects/tinkerbell/rufio/docker/linux/Dockerfile
+++ b/projects/tinkerbell/rufio/docker/linux/Dockerfile
@@ -25,4 +25,4 @@ COPY ATTRIBUTION.txt /ATTRIBUTION.txt
 
 USER 65532:65532
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["/usr/bin/manager"]

--- a/projects/tinkerbell/tinkerbell-chart/chart/templates/rufio-deployment.yaml
+++ b/projects/tinkerbell/tinkerbell-chart/chart/templates/rufio-deployment.yaml
@@ -21,8 +21,6 @@ spec:
       containers:
       - args:
         - --leader-elect
-        command:
-        - /manager
         image: {{ .Values.rufio.image }}
         livenessProbe:
           httpGet:


### PR DESCRIPTION
*Description of changes:*
Fixes error: `starting container process caused: exec: "/manager": stat /manager: no such file or directory: unknown.` on pod creation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
