### PR TITLE
Various fixes to the attribution and help generation

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -347,7 +347,6 @@ GOBUILD_COMMAND?=build
 
 ############### BINARIES DEPS ######################
 BINARY_DEPS_DIR?=$(OUTPUT_DIR)/dependencies
-FETCH_BINARIES_TARGETS?=
 PROJECT_DEPENDENCIES?=
 HANDLE_DEPENDENCIES_TARGET=handle-dependencies
 ####################################################
@@ -375,7 +374,7 @@ IMAGE_OS?=
 #################### OTHER #########################
 KUSTOMIZE_TARGET=$(OUTPUT_DIR)/kustomize
 GIT_DEPS_DIR?=$(OUTPUT_DIR)/gitdependencies
-SPECIAL_TARGET_SECONDARY=$(strip $(call FULL_FETCH_BINARIES_TARGETS, $(FETCH_BINARIES_TARGETS)) $(GO_MOD_DOWNLOAD_TARGETS))
+SPECIAL_TARGET_SECONDARY=$(strip $(PROJECT_DEPENDENCIES_TARGETS) $(GO_MOD_DOWNLOAD_TARGETS))
 SKIP_CHECKSUM_VALIDATION?=false
 ####################################################
 
@@ -713,7 +712,7 @@ add-generated-help-block: # Add or update generated help block to document proje
 add-generated-help-block:
 	$(BUILD_LIB)/generate_help_body.sh $(MAKE_ROOT) "$(BINARY_TARGET_FILES)" "$(BINARY_PLATFORMS)" "${BINARY_TARGETS}" \
 		$(REPO) $(if $(PATCHES_DIR),true,false) "$(LOCAL_IMAGE_TARGETS)" "$(IMAGE_TARGETS)" "$(BUILD_TARGETS)" "$(RELEASE_TARGETS)" \
-		"$(HAS_S3_ARTIFACTS)" "$(HAS_LICENSES)" "$(REPO_NO_CLONE)" "$(call FULL_FETCH_BINARIES_TARGETS,$(FETCH_BINARIES_TARGETS))" \
+		"$(HAS_S3_ARTIFACTS)" "$(HAS_LICENSES)" "$(REPO_NO_CLONE)" "$(PROJECT_DEPENDENCIES_TARGETS)" \
 		"$(HAS_HELM_CHART)"
 
 ## --------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,6 @@ AWS_REGION?=us-west-2
 IMAGE_REPO?=$(if $(AWS_ACCOUNT_ID),$(AWS_ACCOUNT_ID).dkr.ecr.$(AWS_REGION).amazonaws.com,localhost:5000)
 ECR_PUBLIC_URI?=$(shell aws ecr-public describe-registries --region us-east-1 --query 'registries[0].registryUri' --output text)
 
-PROJECTS?=aws_eks-anywhere aws_eks-anywhere-packages aws-containers_hello-eks-anywhere brancz_kube-rbac-proxy kubernetes-sigs_cluster-api-provider-vsphere kubernetes-sigs_cri-tools kubernetes-sigs_vsphere-csi-driver jetstack_cert-manager kubernetes_cloud-provider-vsphere plunder-app_kube-vip kubernetes-sigs_etcdadm fluxcd_helm-controller fluxcd_kustomize-controller fluxcd_notification-controller fluxcd_source-controller rancher_local-path-provisioner aws_etcdadm-bootstrap-provider aws_etcdadm-controller tinkerbell_cluster-api-provider-tinkerbell tinkerbell_hegel cloudflare_cfssl tinkerbell_boots tinkerbell_hub tinkerbell_pbnj tinkerbell_hook tinkerbell_rufio aws_cluster-api-provider-aws-snow distribution_distribution goharbor_harbor cilium_cilium grpc-ecosystem_grpc-health-probe kubernetes-sigs_cluster-api-provider-cloudstack aquasecurity_harbor-scanner-trivy aquasecurity_trivy
-BUILD_TARGETS=$(addprefix build-project-, $(PROJECTS))
-
-EKSA_TOOLS_PREREQS=kubernetes-sigs_cluster-api kubernetes-sigs_cluster-api-provider-aws kubernetes-sigs_kind fluxcd_flux2 vmware_govmomi replicatedhq_troubleshoot helm_helm tinkerbell_tink apache_cloudstack-cloudmonkey
-EKSA_TOOLS_PREREQS_BUILD_TARGETS=$(addprefix build-project-, $(EKSA_TOOLS_PREREQS))
-
-ALL_PROJECTS=$(PROJECTS) $(EKSA_TOOLS_PREREQS) aws_bottlerocket-bootstrap aws_eks-anywhere-build-tooling kubernetes-sigs_image-builder
-
 RELEASE_BRANCH?=
 GIT_HASH:=$(shell git -C $(BASE_DIRECTORY) rev-parse HEAD)
 ALL_PROJECTS=$(shell $(BUILD_LIB)/all_projects.sh $(BASE_DIRECTORY))

