### PR TITLE
Implement retry logic for tink-worker docker image pull...

### DIFF
--- a/projects/tinkerbell/hook/CHECKSUMS
+++ b/projects/tinkerbell/hook/CHECKSUMS
@@ -1,4 +1,4 @@
-a22ad6b436365a0cac65d22f7dd749a00ef2d944a4d2c415f12488449d2119fc  _output/bin/hook/linux-amd64/bootkit
+ee33312369e7ea86a46d2fd7bd9924e74873de8606018197fd0a5c478b68aba8  _output/bin/hook/linux-amd64/bootkit
 286699b0bca2a1365c2431a22b5eca8740dd65605c5eb39a3545c82e6df0bb5f  _output/bin/hook/linux-amd64/tink-docker
-d430ba18b9068bcc49a1156642fd927bef99e5e87e147f2097cef6ed69c6c475  _output/bin/hook/linux-arm64/bootkit
+27cb5a63885d8f68a60792a76a42f0aafbd103b37d05a8dc5ff1435dd35eb3bc  _output/bin/hook/linux-arm64/bootkit
 5b9197c223bc2df605249248fd319576ec9e958da047feae08a120e5ccbe3820  _output/bin/hook/linux-arm64/tink-docker

--- a/projects/tinkerbell/hook/patches/0002-Implement-retry-for-tink-worker-docker-image-pull-to.patch
+++ b/projects/tinkerbell/hook/patches/0002-Implement-retry-for-tink-worker-docker-image-pull-to.patch
@@ -1,0 +1,46 @@
+From d1a5f1a6cc161a04781204ecd49bfe3457ea3ee7 Mon Sep 17 00:00:00 2001
+From: Pooja Trivedi <tripooja@amazon.com>
+Date: Mon, 6 Jun 2022 14:49:55 -0700
+Subject: [PATCH] Implement retry for tink-worker docker image pull to allow
+ for races where linuxkit network or dns may not have been fully set up and
+ functional yet.
+
+Signed-off-by: Pooja Trivedi <tripooja@amazon.com>
+---
+ bootkit/main.go | 20 ++++++++++++++++++--
+ 1 file changed, 18 insertions(+), 2 deletions(-)
+
+diff --git a/bootkit/main.go b/bootkit/main.go
+index a579351..a9211c9 100644
+--- a/bootkit/main.go
++++ b/bootkit/main.go
+@@ -146,8 +146,24 @@ func main() {
+ 
+ 	fmt.Printf("Pulling image [%s]", imageName)
+ 
+-	out, err := cli.ImagePull(ctx, imageName, pullOpts)
+-	if err != nil {
++	// TODO: should remove all this hardcoding or move it to a const at some point
++	attempts := 10
++	sleepSeconds := 5
++
++	failedImagePull := true
++
++	var out io.ReadCloser
++	for i := 0; i < attempts; i++ {
++		out, err = cli.ImagePull(ctx, imageName, pullOpts)
++		if err == nil {
++			failedImagePull = false
++			break
++		}
++		fmt.Printf("Error pulling image [%s] [%v]. Retrying after %d seconds...\n", imageName, err, sleepSeconds)
++		time.Sleep(time.Second * 5)
++	}
++
++	if failedImagePull {
+ 		panic(err)
+ 	}
+ 
+-- 
+2.33.0
+


### PR DESCRIPTION
...to allow for races where linuxkit network or dns may not have been fully set up and functional yet.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
