### PR TITLE
Create a patch for retrying to list members in the join command

### DIFF
--- a/projects/kubernetes-sigs/etcdadm/CHECKSUMS
+++ b/projects/kubernetes-sigs/etcdadm/CHECKSUMS
@@ -1,2 +1,2 @@
-f34fe924adb93dc2e05b766d80adae2a821ad514fd77fca67aa516a1be96c22b  _output/bin/etcdadm/linux-amd64/etcdadm
-7e8429dee8352da69fa2b377f785c923b295da7b244f4e1905d6d1cba0350b04  _output/bin/etcdadm/linux-arm64/etcdadm
+a35995a1940ea920ebdd21ea8382b5c172400046afcbe95d7f54f15b47e7f4e2  _output/bin/etcdadm/linux-amd64/etcdadm
+39781d639168e70c693e893fa189c33bfc42bd80b847e21db6e32f7d7a897311  _output/bin/etcdadm/linux-arm64/etcdadm

--- a/projects/kubernetes-sigs/etcdadm/CHECKSUMS
+++ b/projects/kubernetes-sigs/etcdadm/CHECKSUMS
@@ -1,2 +1,2 @@
-1a71735aea6e420988d308c847e1e7df1c146254160fd0ed1c99dcdfb3072a9e  _output/bin/etcdadm/linux-amd64/etcdadm
-37b087f5b30d1787f0f666553b563d6a8f3a02dd4f86e6b8a92a2ef77f665b9d  _output/bin/etcdadm/linux-arm64/etcdadm
+f34fe924adb93dc2e05b766d80adae2a821ad514fd77fca67aa516a1be96c22b  _output/bin/etcdadm/linux-amd64/etcdadm
+7e8429dee8352da69fa2b377f785c923b295da7b244f4e1905d6d1cba0350b04  _output/bin/etcdadm/linux-arm64/etcdadm

--- a/projects/kubernetes-sigs/etcdadm/patches/0014-Add-retry-on-listing-members-in-join-command.patch
+++ b/projects/kubernetes-sigs/etcdadm/patches/0014-Add-retry-on-listing-members-in-join-command.patch
@@ -1,7 +1,7 @@
-From 35a9d8d692c24b89be947ba216980676670668fa Mon Sep 17 00:00:00 2001
+From 1841c1668306c9a05399090fdaeac5e128d2e374 Mon Sep 17 00:00:00 2001
 From: Wonkun Kim <wonkun@amazon.com>
-Date: Fri, 3 Jun 2022 15:33:17 -0500
-Subject: [PATCH] Update join.go
+Date: Fri, 3 Jun 2022 16:25:08 -0500
+Subject: [PATCH] Add retry on listing members in join command
 
 ---
  cmd/join.go | 51 +++++++++++++++++++++++++++++++--------------------

--- a/projects/kubernetes-sigs/etcdadm/patches/0014-Add-retry-on-listing-members-in-join-command.patch
+++ b/projects/kubernetes-sigs/etcdadm/patches/0014-Add-retry-on-listing-members-in-join-command.patch
@@ -1,0 +1,90 @@
+From 35a9d8d692c24b89be947ba216980676670668fa Mon Sep 17 00:00:00 2001
+From: Wonkun Kim <wonkun@amazon.com>
+Date: Fri, 3 Jun 2022 15:33:17 -0500
+Subject: [PATCH] Update join.go
+
+---
+ cmd/join.go | 51 +++++++++++++++++++++++++++++++--------------------
+ 1 file changed, 31 insertions(+), 20 deletions(-)
+
+diff --git a/cmd/join.go b/cmd/join.go
+index dee7eba9..fa503318 100644
+--- a/cmd/join.go
++++ b/cmd/join.go
+@@ -132,6 +132,22 @@ func membership() phase {
+ 				return nil
+ 			}
+ 
++			var lastErr error
++			retrySteps := 1
++			if in.etcdAdmConfig.Retry {
++				retrySteps = constants.DefaultBackOffSteps
++			}
++
++			// Exponential backoff for MemberList and MemberAdd (values exclude jitter):
++			// If --retry=false, add member only try one times, otherwise try five times.
++			// The backoff duration is 0, 2, 4, 8, 16 s
++			opts := wait.Backoff{
++				Duration: constants.DefaultBackOffDuration,
++				Steps:    retrySteps,
++				Factor:   constants.DefaultBackOffFactor,
++				Jitter:   0.1,
++			}
++
+ 			var localMember *etcdserverpb.Member
+ 			var members []*etcdserverpb.Member
+ 			log.Println("[membership] Checking if this member was added")
+@@ -139,13 +155,23 @@ func membership() phase {
+ 			if err != nil {
+ 				return fmt.Errorf("error checking membership: %v", err)
+ 			}
+-			ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultEtcdRequestTimeout)
+-			mresp, err := client.MemberList(ctx)
+-			cancel()
++
++			err = wait.ExponentialBackoff(opts, func() (bool, error) {
++				ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultEtcdRequestTimeout)
++				mresp, err := client.MemberList(ctx)
++				cancel()
++				if err != nil {
++					log.Warningf("[membership] Error listing members: %v, will retry after %s.", err, opts.Step())
++					lastErr = err
++					return false, nil
++				}
++				members = mresp.Members
++				return true, nil
++			})
+ 			if err != nil {
+-				return fmt.Errorf("error listing members: %v", err)
++				return fmt.Errorf("error listing members: %v", lastErr)
+ 			}
+-			members = mresp.Members
++
+ 			localMember, ok := etcd.MemberForPeerURLs(members, in.etcdAdmConfig.InitialAdvertisePeerURLs.StringSlice())
+ 			if !ok {
+ 				log.Printf("[membership] Member was not added")
+@@ -153,21 +179,6 @@ func membership() phase {
+ 				os.RemoveAll(in.etcdAdmConfig.DataDir)
+ 				log.Println("[membership] Adding member")
+ 
+-				var lastErr error
+-				retrySteps := 1
+-				if in.etcdAdmConfig.Retry {
+-					retrySteps = constants.DefaultBackOffSteps
+-				}
+-
+-				// Exponential backoff for MemberAdd (values exclude jitter):
+-				// If --retry=false, add member only try one times, otherwise try five times.
+-				// The backoff duration is 0, 2, 4, 8, 16 s
+-				opts := wait.Backoff{
+-					Duration: constants.DefaultBackOffDuration,
+-					Steps:    retrySteps,
+-					Factor:   constants.DefaultBackOffFactor,
+-					Jitter:   0.1,
+-				}
+ 				err := wait.ExponentialBackoff(opts, func() (bool, error) {
+ 					ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultEtcdRequestTimeout)
+ 					mresp, err := client.MemberAdd(ctx, in.etcdAdmConfig.InitialAdvertisePeerURLs.StringSlice())
+-- 
+2.32.1 (Apple Git-133)
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When a new ETCD machine tries to join a cluster while the machine is not reachable the joining process fails at listing members without retrying. This PR adds the retry logic to this step so that the machine can join when it is reachable. 

Upstream PR: https://github.com/kubernetes-sigs/etcdadm/pull/316


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