--- a/build/lib/generate_help_body.sh
+++ b/build/lib/generate_help_body.sh
@@ -153,7 +153,7 @@ ${GIT_TARGETS_HELP}${PATCHES_TARGET}${BINARY_TARGETS_HELP}${IMAGE_TARGETS_HELP}$
 ${EXTRA_HELP}
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls \`${BUILD_TARGETS}\`
+build: ## Called via prow presubmit, calls \`${BUILD_TARGETS//$PROJECT_ROOT\//""}" \`
 release: ## Called via prow postsubmit + release jobs, calls \`${RELEASE_TARGETS}\`
 ${FOOTER}
 EOF

--- a/build/update-attribution-files/create_pr.sh
+++ b/build/update-attribution-files/create_pr.sh
@@ -38,6 +38,8 @@ git config remote.upstream.url >&- || git remote add upstream https://github.com
 # Files have already changed, stash to perform rebase
 git stash
 git fetch upstream
+
+git checkout $MAIN_BRANCH
 # there will be conflicts before we are on the bots fork at this point
 # -Xtheirs instructs git to favor the changes from the current branch
 git rebase -Xtheirs upstream/$MAIN_BRANCH

--- a/build/update-attribution-files/create_pr.sh
+++ b/build/update-attribution-files/create_pr.sh
@@ -120,9 +120,24 @@ EOF
     pr:create "$pr_title" "$commit_message" "$pr_branch" "$pr_body"
 }
 
+function pr::file:add() {
+    local -r file="$1"
+
+    if git check-ignore -q $FILE; then
+        continue
+    fi
+
+    local -r diff="$(git diff --ignore-blank-lines --ignore-all-space $FILE)"
+    if [[ -z $diff ]]; then
+        continue
+    fi
+
+    git add $file
+}
+
 # Add checksum files
-for FILE in $(find . -type f -name CHECKSUMS); do    
-    git check-ignore -q $FILE || git add $FILE
+for FILE in $(find . -type f -name CHECKSUMS); do
+    pr::file:add $FILE
 done
 
 git add ./build/lib/install_go_versions.sh
@@ -140,7 +155,7 @@ fi
 
 # Add attribution files
 for FILE in $(find . -type f \( -name "*ATTRIBUTION.txt" ! -path "*/_output/*" \)); do    
-    git check-ignore -q $FILE || git add $FILE
+    pr::file:add $FILE
 done
 
 # stash help.mk files
@@ -155,7 +170,7 @@ if [ "$(git stash list)" != "" ]; then
 fi
 # Add help.mk/Makefile files
 for FILE in $(find . -type f \( -name Help.mk -o -name Makefile \)); do    
-    git check-ignore -q $FILE || git add $FILE
+    pr::file:add $FILE
 done
 
 pr::create::help

--- a/projects/apache/cloudstack-cloudmonkey/.gitignore
+++ b/projects/apache/cloudstack-cloudmonkey/.gitignore
@@ -1,0 +1,1 @@
+cloudstack-cloudmonkey

--- a/projects/apache/cloudstack-cloudmonkey/Help.mk
+++ b/projects/apache/cloudstack-cloudmonkey/Help.mk
@@ -45,6 +45,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution  upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums  upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution  upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums  upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/aquasecurity/harbor-scanner-trivy/Help.mk
+++ b/projects/aquasecurity/harbor-scanner-trivy/Help.mk
@@ -45,6 +45,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution  upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums  upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution  upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums  upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/aquasecurity/trivy/Help.mk
+++ b/projects/aquasecurity/trivy/Help.mk
@@ -45,6 +45,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution  upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums  upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution  upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums  upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/aws-containers/hello-eks-anywhere/Help.mk
+++ b/projects/aws-containers/hello-eks-anywhere/Help.mk
@@ -38,6 +38,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/aws/bottlerocket-bootstrap/.gitignore
+++ b/projects/aws/bottlerocket-bootstrap/.gitignore
@@ -2,3 +2,4 @@
 vendor
 bottlerocket-bootstrap
 GIT_TAG
+eks-anywhere-go-mod-download

--- a/projects/aws/bottlerocket-bootstrap/Help.mk
+++ b/projects/aws/bottlerocket-bootstrap/Help.mk
@@ -19,10 +19,10 @@ bottlerocket-bootstrap/images/push: ## Builds/pushes `bottlerocket-bootstrap/ima
 
 ##@ Fetch Binary Targets
 _output/1-21/dependencies/linux-amd64/eksd/kubernetes/client: ## Fetch `_output/1-21/dependencies/linux-amd64/eksd/kubernetes/client`
