### PR TITLE
Adding a patch to add CAPT BMCjob watch

### DIFF
--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/CHECKSUMS
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/CHECKSUMS
@@ -1,2 +1,2 @@
-ef146f08d570f9bd3c52e19e63511b972b1c7a58f2e4f6d576d73b7d8cf4a874  _output/bin/cluster-api-provider-tinkerbell/linux-amd64/manager
-475b73d9d35100f3cda05ef9b1285f87a47ab843992a70c6b85730a916cef0fc  _output/bin/cluster-api-provider-tinkerbell/linux-arm64/manager
+050cbbe7d324f14775159f21e506c31796d63d1af0d9d3d1df462c6c0ca3c974  _output/bin/cluster-api-provider-tinkerbell/linux-amd64/manager
+ce20abb7b74ca9a7553096c1966533009a28bbc76f4fa3040c0a655e61e28027  _output/bin/cluster-api-provider-tinkerbell/linux-arm64/manager

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0002-Adding-watch-on-Rufio-BMCJob.patch
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0002-Adding-watch-on-Rufio-BMCJob.patch
@@ -1,0 +1,318 @@
+From 25721cc2055f26a839470a070febe815b9f19924 Mon Sep 17 00:00:00 2001
+From: Aravind Ramalingam <ramaliar@amazon.com>
+Date: Mon, 6 Jun 2022 10:15:20 -0700
+Subject: [PATCH] Adding watch on Rufio BMCJob
+
+Signed-off-by: Aravind Ramalingam <ramaliar@amazon.com>
+---
+ controllers/base.go                         | 60 +++++++++++--
+ controllers/machine.go                      | 95 ++++++++++++---------
+ controllers/tinkerbellmachine_controller.go | 10 ++-
+ 3 files changed, 121 insertions(+), 44 deletions(-)
+
+diff --git a/controllers/base.go b/controllers/base.go
+index ff75d61..9269d56 100644
+--- a/controllers/base.go
++++ b/controllers/base.go
+@@ -186,6 +186,7 @@ func (bmrc *baseMachineReconcileContext) powerOffHardware(hardware *tinkv1.Hardw
+ // createPowerOffJob creates a BMCJob object with the required tasks for hardware power off.
+ func (bmrc *baseMachineReconcileContext) createPowerOffJob(hardware *tinkv1.Hardware) error {
+ 	powerOffAction := rufiov1.HardPowerOff
++	controller := true
+ 	bmcJob := &rufiov1.BMCJob{
+ 		ObjectMeta: metav1.ObjectMeta{
+ 			Name:      fmt.Sprintf("%s-poweroff", bmrc.tinkerbellMachine.Name),
+@@ -196,6 +197,7 @@ func (bmrc *baseMachineReconcileContext) createPowerOffJob(hardware *tinkv1.Hard
+ 					Kind:       "TinkerbellMachine",
+ 					Name:       bmrc.tinkerbellMachine.Name,
+ 					UID:        bmrc.tinkerbellMachine.ObjectMeta.UID,
++					Controller: &controller,
+ 				},
+ 			},
+ 		},
+@@ -219,10 +221,62 @@ func (bmrc *baseMachineReconcileContext) createPowerOffJob(hardware *tinkv1.Hard
+ 	return nil
+ }
+ 
++// getBMCJob fetches the BMCJob with name JName.
++func (bmrc *baseMachineReconcileContext) getBMCJob(jName string, bmj *rufiov1.BMCJob) error {
++	namespacedName := types.NamespacedName{
++		Name:      jName,
++		Namespace: bmrc.tinkerbellMachine.Namespace,
++	}
++
++	err := bmrc.client.Get(bmrc.ctx, namespacedName, bmj)
++	if err != nil {
++		return fmt.Errorf("GET BMCJob: %w", err)
++	}
++
++	return nil
++}
++
+ // DeleteMachineWithDependencies removes template and workflow objects associated with given machine.
+ func (bmrc *baseMachineReconcileContext) DeleteMachineWithDependencies() error {
+ 	bmrc.log.Info("Removing machine", "hardwareName", bmrc.tinkerbellMachine.Spec.HardwareName)
+ 
++	// Fetch a poweroff BMCJob for machine.
++	bmcJob := &rufiov1.BMCJob{}
++	jobName := fmt.Sprintf("%s-poweroff", bmrc.tinkerbellMachine.Name)
++
++	err := bmrc.getBMCJob(jobName, bmcJob)
++	if err != nil {
++		if apierrors.IsNotFound(err) {
++			// BMCJob not found, hence Machine is not powered off.
++			// Proceed to remove dependencies.
++			return bmrc.removeDependencies()
++		}
++
++		return fmt.Errorf("get bmc job for machine: %w", err)
++	}
++
++	// Check the Job conditions to ensure the power off job is complete.
++	if bmcJob.HasCondition(rufiov1.JobCompleted, rufiov1.ConditionTrue) {
++		controllerutil.RemoveFinalizer(bmrc.tinkerbellMachine, infrastructurev1.MachineFinalizer)
++
++		bmrc.log.Info("Patching Machine object to remove finalizer")
++
++		return bmrc.patch()
++	}
++
++	if bmcJob.HasCondition(rufiov1.JobFailed, rufiov1.ConditionTrue) {
++		return fmt.Errorf("bmc job %s/%s failed", bmcJob.Namespace, bmcJob.Name)
++	}
++
++	// Job Running is a noop.
++	if bmcJob.HasCondition(rufiov1.JobRunning, rufiov1.ConditionTrue) {
++		return nil
++	}
++
++	return nil
++}
++
++func (bmrc *baseMachineReconcileContext) removeDependencies() error {
+ 	if err := bmrc.removeTemplate(); err != nil {
+ 		return fmt.Errorf("removing Template: %w", err)
+ 	}
+@@ -235,11 +289,7 @@ func (bmrc *baseMachineReconcileContext) DeleteMachineWithDependencies() error {
+ 		return fmt.Errorf("releasing Hardware: %w", err)
+ 	}
+ 
+-	controllerutil.RemoveFinalizer(bmrc.tinkerbellMachine, infrastructurev1.MachineFinalizer)
+-
+-	bmrc.log.Info("Patching Machine object to remove finalizer")
+-
+-	return bmrc.patch()
++	return nil
+ }
+ 
+ // IntoMachineReconcileContext implements BaseMachineReconcileContext by building MachineReconcileContext
+diff --git a/controllers/machine.go b/controllers/machine.go
+index 7bb1278..5eb58f8 100644
+--- a/controllers/machine.go
++++ b/controllers/machine.go
+@@ -97,6 +97,10 @@ func (mrc *machineReconcileContext) ensureDependencies() error {
+ 		return fmt.Errorf("ensuring workflow: %w", err)
+ 	}
+ 
++	if err := mrc.createHardwareProvisionJob(hardware); err != nil {
++		return fmt.Errorf("failed create hardware provision job: %w", err)
++	}
++
+ 	return nil
+ }
+ 
+@@ -111,6 +115,43 @@ func (mrc *machineReconcileContext) markAsReady() error {
+ }
+ 
+ func (mrc *machineReconcileContext) Reconcile() error {
++	// Fetch a provisioining BMCJob for machine.
++	bmcJob := &rufiov1.BMCJob{}
++	jobName := fmt.Sprintf("%s-provision", mrc.tinkerbellMachine.Name)
++
++	err := mrc.getBMCJob(jobName, bmcJob)
++	if err != nil {
++		if apierrors.IsNotFound(err) {
++			// BMCJob not found, hence Machine is not ready for provisioining.
++			// Proceed to reconcile.
++			return mrc.reconcile()
++		}
++
++		return fmt.Errorf("get bmc job for machine: %w", err)
++	}
++
++	// Check the Job conditions to ensure the Machine is Ready.
++	if bmcJob.HasCondition(rufiov1.JobCompleted, rufiov1.ConditionTrue) {
++		if err := mrc.markAsReady(); err != nil {
++			return fmt.Errorf("marking machine as ready: %w", err)
++		}
++
++		return nil
++	}
++
++	if bmcJob.HasCondition(rufiov1.JobFailed, rufiov1.ConditionTrue) {
++		return fmt.Errorf("bmc job %s/%s failed", bmcJob.Namespace, bmcJob.Name)
++	}
++
++	// Job Running is a noop.
++	if bmcJob.HasCondition(rufiov1.JobRunning, rufiov1.ConditionTrue) {
++		return nil
++	}
++
++	return nil
++}
++
++func (mrc *machineReconcileContext) reconcile() error {
+ 	// To make sure we do not create orphaned objects.
+ 	if err := mrc.addFinalizer(); err != nil {
+ 		return fmt.Errorf("adding finalizer: %w", err)
+@@ -120,10 +161,6 @@ func (mrc *machineReconcileContext) Reconcile() error {
+ 		return fmt.Errorf("ensuring machine dependencies: %w", err)
+ 	}
+ 
+-	if err := mrc.markAsReady(); err != nil {
+-		return fmt.Errorf("marking machine as ready: %w", err)
+-	}
+-
+ 	return nil
+ }
+ 
+@@ -351,10 +388,6 @@ func (mrc *machineReconcileContext) ensureHardware() (*tinkv1.Hardware, error) {
+ 		return nil, fmt.Errorf("ensuring Hardware user data: %w", err)
+ 	}
+ 
+-	if err := mrc.ensureHardwareReadyToProvision(hardware); err != nil {
+-		return nil, fmt.Errorf("failed to ensure hardware ready for provisioning: %w", err)
+-	}
+-
+ 	return hardware, mrc.setStatus(hardware)
+ }
+ 
+@@ -473,10 +506,10 @@ func byHardwareAffinity(hardware []tinkv1.Hardware, preferred []infrastructurev1
+ 	}, nil
+ }
+ 
+-// ensureHardwareReadyToProvision ensures the hardware is ready to be provisioned.
++// createHardwareProvisionJob ensures the hardware is ready to be provisioned.
+ // Uses the BMCRef from the hardware to create a BMCJob.
+ // The BMCJob is responsible for getting the machine to desired state for provisioning.
+-func (mrc *machineReconcileContext) ensureHardwareReadyToProvision(hardware *tinkv1.Hardware) error {
++func (mrc *machineReconcileContext) createHardwareProvisionJob(hardware *tinkv1.Hardware) error {
+ 	if hardware.Spec.BMCRef == nil {
+ 		mrc.log.Info("Skipping BMC state management", "BMCRef", hardware.Spec.BMCRef, "Hardware", hardware.Name)
+ 
+@@ -484,47 +517,35 @@ func (mrc *machineReconcileContext) ensureHardwareReadyToProvision(hardware *tin
+ 	}
+ 
+ 	jobName := fmt.Sprintf("%s-provision", mrc.tinkerbellMachine.Name)
+-	// Check if BMC Job already exists for the machine
+-	exists, err := mrc.bmcJobExists(jobName)
+-	if err != nil {
+-		return err
+-	}
+-
+-	if exists {
+-		return nil
+-	}
+-
+ 	// Create a BMCJob for hardware provisioning
+-	if err := mrc.createBMCJobForHardware(hardware, jobName); err != nil {
++	if err := mrc.createBMCJob(hardware, jobName); err != nil {
+ 		return err
+ 	}
+ 
++	mrc.log.Info("BMCJob created", "Name", jobName, "Namespace", mrc.tinkerbellMachine.Namespace)
++
+ 	return nil
+ }
+ 
+-// bmcJobExists checks if a BMCJob exists for the machine.
+-func (mrc *machineReconcileContext) bmcJobExists(name string) (bool, error) {
++// getBMCJob fetches the BMCJob with name JName.
++func (mrc *machineReconcileContext) getBMCJob(jName string, bmj *rufiov1.BMCJob) error {
+ 	namespacedName := types.NamespacedName{
+-		Name:      name,
++		Name:      jName,
+ 		Namespace: mrc.tinkerbellMachine.Namespace,
+ 	}
+ 
+-	err := mrc.client.Get(mrc.ctx, namespacedName, &rufiov1.BMCJob{})
++	err := mrc.client.Get(mrc.ctx, namespacedName, bmj)
+ 	if err != nil {
+-		if apierrors.IsNotFound(err) {
+-			return false, nil
+-		}
+-
+-		return false, fmt.Errorf("checking if bmc job exists: %w", err)
++		return fmt.Errorf("GET BMCJob: %w", err)
+ 	}
+ 
+-	return true, nil
++	return nil
+ }
+ 
+-// createBMCJobForHardware creates a BMCJob object with the required tasks for hardware provisioning.
+-func (mrc *machineReconcileContext) createBMCJobForHardware(hardware *tinkv1.Hardware, name string) error {
+-	powerOffAction := rufiov1.HardPowerOff
++// createBMCJob creates a BMCJob object with the required tasks for hardware provisioning.
++func (mrc *machineReconcileContext) createBMCJob(hardware *tinkv1.Hardware, name string) error {
+ 	powerOnAction := rufiov1.PowerOn
++	controller := true
+ 	bmcJob := &rufiov1.BMCJob{
+ 		ObjectMeta: metav1.ObjectMeta{
+ 			Name:      name,
+@@ -535,6 +556,7 @@ func (mrc *machineReconcileContext) createBMCJobForHardware(hardware *tinkv1.Har
+ 					Kind:       "TinkerbellMachine",
+ 					Name:       mrc.tinkerbellMachine.Name,
+ 					UID:        mrc.tinkerbellMachine.ObjectMeta.UID,
++					Controller: &controller,
+ 				},
+ 			},
+ 		},
+@@ -544,15 +566,12 @@ func (mrc *machineReconcileContext) createBMCJobForHardware(hardware *tinkv1.Har
+ 				Namespace: mrc.tinkerbellMachine.Namespace,
+ 			},
+ 			Tasks: []rufiov1.Task{
+-				{
+-					PowerAction: &powerOffAction,
+-				},
+ 				{
+ 					OneTimeBootDeviceAction: &rufiov1.OneTimeBootDeviceAction{
+ 						Devices: []rufiov1.BootDevice{
+ 							rufiov1.PXE,
+ 						},
+-						EFIBoot: false,
++						EFIBoot: hardware.Spec.Interfaces[0].DHCP.UEFI,
+ 					},
+ 				},
+ 				{
+diff --git a/controllers/tinkerbellmachine_controller.go b/controllers/tinkerbellmachine_controller.go
+index 81d1471..40d8bed 100644
+--- a/controllers/tinkerbellmachine_controller.go
++++ b/controllers/tinkerbellmachine_controller.go
+@@ -32,6 +32,8 @@ import (
+ 	"sigs.k8s.io/controller-runtime/pkg/handler"
+ 	"sigs.k8s.io/controller-runtime/pkg/source"
+ 
++	rufiov1 "github.com/tinkerbell/rufio/api/v1alpha1"
++
+ 	infrastructurev1 "github.com/tinkerbell/cluster-api-provider-tinkerbell/api/v1beta1"
+ )
+ 
+@@ -112,7 +114,13 @@ func (tmr *TinkerbellMachineReconciler) SetupWithManager(
+ 			&source.Kind{Type: &clusterv1.Cluster{}},
+ 			handler.EnqueueRequestsFromMapFunc(clusterToObjectFunc),
+ 			builder.WithPredicates(predicates.ClusterUnpausedAndInfrastructureReady(log)),
+-		)
++		).
++		Watches(
++			&source.Kind{Type: &rufiov1.BMCJob{}},
++			&handler.EnqueueRequestForOwner{
++				OwnerType:    &infrastructurev1.TinkerbellMachine{},
++				IsController: true,
++			})
+ 
+ 	if err := builder.Complete(tmr); err != nil {
+ 		return fmt.Errorf("failed to create controller: %w", err)
+-- 
+2.34.1
+


### PR DESCRIPTION
*Description of changes:*
Adding a CAPT patch to watch BMCJobs and mark machine ready only after job is completed. Similarly for delete cluster.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
