### PR TITLE
Fixes update checksum in docker target

### DIFF
--- a/build/lib/run_target_docker.sh
+++ b/build/lib/run_target_docker.sh
@@ -16,7 +16,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
-
+set -x
 PROJECT="$1"
 TARGET="$2"
 IMAGE_REPO="${3:-}"
@@ -37,14 +37,33 @@ if ! docker ps -f name=eks-a-builder | grep -w eks-a-builder; then
 		public.ecr.aws/eks-distro-build-tooling/builder-base:latest  infinity 
 fi
 
+EXTRA_INCLUDES=""
+PROJECT_DEPENDENCIES=$(make --no-print-directory -C $MAKE_ROOT/projects/$PROJECT var-value-PROJECT_DEPENDENCIES RELEASE_BRANCH=1-20)
+if [ -n "$PROJECT_DEPENDENCIES" ]; then
+	DEPS=(${PROJECT_DEPENDENCIES// / })
+	for dep in "${DEPS[@]}"; do
+		DEP_PRODUCT="$(cut -d/ -f1 <<< $dep)"
+		DEP_ORG="$(cut -d/ -f2 <<< $dep)"
+		DEP_REPO="$(cut -d/ -f3 <<< $dep)"
+
+		if [[ "$DEP_PRODUCT" == "eksd" ]]; then
+			continue
+		fi
+
+		EXTRA_INCLUDES+=" --include=projects/$DEP_ORG/$DEP_REPO/***"
+	done
+fi
+
 rsync -e 'docker exec -i' -rm --exclude='.git/***' \
 	--exclude="projects/$PROJECT/_output/***" --exclude="projects/$PROJECT/$(basename $PROJECT)/***" \
 	--include="projects/$PROJECT/***" --include="projects/kubernetes-sigs/image-builder/BOTTLEROCKET_OVA_RELEASES" \
-	--include="release/SUPPORTED_RELEASE_BRANCHES" --include="projects/kubernetes-sigs/cri-tools/GIT_TAG" \
+	--include="release/SUPPORTED_RELEASE_BRANCHES" --include="projects/kubernetes-sigs/cri-tools/GIT_TAG" $EXTRA_INCLUDES \
 	--include='*/' --exclude='projects/***' $MAKE_ROOT/ eks-a-builder:/eks-anywhere-build-tooling
 
 # Need so git properly finds the root of the repo
-docker exec -it eks-a-builder mkdir -p /eks-anywhere-build-tooling/.git/{refs,objects}
+CURRENT_HEAD="$(cat $MAKE_ROOT/.git/HEAD | awk '{print $2}')"
+docker exec -it eks-a-builder mkdir -p /eks-anywhere-build-tooling/.git/{refs,objects} /eks-anywhere-build-tooling/.git/$(dirname $CURRENT_HEAD)
 docker cp $MAKE_ROOT/.git/HEAD eks-a-builder:/eks-anywhere-build-tooling/.git
+docker cp $MAKE_ROOT/.git/$CURRENT_HEAD eks-a-builder:/eks-anywhere-build-tooling/.git/$CURRENT_HEAD
 
 docker exec -it eks-a-builder make $TARGET -C /eks-anywhere-build-tooling/projects/$PROJECT RELEASE_BRANCH=$RELEASE_BRANCH IMAGE_REPO=$IMAGE_REPO ARTIFACTS_BUCKET=$ARTIFACTS_BUCKET


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Due to the new dependencies support the run in docker targets are broken because to avoid copying the entire repo into the docker builder container, the rsync was not including the dependency project source code.  This reads the deps from the makefile and copies those projects to the builder container as well.

This also fixes the .git HEAD warning to avoid confusion.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
