### PR TITLE
Patch hook to skip pulling registry cert

### DIFF
--- a/projects/tinkerbell/hook/CHECKSUMS
+++ b/projects/tinkerbell/hook/CHECKSUMS
@@ -1,4 +1,4 @@
 a22ad6b436365a0cac65d22f7dd749a00ef2d944a4d2c415f12488449d2119fc  _output/bin/hook/linux-amd64/bootkit
-63fa132996a521063df5d9f9c5bee8dfb78c6d46567bf3721679cf08e4d05f7d  _output/bin/hook/linux-amd64/tink-docker
+286699b0bca2a1365c2431a22b5eca8740dd65605c5eb39a3545c82e6df0bb5f  _output/bin/hook/linux-amd64/tink-docker
 d430ba18b9068bcc49a1156642fd927bef99e5e87e147f2097cef6ed69c6c475  _output/bin/hook/linux-arm64/bootkit
-df5ae3376a3b117a3709f56330d1ea442500e0a92a18b1e038417b0f84684fd5  _output/bin/hook/linux-arm64/tink-docker
+5b9197c223bc2df605249248fd319576ec9e958da047feae08a120e5ccbe3820  _output/bin/hook/linux-arm64/tink-docker

--- a/projects/tinkerbell/hook/patches/0001-Download-registry-cert-only-if-tinkerbell_tls-is-tru.patch
+++ b/projects/tinkerbell/hook/patches/0001-Download-registry-cert-only-if-tinkerbell_tls-is-tru.patch
@@ -1,0 +1,84 @@
+From 1f2ccd07073f2109fb057e8de8b8f0b37baf187b Mon Sep 17 00:00:00 2001
+From: Abhinav Pandey <abhinavmpandey08@gmail.com>
+Date: Fri, 3 Jun 2022 09:06:43 -0400
+Subject: [PATCH] Download registry cert only if tinkerbell_tls is true
+
+---
+ tink-docker/main.go | 40 +++++++++++++++++++++++++---------------
+ 1 file changed, 25 insertions(+), 15 deletions(-)
+
+diff --git a/tink-docker/main.go b/tink-docker/main.go
+index 5dc28cd..987b7ce 100644
+--- a/tink-docker/main.go
++++ b/tink-docker/main.go
+@@ -8,15 +8,17 @@ import (
+ 	"net/http"
+ 	"os"
+ 	"os/exec"
++	"strconv"
+ 	"strings"
+ 	"time"
+ )
+ 
+ type tinkConfig struct {
+-	registry   string
+-	baseURL    string
+-	tinkerbell string
+-	syslogHost string
++	registry      string
++	baseURL       string
++	tinkerbell    string
++	syslogHost    string
++	tinkServerTLS bool
+ 
+ 	// TODO add others
+ }
+@@ -39,19 +41,21 @@ func main() {
+ 	cmdLines := strings.Split(string(content), " ")
+ 	cfg := parseCmdLine(cmdLines)
+ 
+-	path := fmt.Sprintf("/etc/docker/certs.d/%s/", cfg.registry)
++	if cfg.tinkServerTLS {
++		path := fmt.Sprintf("/etc/docker/certs.d/%s/", cfg.registry)
+ 
+-	// Create the directory
+-	err = os.MkdirAll(path, os.ModeDir)
+-	if err != nil {
+-		panic(err)
+-	}
+-	// Download the configuration
+-	err = downloadFile(path+"ca.crt", cfg.baseURL+"/ca.pem")
+-	if err != nil {
+-		panic(err)
++		// Create the directory
++		err = os.MkdirAll(path, os.ModeDir)
++		if err != nil {
++			panic(err)
++		}
++		// Download the configuration
++		err = downloadFile(path+"ca.crt", cfg.baseURL+"/ca.pem")
++		if err != nil {
++			panic(err)
++		}
++		fmt.Println("Downloaded the repository certificates, starting the Docker Engine")
+ 	}
+-	fmt.Println("Downloaded the repository certificates, starting the Docker Engine")
+ 
+ 	d := dockerConfig{
+ 		Debug:     true,
+@@ -105,6 +109,12 @@ func parseCmdLine(cmdLines []string) (cfg tinkConfig) {
+ 			cfg.tinkerbell = cmdLine[1]
+ 		case "syslog_host":
+ 			cfg.syslogHost = cmdLine[1]
++		case "tinkerbell_tls":
++			var err error
++			if cfg.tinkServerTLS, err = strconv.ParseBool(cmdLine[1]); err != nil {
++				fmt.Println("tinkerbell_tls is not set to a valid boolean value, defaulting to true")
++				cfg.tinkServerTLS = true
++			}
+ 		}
+ 	}
+ 	return cfg
+-- 
+2.30.1 (Apple Git-130)
+


### PR DESCRIPTION
*Description of changes:*
Hook currently tries to pull the cert unconditionally and panics if the cert is not served from a hardcoded endpoint. 
This PR patches hook to only pull the cert if tls is enabled 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
