### PR TITLE
Fix EOF errors occuring during Packer build

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0008-Add-support-for-RHEL-8-RAW-image-builds.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0008-Add-support-for-RHEL-8-RAW-image-builds.patch
@@ -112,9 +112,9 @@ index 000000000..05a9625c8
 +rm -f /swapfile
 +sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
 +
-+sed -i '/^\(HWADDR\|UUID\)=/d' /etc/sysconfig/network-scripts/ifcfg-*   
++sed -i '/^\(HWADDR\|UUID\)=/d' /etc/sysconfig/network-scripts/ifcfg-*
 +
-+%end 
++%end
 \ No newline at end of file
 diff --git a/images/capi/packer/raw/raw-rhel-8.json b/images/capi/packer/raw/raw-rhel-8.json
 new file mode 100644

--- a/projects/kubernetes-sigs/image-builder/patches/0009-Add-support-for-RHEL-8-OVA-builds.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0009-Add-support-for-RHEL-8-OVA-builds.patch
@@ -111,7 +111,6 @@ index 000000000..5bcfe5cee
 +  "shutdown_command": "shutdown -P now",
 +  "vsphere_guest_os_type": "rhel8_64Guest"
 +}
-\ No newline at end of file
 -- 
 2.34.1
 


### PR DESCRIPTION
This should potentially solve the flaky EOF errors when Packer parses the var files.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