-_output/1-21/dependencies/linux-amd64/eksd/kubernetes/server: ## Fetch `_output/1-21/dependencies/linux-amd64/eksd/kubernetes/server`
-_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm: ## Fetch `_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm`
 _output/1-21/dependencies/linux-arm64/eksd/kubernetes/client: ## Fetch `_output/1-21/dependencies/linux-arm64/eksd/kubernetes/client`
+_output/1-21/dependencies/linux-amd64/eksd/kubernetes/server: ## Fetch `_output/1-21/dependencies/linux-amd64/eksd/kubernetes/server`
 _output/1-21/dependencies/linux-arm64/eksd/kubernetes/server: ## Fetch `_output/1-21/dependencies/linux-arm64/eksd/kubernetes/server`
+_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm: ## Fetch `_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm`
 _output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/etcdadm: ## Fetch `_output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/etcdadm`
 
 ##@ Checksum Targets
@@ -49,6 +49,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/aws/cluster-api-provider-aws-snow/Help.mk
+++ b/projects/aws/cluster-api-provider-aws-snow/Help.mk
@@ -37,6 +37,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/aws/eks-anywhere-build-tooling/Help.mk
+++ b/projects/aws/eks-anywhere-build-tooling/Help.mk
@@ -14,22 +14,22 @@ eks-anywhere-cli-tools/images/push: ## Builds/pushes `eks-anywhere-cli-tools/ima
 
 ##@ Fetch Binary Targets
 _output/dependencies/linux-amd64/eksa/fluxcd/flux2: ## Fetch `_output/dependencies/linux-amd64/eksa/fluxcd/flux2`
-_output/dependencies/linux-amd64/eksa/kubernetes-sigs/cluster-api: ## Fetch `_output/dependencies/linux-amd64/eksa/kubernetes-sigs/cluster-api`
-_output/dependencies/linux-amd64/eksa/kubernetes-sigs/kind: ## Fetch `_output/dependencies/linux-amd64/eksa/kubernetes-sigs/kind`
-_output/dependencies/linux-amd64/eksa/replicatedhq/troubleshoot: ## Fetch `_output/dependencies/linux-amd64/eksa/replicatedhq/troubleshoot`
-_output/dependencies/linux-amd64/eksa/vmware/govmomi: ## Fetch `_output/dependencies/linux-amd64/eksa/vmware/govmomi`
-_output/dependencies/linux-amd64/eksd/kubernetes/client: ## Fetch `_output/dependencies/linux-amd64/eksd/kubernetes/client`
-_output/dependencies/linux-amd64/eksa/helm/helm: ## Fetch `_output/dependencies/linux-amd64/eksa/helm/helm`
-_output/dependencies/linux-amd64/eksa/tinkerbell/tink/94-2b1eddcdf90082499b7663ca3c47e77dc12ad34c: ## Fetch `_output/dependencies/linux-amd64/eksa/tinkerbell/tink/94-2b1eddcdf90082499b7663ca3c47e77dc12ad34c`
-_output/dependencies/linux-amd64/eksa/apache/cloudstack-cloudmonkey: ## Fetch `_output/dependencies/linux-amd64/eksa/apache/cloudstack-cloudmonkey`
 _output/dependencies/linux-arm64/eksa/fluxcd/flux2: ## Fetch `_output/dependencies/linux-arm64/eksa/fluxcd/flux2`
