### PR TITLE
CAPT job power reset action

### DIFF
--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/CHECKSUMS
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/CHECKSUMS
@@ -1,2 +1,2 @@
-91720095b82a8db491939b0704afc5251e85161c6e04c3ec3f737651862b57db  _output/bin/cluster-api-provider-tinkerbell/linux-amd64/manager
-1f3c1669d1e9ad6f71cc02e974789df151e8658fcb70c45b6bb7b62eba47f262  _output/bin/cluster-api-provider-tinkerbell/linux-arm64/manager
+5cf54cd22d3fc91223364806380dc14064f76b519ead93f8a54fe4165f98bd15  _output/bin/cluster-api-provider-tinkerbell/linux-amd64/manager
+b973297f9a04430aaa291d9e4bd3b9579e8d20011855d50e4135b9ad1a45d86f  _output/bin/cluster-api-provider-tinkerbell/linux-arm64/manager

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0004-Replace-poweroff-poweron-with-reset.patch
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/patches/0004-Replace-poweroff-poweron-with-reset.patch
@@ -1,0 +1,46 @@
+From 4c30ba65baf17e89a7b4d6f0a5161157c30d07bf Mon Sep 17 00:00:00 2001
+From: Aravind Ramalingam <ramaliar@amazon.com>
+Date: Wed, 8 Jun 2022 10:11:11 -0700
+Subject: [PATCH] Replace poweroff poweron with reset
+
+Signed-off-by: Aravind Ramalingam <ramaliar@amazon.com>
+---
+ controllers/machine.go | 8 ++------
+ 1 file changed, 2 insertions(+), 6 deletions(-)
+
+diff --git a/controllers/machine.go b/controllers/machine.go
+index 8ad050e..c670261 100644
+--- a/controllers/machine.go
++++ b/controllers/machine.go
+@@ -574,8 +574,7 @@ func (mrc *machineReconcileContext) getBMCJob(jName string, bmj *rufiov1.BMCJob)
+ 
+ // createBMCJob creates a BMCJob object with the required tasks for hardware provisioning.
+ func (mrc *machineReconcileContext) createBMCJob(hardware *tinkv1.Hardware, name string) error {
+-	powerOffAction := rufiov1.HardPowerOff
+-	powerOnAction := rufiov1.PowerOn
++	powerResetAction := rufiov1.Reset
+ 	controller := true
+ 	bmcJob := &rufiov1.BMCJob{
+ 		ObjectMeta: metav1.ObjectMeta{
+@@ -597,9 +596,6 @@ func (mrc *machineReconcileContext) createBMCJob(hardware *tinkv1.Hardware, name
+ 				Namespace: mrc.tinkerbellMachine.Namespace,
+ 			},
+ 			Tasks: []rufiov1.Task{
+-				{
+-					PowerAction: &powerOffAction,
+-				},
+ 				{
+ 					OneTimeBootDeviceAction: &rufiov1.OneTimeBootDeviceAction{
+ 						Devices: []rufiov1.BootDevice{
+@@ -609,7 +605,7 @@ func (mrc *machineReconcileContext) createBMCJob(hardware *tinkv1.Hardware, name
+ 					},
+ 				},
+ 				{
+-					PowerAction: &powerOnAction,
++					PowerAction: &powerResetAction,
+ 				},
+ 			},
+ 		},
+-- 
+2.34.1
+


### PR DESCRIPTION
*Description of changes:*
Upon testing it was noticed that doing a powerOff and then powerOn was at times being flaky. This could be due to the response time of the BMC.
Replacing with power reset call.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
