### PR TITLE
CAPI Patch: Bottlerocket parse and set provider-id for Kubelet args

### DIFF
--- a/projects/kubernetes-sigs/cluster-api/patches/0019-Parse-provider-id-from-kubelet-extra-args.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0019-Parse-provider-id-from-kubelet-extra-args.patch
@@ -1,0 +1,48 @@
+From 20c07c1ff11eeeab83ce10311c805f51fde8bf2b Mon Sep 17 00:00:00 2001
+From: Vignesh Goutham Ganesh <vgg@amazon.com>
+Date: Wed, 8 Jun 2022 10:27:26 -0700
+Subject: [PATCH] Parse provider-id from kubelet extra args
+
+Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
+---
+ bootstrap/kubeadm/internal/bottlerocket/bootstrap.go    | 3 +++
+ bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go | 2 ++
+ 2 files changed, 5 insertions(+)
+
+diff --git a/bootstrap/kubeadm/internal/bottlerocket/bootstrap.go b/bootstrap/kubeadm/internal/bottlerocket/bootstrap.go
+index f8f1b97cb..efdb51fef 100644
+--- a/bootstrap/kubeadm/internal/bottlerocket/bootstrap.go
++++ b/bootstrap/kubeadm/internal/bottlerocket/bootstrap.go
+@@ -16,6 +16,9 @@ standalone-mode = true
+ authentication-mode = "tls"
+ server-tls-bootstrap = false
+ pod-infra-container-image = "{{.PauseContainerSource}}"
++{{- if (ne .ProviderId "")}}
++provider-id = "{{.ProviderId}}"
++{{- end -}}
+ {{- end -}}
+ `
+ 
+diff --git a/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go b/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go
+index e635308ea..3a760d51a 100644
+--- a/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go
++++ b/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go
+@@ -44,6 +44,7 @@ type BottlerocketSettingsInput struct {
+ 	RegistryMirrorCACert       string
+ 	NodeLabels                 string
+ 	Taints                     string
++	ProviderId                 string
+ }
+ 
+ type HostPath struct {
+@@ -151,6 +152,7 @@ func getBottlerocketNodeUserData(bootstrapContainerUserData []byte, users []boot
+ 		RegistryMirrorEndpoint:     config.RegistryMirrorConfiguration.Endpoint,
+ 		NodeLabels:                 parseNodeLabels(config.KubeletExtraArgs["node-labels"]), // empty string if it does not exist
+ 		Taints:                     parseTaints(config.Taints), //empty string if it does not exist
++		ProviderId:                 config.KubeletExtraArgs["provider-id"],
+ 	}
+ 	if config.BottlerocketControl.ImageRepository != "" && config.BottlerocketControl.ImageTag != "" {
+ 		bottlerocketInput.ControlContainerSource = fmt.Sprintf("%s:%s", config.BottlerocketControl.ImageRepository, config.BottlerocketControl.ImageTag)
+-- 
+2.24.3 (Apple Git-128)
+


### PR DESCRIPTION
*Description of changes:*
Metal workflows do not have cloud-provider to set the provider id on a node spec. Kubelet needs to be passed this field in order for kubelet to set this on the node spec. This is used by machine controllers on CAPI to mark a node as completely bootstrapped.

/hold

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