+_output/dependencies/linux-amd64/eksa/kubernetes-sigs/cluster-api: ## Fetch `_output/dependencies/linux-amd64/eksa/kubernetes-sigs/cluster-api`
 _output/dependencies/linux-arm64/eksa/kubernetes-sigs/cluster-api: ## Fetch `_output/dependencies/linux-arm64/eksa/kubernetes-sigs/cluster-api`
+_output/dependencies/linux-amd64/eksa/kubernetes-sigs/kind: ## Fetch `_output/dependencies/linux-amd64/eksa/kubernetes-sigs/kind`
 _output/dependencies/linux-arm64/eksa/kubernetes-sigs/kind: ## Fetch `_output/dependencies/linux-arm64/eksa/kubernetes-sigs/kind`
+_output/dependencies/linux-amd64/eksa/replicatedhq/troubleshoot: ## Fetch `_output/dependencies/linux-amd64/eksa/replicatedhq/troubleshoot`
 _output/dependencies/linux-arm64/eksa/replicatedhq/troubleshoot: ## Fetch `_output/dependencies/linux-arm64/eksa/replicatedhq/troubleshoot`
+_output/dependencies/linux-amd64/eksa/vmware/govmomi: ## Fetch `_output/dependencies/linux-amd64/eksa/vmware/govmomi`
 _output/dependencies/linux-arm64/eksa/vmware/govmomi: ## Fetch `_output/dependencies/linux-arm64/eksa/vmware/govmomi`
+_output/dependencies/linux-amd64/eksd/kubernetes/client: ## Fetch `_output/dependencies/linux-amd64/eksd/kubernetes/client`
 _output/dependencies/linux-arm64/eksd/kubernetes/client: ## Fetch `_output/dependencies/linux-arm64/eksd/kubernetes/client`
+_output/dependencies/linux-amd64/eksa/helm/helm: ## Fetch `_output/dependencies/linux-amd64/eksa/helm/helm`
 _output/dependencies/linux-arm64/eksa/helm/helm: ## Fetch `_output/dependencies/linux-arm64/eksa/helm/helm`
+_output/dependencies/linux-amd64/eksa/tinkerbell/tink/94-2b1eddcdf90082499b7663ca3c47e77dc12ad34c: ## Fetch `_output/dependencies/linux-amd64/eksa/tinkerbell/tink/94-2b1eddcdf90082499b7663ca3c47e77dc12ad34c`
 _output/dependencies/linux-arm64/eksa/tinkerbell/tink/94-2b1eddcdf90082499b7663ca3c47e77dc12ad34c: ## Fetch `_output/dependencies/linux-arm64/eksa/tinkerbell/tink/94-2b1eddcdf90082499b7663ca3c47e77dc12ad34c`
+_output/dependencies/linux-amd64/eksa/apache/cloudstack-cloudmonkey: ## Fetch `_output/dependencies/linux-amd64/eksa/apache/cloudstack-cloudmonkey`
 _output/dependencies/linux-arm64/eksa/apache/cloudstack-cloudmonkey: ## Fetch `_output/dependencies/linux-arm64/eksa/apache/cloudstack-cloudmonkey`
 
 ##@ Clean Targets

--- a/projects/aws/eks-anywhere-packages/Help.mk
+++ b/projects/aws/eks-anywhere-packages/Help.mk
@@ -52,6 +52,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/aws/eks-anywhere/Help.mk
+++ b/projects/aws/eks-anywhere/Help.mk
@@ -31,6 +31,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `local-images`
-release: ## Called via prow postsubmit + release jobs, calls `images`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/aws/eks-anywhere/Makefile
+++ b/projects/aws/eks-anywhere/Makefile
@@ -19,8 +19,6 @@ REPO_NO_CLONE=true
 include $(BASE_DIRECTORY)/Common.mk
 
 
-
-
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block
 # This is added to help document dynamic targets and support shell autocompletion

