### PR TITLE
Adding CAPT patch for adding Ready label for TinkerbellMachine

### DIFF
--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/CHECKSUMS
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/CHECKSUMS
@@ -1,2 +1,2 @@
-050cbbe7d324f14775159f21e506c31796d63d1af0d9d3d1df462c6c0ca3c974  _output/bin/cluster-api-provider-tinkerbell/linux-amd64/manager
-ce20abb7b74ca9a7553096c1966533009a28bbc76f4fa3040c0a655e61e28027  _output/bin/cluster-api-provider-tinkerbell/linux-arm64/manager
+91720095b82a8db491939b0704afc5251e85161c6e04c3ec3f737651862b57db  _output/bin/cluster-api-provider-tinkerbell/linux-amd64/manager
+1f3c1669d1e9ad6f71cc02e974789df151e8658fcb70c45b6bb7b62eba47f262  _output/bin/cluster-api-provider-tinkerbell/linux-arm64/manager

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0003-Adding-MachineReady-label-to-TinkerbellMAchine-and-c.patch
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0003-Adding-MachineReady-label-to-TinkerbellMAchine-and-c.patch
@@ -1,0 +1,96 @@
+From 42acb9ce1582dc9628df7185c7be467a27c232f5 Mon Sep 17 00:00:00 2001
+From: Aravind Ramalingam <ramaliar@amazon.com>
+Date: Tue, 7 Jun 2022 13:34:02 -0700
+Subject: [PATCH] Adding MachineReady label to TinkerbellMAchine and checking
+ on Reconcile
+
+Signed-off-by: Aravind Ramalingam <ramaliar@amazon.com>
+---
+ controllers/machine.go                      | 34 +++++++++++++++++++++
+ controllers/tinkerbellcluster_controller.go |  3 ++
+ 2 files changed, 37 insertions(+)
+
+diff --git a/controllers/machine.go b/controllers/machine.go
+index 5eb58f8..8ad050e 100644
+--- a/controllers/machine.go
++++ b/controllers/machine.go
+@@ -114,7 +114,36 @@ func (mrc *machineReconcileContext) markAsReady() error {
+ 	return nil
+ }
+ 
++func (mrc *machineReconcileContext) setMachineReadyLabel() {
++	if len(mrc.tinkerbellMachine.ObjectMeta.Labels) == 0 {
++		mrc.tinkerbellMachine.ObjectMeta.Labels = map[string]string{}
++	}
++
++	mrc.tinkerbellMachine.ObjectMeta.Labels[MachineReadyLabel] = "True"
++}
++
++func (mrc *machineReconcileContext) isMachineReady() bool {
++	if len(mrc.tinkerbellMachine.ObjectMeta.Labels) == 0 {
++		return false
++	}
++
++	if _, ok := mrc.tinkerbellMachine.ObjectMeta.Labels[MachineReadyLabel]; ok {
++		return true
++	}
++
++	return false
++}
++
+ func (mrc *machineReconcileContext) Reconcile() error {
++	// Check if the machine was already marked Ready
++	if mrc.isMachineReady() {
++		if err := mrc.markAsReady(); err != nil {
++			return fmt.Errorf("marking machine as ready: %w", err)
++		}
++
++		return nil
++	}
++
+ 	// Fetch a provisioining BMCJob for machine.
+ 	bmcJob := &rufiov1.BMCJob{}
+ 	jobName := fmt.Sprintf("%s-provision", mrc.tinkerbellMachine.Name)
+@@ -132,6 +161,7 @@ func (mrc *machineReconcileContext) Reconcile() error {
+ 
+ 	// Check the Job conditions to ensure the Machine is Ready.
+ 	if bmcJob.HasCondition(rufiov1.JobCompleted, rufiov1.ConditionTrue) {
++		mrc.setMachineReadyLabel()
+ 		if err := mrc.markAsReady(); err != nil {
+ 			return fmt.Errorf("marking machine as ready: %w", err)
+ 		}
+@@ -544,6 +574,7 @@ func (mrc *machineReconcileContext) getBMCJob(jName string, bmj *rufiov1.BMCJob)
+ 
+ // createBMCJob creates a BMCJob object with the required tasks for hardware provisioning.
+ func (mrc *machineReconcileContext) createBMCJob(hardware *tinkv1.Hardware, name string) error {
++	powerOffAction := rufiov1.HardPowerOff
+ 	powerOnAction := rufiov1.PowerOn
+ 	controller := true
+ 	bmcJob := &rufiov1.BMCJob{
+@@ -566,6 +597,9 @@ func (mrc *machineReconcileContext) createBMCJob(hardware *tinkv1.Hardware, name
+ 				Namespace: mrc.tinkerbellMachine.Namespace,
+ 			},
+ 			Tasks: []rufiov1.Task{
++				{
++					PowerAction: &powerOffAction,
++				},
+ 				{
+ 					OneTimeBootDeviceAction: &rufiov1.OneTimeBootDeviceAction{
+ 						Devices: []rufiov1.BootDevice{
+diff --git a/controllers/tinkerbellcluster_controller.go b/controllers/tinkerbellcluster_controller.go
+index 15e7d52..d14a958 100644
+--- a/controllers/tinkerbellcluster_controller.go
++++ b/controllers/tinkerbellcluster_controller.go
+@@ -138,6 +138,9 @@ const (
+ 	// ClusterNamespaceLabel is used to mark in which Namespace hardware is used.
+ 	ClusterNamespaceLabel = "v1alpha1.tinkerbell.org/clusterNamespace"
+ 
++	// MachineReadyLabel is used to mark TinkerbellMachine as Ready
++	MachineReadyLabel = "v1alpha1.tinkerbell.org/machineReady"
++
+ 	// KubernetesAPIPort is a port used by Tinkerbell clusters for Kubernetes API.
+ 	KubernetesAPIPort = 6443
+ )
+-- 
+2.34.1
+


### PR DESCRIPTION
*Description of changes:*
Adding a label to `TinkerbellMachine` when machine has reached ready state. 
Labels get retained on `clusterctl move` and gets checked to prevent repetitive reconciliation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
