### PR TITLE
Fix README version field for projects with dashes in tag

### DIFF
--- a/build/lib/readme_check.sh
+++ b/build/lib/readme_check.sh
@@ -19,9 +19,14 @@ set -o nounset
 set -o pipefail
 
 RETURN=0
+SED=sed
+if [ "$(uname -s)" = "Darwin" ]; then
+    SED=gsed
+fi
+
 for GIT_TAG_FILE in projects/*/*/GIT_TAG
 do
-    VERSION="$(cat $GIT_TAG_FILE)"
+    VERSION="$(cat $GIT_TAG_FILE | $SED "s,-,--,g")"
     README="$(dirname $GIT_TAG_FILE)/README.md"
     if [ ! -f $README ]
     then
@@ -39,7 +44,7 @@ do
         continue
     fi
     RETURN=-1
-    ACTUAL_VERSION=$(grep "img.shields.io/badge/version" ${README} | sed -e 's,.*img.shields.io/badge/version-,,' -e 's/-blue).*$//')
+    ACTUAL_VERSION=$(grep "img.shields.io/badge/version" ${README} | $SED -e 's,.*img.shields.io/badge/version-,,' -e 's/-blue).*$//')
     echo "Version mismatch $README expected $VERSION actual $ACTUAL_VERSION"
-    sed -i -e "s/$ACTUAL_VERSION/$VERSION/" $README
+    $SED -i -e "s/$ACTUAL_VERSION/$VERSION/" $README
 done

--- a/projects/cilium/cilium/README.md
+++ b/projects/cilium/cilium/README.md
@@ -1,5 +1,5 @@
 ## **Cilium**
-![Version](https://img.shields.io/badge/version-v1.10.11-eksa.2-blue)
+![Version](https://img.shields.io/badge/version-v1.10.11--eksa.2-blue)
 ![Build Status](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiYTh2UnBFVGhjQ1EyeENsWU91ZlJzMktyZHRINlpFWlc0RkZ5amU3Yy96b3p2Z2dxNThZZVQ5ZjRPTEZndGVNQVMwNkMvVmZZR000bGJXWDFqWDFnUlZVPSIsIml2UGFyYW1ldGVyU3BlYyI6ImZRZ2JzZmhRcWZtNFNHZTciLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=main)
 
 [Cilium](https://github.com/cilium/cilium) is an open-source software for providing and transparently securing network connectivity and load-balancing between application workloads such as application containers or processes. Cilium operates at Layer 3/4 to provide traditional networking and security services as well as at Layer 7 to protect and secure use of modern application protocols such as HTTP, gRPC and Kafka. Cilium is integrated into common orchestration frameworks such as Kubernetes. A new Linux kernel technology called [eBPF](https://ebpf.io) is at the foundation of Cilium. It supports dynamic insertion of eBPF bytecode into the Linux kernel at various integration points such as network I/O, application sockets and tracepoints to implement security, networking and visibility logic.

--- a/projects/kubernetes-sigs/cluster-api-provider-cloudstack/README.md
+++ b/projects/kubernetes-sigs/cluster-api-provider-cloudstack/README.md
@@ -1,5 +1,5 @@
 ## **Cluster API Provider for CloudStack**
-![Version](https://img.shields.io/badge/version-v0.4.5-rc3-blue)
+![Version](https://img.shields.io/badge/version-v0.4.5--rc3-blue)
 [![Go Report Card](https://goreportcard.com/badge/kubernetes-sigs/cluster-api-provider-cloudstack)](https://goreportcard.com/report/kubernetes-sigs/cluster-api-provider-cloudstack)
 ![Build Status](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiS0M4VGRyK0xWM2ZZY0pRbVMvY0pHRWlVSEJ3M1I4SXNRaVNxSnB5blVYTHpHSkNFWlpXcWhHSmdlSkhCVnVwSXJyVm16NFlSUzVSRC9vN2g2bmY5NjVnPSIsIml2UGFyYW1ldGVyU3BlYyI6ImQ4ZldMWnMweEIyTmxrTk8iLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=main)
 

--- a/projects/tinkerbell/rufio/README.md
+++ b/projects/tinkerbell/rufio/README.md
@@ -1,5 +1,5 @@
 ## **Rufio**
-![Version](https://img.shields.io/badge/version-599b7401b5ccda2cfacf004668006562cb3e541a-blue)
+![Version](https://img.shields.io/badge/version-a4053e5c1e7f32fb5c0a9962846c219c3ef8aaf3-blue)
 
 [Rufio](https://github.com/tinkerbell/rufio) is a Kubernetes controller for managing baseboard management state and actions.
 

--- a/projects/tinkerbell/tink/README.md
+++ b/projects/tinkerbell/tink/README.md
@@ -1,5 +1,5 @@
 ## **Tink**
-![Version](https://img.shields.io/badge/version-7a8ca47540c5800c1d0cac075cf7e2c5da69b186-blue)
+![Version](https://img.shields.io/badge/version-88798fa1c653fd71e50cba94f76d3eb6f0c7396c-blue)
 ![Build Status](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiUmxrMmd4b2N6dk02TDRPVlVXQ1N3aEhsRzAxWFBtZ1Y1VVNXWEtVZlVNS0tkQlZ4MHFuNXJiWld0ZFMvVzVmMzZxWjhKK3FERWdQeEV6RWd6WFZBcGM0PSIsIml2UGFyYW1ldGVyU3BlYyI6ImEvZEhCemJsQXJWZXVmc2kiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=main)
 
 [Tink](https://github.com/tinkerbell/tink) consists of the tink-server, tink-controller, tink-worker, and tink-cli. The tink-worker and tink-server communicate over gRPC, and are responsible for processing workflows. Tink-controller is Kubernetes controller that is responsible for reconciling Tinkerbell hardwares, templates and workflows. The CLI is the user-interactive piece for creating workflows and their building blocks, templates and hardware data.


### PR DESCRIPTION
Some projects have a dash in their Git tag, and we can't use these directly in the badge URL template. Using two dashes renders the badge properly.
`https://img.shields.io/badge/version-v0.4.5-rc3-blue`: ![Badge](https://img.shields.io/badge/version-v0.4.5-rc3-blue)
`https://img.shields.io/badge/version-v0.4.5--rc3-blue`: ![Badge](https://img.shields.io/badge/version-v0.4.5--rc3-blue)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