--- a/projects/aws/etcdadm-bootstrap-provider/Help.mk
+++ b/projects/aws/etcdadm-bootstrap-provider/Help.mk
@@ -51,6 +51,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/aws/etcdadm-controller/Help.mk
+++ b/projects/aws/etcdadm-controller/Help.mk
@@ -51,6 +51,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/brancz/kube-rbac-proxy/Help.mk
+++ b/projects/brancz/kube-rbac-proxy/Help.mk
@@ -46,6 +46,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/cloudflare/cfssl/Help.mk
+++ b/projects/cloudflare/cfssl/Help.mk
@@ -65,6 +65,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/distribution/distribution/Help.mk
+++ b/projects/distribution/distribution/Help.mk
@@ -46,6 +46,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution  upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums  upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution  upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums  upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/fluxcd/flux2/Help.mk
+++ b/projects/fluxcd/flux2/Help.mk
@@ -55,6 +55,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/fluxcd/helm-controller/Help.mk
+++ b/projects/fluxcd/helm-controller/Help.mk
@@ -47,6 +47,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/fluxcd/kustomize-controller/Help.mk
+++ b/projects/fluxcd/kustomize-controller/Help.mk
@@ -46,6 +46,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/fluxcd/notification-controller/Help.mk
+++ b/projects/fluxcd/notification-controller/Help.mk
@@ -47,6 +47,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/fluxcd/source-controller/Help.mk
+++ b/projects/fluxcd/source-controller/Help.mk
@@ -47,6 +47,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/goharbor/harbor/Help.mk
+++ b/projects/goharbor/harbor/Help.mk
@@ -60,10 +60,10 @@ helm/push: ## Build helm chart and push to registry defined in IMAGE_REPO.
 
 ##@ Fetch Binary Targets
 _output/dependencies/linux-amd64/eksa/distribution/distribution: ## Fetch `_output/dependencies/linux-amd64/eksa/distribution/distribution`
-_output/dependencies/linux-amd64/eksa/aquasecurity/trivy: ## Fetch `_output/dependencies/linux-amd64/eksa/aquasecurity/trivy`
-_output/dependencies/linux-amd64/eksa/aquasecurity/harbor-scanner-trivy: ## Fetch `_output/dependencies/linux-amd64/eksa/aquasecurity/harbor-scanner-trivy`
 _output/dependencies/linux-arm64/eksa/distribution/distribution: ## Fetch `_output/dependencies/linux-arm64/eksa/distribution/distribution`
+_output/dependencies/linux-amd64/eksa/aquasecurity/trivy: ## Fetch `_output/dependencies/linux-amd64/eksa/aquasecurity/trivy`
 _output/dependencies/linux-arm64/eksa/aquasecurity/trivy: ## Fetch `_output/dependencies/linux-arm64/eksa/aquasecurity/trivy`
+_output/dependencies/linux-amd64/eksa/aquasecurity/harbor-scanner-trivy: ## Fetch `_output/dependencies/linux-amd64/eksa/aquasecurity/harbor-scanner-trivy`
 _output/dependencies/linux-arm64/eksa/aquasecurity/harbor-scanner-trivy: ## Fetch `_output/dependencies/linux-arm64/eksa/aquasecurity/harbor-scanner-trivy`
 
 ##@ Checksum Targets
@@ -91,6 +91,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/grpc-ecosystem/grpc-health-probe/Help.mk
+++ b/projects/grpc-ecosystem/grpc-health-probe/Help.mk
@@ -45,6 +45,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution  upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums  upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution  upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums  upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/helm/helm/Help.mk
+++ b/projects/helm/helm/Help.mk
@@ -46,6 +46,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution  upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums  upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution  upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums  upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/jetstack/cert-manager/Help.mk
+++ b/projects/jetstack/cert-manager/Help.mk
@@ -67,6 +67,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/cluster-api-provider-aws/Help.mk
+++ b/projects/kubernetes-sigs/cluster-api-provider-aws/Help.mk
@@ -61,6 +61,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/cluster-api-provider-cloudstack/Help.mk
+++ b/projects/kubernetes-sigs/cluster-api-provider-cloudstack/Help.mk
@@ -51,6 +51,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/cluster-api-provider-vsphere/Help.mk
+++ b/projects/kubernetes-sigs/cluster-api-provider-vsphere/Help.mk
@@ -52,6 +52,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/cluster-api/Help.mk
+++ b/projects/kubernetes-sigs/cluster-api/Help.mk
@@ -70,6 +70,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/cri-tools/Help.mk
+++ b/projects/kubernetes-sigs/cri-tools/Help.mk
@@ -47,6 +47,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution  upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums  upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution  upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums  upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/etcdadm/Help.mk
+++ b/projects/kubernetes-sigs/etcdadm/Help.mk
@@ -46,6 +46,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution  upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums  upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution  upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums  upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/image-builder/Help.mk
+++ b/projects/kubernetes-sigs/image-builder/Help.mk
@@ -17,6 +17,12 @@ images: ## Pushes `image-builder/images/push` to IMAGE_REPO
 image-builder/images/amd64: ## Builds/pushes `image-builder/images/amd64`
 image-builder/images/push: ## Builds/pushes `image-builder/images/push`
 
