### PR TITLE
Add 1.23 builds for Bottlerocket

### DIFF
--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_ADMIN_CONTAINER_METADATA
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_ADMIN_CONTAINER_METADATA
@@ -1,2 +1,2 @@
-tag: v0.8.0
-imageDigest: sha256:279ff0b939c8ebfae8fb5086751de831edee4c1ef307b6f0a27b553b1c2c9b52
+tag: v0.9.0
+imageDigest: sha256:d7a394014cd60caa821d7c748637d1bf21ed955eb06a8cef7864c9a5f2e75b02

--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_OVA_RELEASES
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_OVA_RELEASES
@@ -1,6 +1,8 @@
 1-20:
-    releaseVersion: v1.7.2
+    releaseVersion: v1.8.0
 1-21:
-    releaseVersion: v1.7.2
+    releaseVersion: v1.8.0
 1-22:
-    releaseVersion: v1.7.2
+    releaseVersion: v1.8.0
+1-23:
+    releaseVersion: v1.8.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
/hold till the bottlerocket 1.8.0 release is out.

1.8.0 was released => https://github.com/bottlerocket-os/bottlerocket/releases/tag/v1.8.0
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
