### PR TITLE
Helm charts with no files.txt

### DIFF
--- a/build/lib/helm_replace.sh
+++ b/build/lib/helm_replace.sh
@@ -29,10 +29,7 @@ DEST_DIR=${OUTPUT_DIR}/helm/${CHART_NAME}
 #
 TEMPLATE_DIR=helm/templates
 SEDFILE=${OUTPUT_DIR}/helm/sedfile
-cat helm/files.txt | while read SOURCE_FILE DESTINATION_FILE
+for file in Chart.yaml values.yaml
 do
-  TMPFILE=/tmp/$(basename ${SOURCE_FILE})
-  cp ${SOURCE_FILE} ${TMPFILE}
-  sed -f ${SEDFILE} ${TMPFILE} >${DEST_DIR}/${DESTINATION_FILE}
-  rm -f ${TMPFILE}
+  sed -f ${SEDFILE} -i ${DEST_DIR}/${file}
 done

--- a/projects/aws-containers/hello-eks-anywhere/helm/files.txt
+++ b/projects/aws-containers/hello-eks-anywhere/helm/files.txt
@@ -1,2 +1,0 @@
-_output/helm/hello-eks-anywhere/Chart.yaml Chart.yaml 
-_output/helm/hello-eks-anywhere/values.yaml values.yaml 

--- a/projects/aws/eks-anywhere-packages/helm/files.txt
+++ b/projects/aws/eks-anywhere-packages/helm/files.txt
@@ -1,2 +1,0 @@
-_output/helm/eks-anywhere-packages/Chart.yaml Chart.yaml 
-_output/helm/eks-anywhere-packages/values.yaml values.yaml 

--- a/projects/fluxcd/flux2/helm/files.txt
+++ b/projects/fluxcd/flux2/helm/files.txt
@@ -1,2 +1,0 @@
-_output/helm/flux2/Chart.yaml Chart.yaml 
-_output/helm/flux2/values.yaml values.yaml 

--- a/projects/goharbor/harbor/helm/files.txt
+++ b/projects/goharbor/harbor/helm/files.txt
@@ -1,3 +1,0 @@
-_output/helm/harbor-helm/Chart.yaml Chart.yaml 
-_output/helm/harbor-helm/values.yaml values.yaml 
-_output/helm/harbor-helm/README.md README.md 

--- a/projects/jetstack/cert-manager/helm/files.txt
+++ b/projects/jetstack/cert-manager/helm/files.txt
@@ -1,3 +1,0 @@
-_output/helm/cert-manager/Chart.template.yaml Chart.yaml 
-_output/helm/cert-manager/values.yaml values.yaml 
-_output/helm/cert-manager/README.template.md README.md 


### PR DESCRIPTION
I'd like to discourage use of this except for the values.yaml and Chart.yaml file. We should be patching everything else. There are a couple cases where we are running this on the README, but those don't matter.

Closes: https://github.com/aws/eks-anywhere-packages/issues/193