+##@ Fetch Binary Targets
+_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm: ## Fetch `_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm`
+_output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/etcdadm: ## Fetch `_output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/etcdadm`
+_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/cri-tools: ## Fetch `_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/cri-tools`
+_output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/cri-tools: ## Fetch `_output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/cri-tools`
+
 ##@ Clean Targets
 clean: ## Removes source and _output directory
 clean-repo: ## Removes source directory
@@ -33,6 +39,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `release-raw-ubuntu-2004-efi image-builder/images/capi/output/fake-ubuntu.gz /home/prow/go/src/github.com/aws/eks-anywhere-build-tooling/projects/kubernetes-sigs/image-builder/_output/tar/1-21/raw/ubuntu/ubuntu.gz upload-artifacts-raw build-ami-ubuntu-2004 setup-packer-configs-ova download-ova-bottlerocket image-builder/images/capi/output/fake-ubuntu.ova /home/prow/go/src/github.com/aws/eks-anywhere-build-tooling/projects/kubernetes-sigs/image-builder/_output/tar/1-21/ova/ubuntu/ubuntu.ova /home/prow/go/src/github.com/aws/eks-anywhere-build-tooling/projects/kubernetes-sigs/image-builder/_output/tar/1-21/ova/bottlerocket/bottlerocket.ova upload-artifacts-ova upload-ova-bottlerocket`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+build: ## Called via prow presubmit, calls `release-raw-ubuntu-2004-efi image-builder/images/capi/output/fake-ubuntu.gz _output/tar/1-21/raw/ubuntu/ubuntu.gz upload-artifacts-raw build-ami-ubuntu-2004 setup-packer-configs-ova download-ova-bottlerocket image-builder/images/capi/output/fake-ubuntu.ova _output/tar/1-21/ova/ubuntu/ubuntu.ova _output/tar/1-21/ova/bottlerocket/bottlerocket.ova upload-artifacts-ova upload-ova-bottlerocket" `
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -67,6 +67,7 @@ FAKE_UBUNTU_OVA_PATH=$(IMAGE_BUILDER_DIR)/output/fake-ubuntu.ova
 FAKE_UBUNTU_RAW_PATH=$(IMAGE_BUILDER_DIR)/output/fake-ubuntu.gz
 
 IMAGE_OS?=ubuntu
+IMAGE_FORMAT?=
 BUILD_AMI_TARGETS=build-ami-ubuntu-2004
 BUILD_OVA_TARGETS=setup-packer-configs-ova download-ova-bottlerocket $(FAKE_UBUNTU_OVA_PATH) $(FINAL_OVA_PATH) $(FINAL_BOTTLEROCKET_OVA_PATH) upload-artifacts-ova upload-ova-bottlerocket
 BUILD_RAW_TARGETS=release-raw-ubuntu-2004-efi $(FAKE_UBUNTU_RAW_PATH) $(FINAL_RAW_IMAGE_PATH) upload-artifacts-raw

--- a/projects/kubernetes-sigs/kind/Help.mk
+++ b/projects/kubernetes-sigs/kind/Help.mk
@@ -30,14 +30,14 @@ kind-base/images/push: ## Builds/pushes `kind-base/images/push`
 
 ##@ Fetch Binary Targets
 _output/1-21/dependencies/linux-amd64/eksd/kubernetes/client: ## Fetch `_output/1-21/dependencies/linux-amd64/eksd/kubernetes/client`
-_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm: ## Fetch `_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm`
-_output/1-21/dependencies/linux-amd64/eksd/cni-plugins: ## Fetch `_output/1-21/dependencies/linux-amd64/eksd/cni-plugins`
-_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/cri-tools: ## Fetch `_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/cri-tools`
-_output/1-21/dependencies/linux-amd64/eksd/etcd/etcd.tar.gz: ## Fetch `_output/1-21/dependencies/linux-amd64/eksd/etcd/etcd.tar.gz`
 _output/1-21/dependencies/linux-arm64/eksd/kubernetes/client: ## Fetch `_output/1-21/dependencies/linux-arm64/eksd/kubernetes/client`
+_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm: ## Fetch `_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm`
 _output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/etcdadm: ## Fetch `_output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/etcdadm`
+_output/1-21/dependencies/linux-amd64/eksd/cni-plugins: ## Fetch `_output/1-21/dependencies/linux-amd64/eksd/cni-plugins`
 _output/1-21/dependencies/linux-arm64/eksd/cni-plugins: ## Fetch `_output/1-21/dependencies/linux-arm64/eksd/cni-plugins`
+_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/cri-tools: ## Fetch `_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/cri-tools`
 _output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/cri-tools: ## Fetch `_output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/cri-tools`
+_output/1-21/dependencies/linux-amd64/eksd/etcd/etcd.tar.gz: ## Fetch `_output/1-21/dependencies/linux-amd64/eksd/etcd/etcd.tar.gz`
 _output/1-21/dependencies/linux-arm64/eksd/etcd/etcd.tar.gz: ## Fetch `_output/1-21/dependencies/linux-arm64/eksd/etcd/etcd.tar.gz`
 
 ##@ Checksum Targets
@@ -72,6 +72,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/vsphere-csi-driver/Help.mk
+++ b/projects/kubernetes-sigs/vsphere-csi-driver/Help.mk
@@ -50,6 +50,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/kubernetes/cloud-provider-vsphere/Help.mk
+++ b/projects/kubernetes/cloud-provider-vsphere/Help.mk
@@ -47,6 +47,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/plunder-app/kube-vip/Help.mk
+++ b/projects/plunder-app/kube-vip/Help.mk
@@ -47,6 +47,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/rancher/local-path-provisioner/Help.mk
+++ b/projects/rancher/local-path-provisioner/Help.mk
@@ -46,6 +46,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/redis/redis/Help.mk
+++ b/projects/redis/redis/Help.mk
@@ -19,7 +19,14 @@ clean: ## Removes source and _output directory
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion
 
+##@Update Helpers
+run-target-in-docker: ## Run `MAKE_TARGET` using builder base docker container
+update-attribution-checksums-docker: ## Update attribution and checksums using the builder base docker container
+stop-docker-builder: ## Clean up builder base docker container
+generate: ## Update UPSTREAM_PROJECTS.yaml
+create-ecr-repos: ## Create repos in ECR for project images for local testing
+
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums local-images attribution attribution-pr `
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+build: ## Called via prow presubmit, calls `local-images`
+release: ## Called via prow postsubmit + release jobs, calls `images`
 ########### END GENERATED ###########################

--- a/projects/replicatedhq/troubleshoot/Help.mk
+++ b/projects/replicatedhq/troubleshoot/Help.mk
@@ -46,6 +46,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution  upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums  upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution  upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums  upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/tinkerbell/boots/Help.mk
+++ b/projects/tinkerbell/boots/Help.mk
@@ -46,6 +46,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/Help.mk
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/Help.mk
@@ -52,6 +52,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/tinkerbell/hegel/Help.mk
+++ b/projects/tinkerbell/hegel/Help.mk
@@ -46,6 +46,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/tinkerbell/hook/Help.mk
+++ b/projects/tinkerbell/hook/Help.mk
@@ -58,6 +58,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/tinkerbell/hub/Help.mk
+++ b/projects/tinkerbell/hub/Help.mk
@@ -63,6 +63,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/tinkerbell/pbnj/Help.mk
+++ b/projects/tinkerbell/pbnj/Help.mk
@@ -50,6 +50,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images  attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images `
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images  attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images `
 ########### END GENERATED ###########################

--- a/projects/tinkerbell/rufio/Help.mk
+++ b/projects/tinkerbell/rufio/Help.mk
@@ -51,6 +51,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/tinkerbell/tink/Help.mk
+++ b/projects/tinkerbell/tink/Help.mk
@@ -68,6 +68,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution local-images upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums images upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution local-images upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums images upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/tinkerbell/tinkerbell-chart/Help.mk
+++ b/projects/tinkerbell/tinkerbell-chart/Help.mk
@@ -6,6 +6,17 @@
 # This is added to help document dynamic targets and support shell autocompletion
 
 
+##@ Image Targets
+local-images: ## Builds `tinkerbell-chart/images/amd64` as oci tars for presumbit validation
+images: ## Pushes `tinkerbell-chart/images/push` to IMAGE_REPO
+tinkerbell-chart/images/amd64: ## Builds/pushes `tinkerbell-chart/images/amd64`
+tinkerbell-chart/images/push: ## Builds/pushes `tinkerbell-chart/images/push`
+
+##@ License Targets
+gather-licenses: ## Helper to call $(GATHER_LICENSES_TARGETS) which gathers all licenses
+attribution: ## Generates attribution from licenses gathered during `gather-licenses`.
+attribution-pr: ## Generates PR to update attribution files for projects
+
 ##@ Clean Targets
 clean: ## Removes source and _output directory
 
@@ -21,6 +32,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate`
-release: ## Called via prow postsubmit + release jobs, calls `build-raw-image`
+build: ## Called via prow presubmit, calls `build-chart`
+release: ## Called via prow postsubmit + release jobs, calls `publish-chart`
 ########### END GENERATED ###########################

--- a/projects/tinkerbell/tinkerbell-chart/Makefile
+++ b/projects/tinkerbell/tinkerbell-chart/Makefile
@@ -29,3 +29,11 @@ build-chart: verify
 .PHONY: publish-chart
 publish-chart: build-chart
 	$(BUILD_LIB)/helm_push.sh $(IMAGE_REPO) $(HELM_DESTINATION_REPOSITORY) $(IMAGE_TAG) $(OUTPUT_DIR)
+
+
+########### DO NOT EDIT #############################
+# To update call: make add-generated-help-block
+# This is added to help document dynamic targets and support shell autocompletion
+# Run make help for a formatted help block with all targets
+include Help.mk
+########### END GENERATED ###########################

--- a/projects/torvalds/linux/.gitignore
+++ b/projects/torvalds/linux/.gitignore
@@ -1,1 +1,2 @@
 linux
+CHECKSUMS

--- a/projects/torvalds/linux/Help.mk
+++ b/projects/torvalds/linux/Help.mk
@@ -10,6 +10,14 @@
 clone-repo:  ## Clone upstream `linux`
 checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
 
+##@ Binary Targets
+binaries: ## Build all binaries: `` for `linux/amd64`
+_output/bin/linux/linux-amd64/tools/bootconfig: ## Build `_output/bin/linux/linux-amd64/tools/bootconfig`
+
+##@ Checksum Targets
+checksums: ## Update checksums file based on currently built binaries.
+validate-checksums: # Validate checksums of currently built binaries against checksums file.
+
 ##@ Artifact Targets
 tarballs: ## Create tarballs by calling build/lib/simple_create_tarballs.sh unless SIMPLE_CREATE_TARBALLS=false, then tarballs must be defined in project Makefile
 s3-artifacts: # Prepare ARTIFACTS_PATH folder structure with tarballs/manifests/other items to be uploaded to s3
@@ -28,8 +36,9 @@ run-target-in-docker: ## Run `MAKE_TARGET` using builder base docker container
 update-attribution-checksums-docker: ## Update attribution and checksums using the builder base docker container
 stop-docker-builder: ## Clean up builder base docker container
 generate: ## Update UPSTREAM_PROJECTS.yaml
+create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution  upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums  upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution  upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums  upload-artifacts`
 ########### END GENERATED ###########################

--- a/projects/vmware/govmomi/Help.mk
+++ b/projects/vmware/govmomi/Help.mk
@@ -45,6 +45,6 @@ generate: ## Update UPSTREAM_PROJECTS.yaml
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `validate-checksums attribution  upload-artifacts attribution-pr`
-release: ## Called via prow postsubmit + release jobs, calls `validate-checksums  upload-artifacts`
+build: ## Called via prow presubmit, calls `handle-dependencies validate-checksums attribution  upload-artifacts attribution-pr`
+release: ## Called via prow postsubmit + release jobs, calls `handle-dependencies validate-checksums  upload-artifacts`
 ########### END GENERATED ###########################


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- The attribution job was using the help branch in the create_pr script for checksums
- Help generation was not project_dep aware and was losing the fetch/binaries targets
- Checksum auto updating was considering whitespace as a reason to update, even though it does not matter for validating checksums
- various gitignore updates and linux checksums ignore since we do not validate that build

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
