### PR TITLE
Metallb helm

### DIFF
--- a/projects/metallb/metallb/Makefile
+++ b/projects/metallb/metallb/Makefile
@@ -16,6 +16,10 @@ IMAGE_NAMES=controller speaker
 DOCKERFILE_FOLDER=./docker/linux/$(IMAGE_NAME)
 
 
+HAS_HELM_CHART=true
+HELM_DIRECTORY=charts/metallb
+HELM_DESTINATION_REPOSITORY=metallb/metallb
+HELM_IMAGE_LIST=metallb/controller metallb/speaker
 
 include $(BASE_DIRECTORY)/Common.mk
 

--- a/projects/metallb/metallb/docker/linux/speaker/Dockerfile
+++ b/projects/metallb/metallb/docker/linux/speaker/Dockerfile
@@ -9,6 +9,5 @@ COPY _output/bin/metallb/$TARGETOS-$TARGETARCH/speaker /opt/metallb/speaker
 COPY _output/LICENSES /LICENSES
 COPY ATTRIBUTION.txt /ATTRIBUTION.txt
 
-USER 1000
 
 ENTRYPOINT ["/opt/metallb/speaker"]

--- a/projects/metallb/metallb/helm/patches/0001-initial-patch.yaml
+++ b/projects/metallb/metallb/helm/patches/0001-initial-patch.yaml
@@ -1,0 +1,692 @@
+From 5f9b19b3d0ec45614bb38b0fb327eab3498be8ee Mon Sep 17 00:00:00 2001
+From: Lewis Diamond <git@lewisdiamond.com>
+Date: Thu, 16 Jun 2022 11:42:22 -0400
+Subject: [PATCH] Clean up unnecessary chart features
+
+Remove PSP, FRR, non-inline config
+---
+ charts/metallb/templates/config.yaml          |  17 +-
+ charts/metallb/templates/controller.yaml      |   3 +-
+ charts/metallb/templates/psp.yaml             |  92 -------
+ charts/metallb/templates/rbac.yaml            |  24 +-
+ .../metallb/templates/service-accounts.yaml   |   2 +
+ charts/metallb/templates/speaker.yaml         | 228 +-----------------
+ charts/metallb/values.schema.json             |  47 ++--
+ charts/metallb/values.yaml                    |  23 +-
+ 8 files changed, 57 insertions(+), 379 deletions(-)
+ delete mode 100644 charts/metallb/templates/psp.yaml
+
+diff --git a/charts/metallb/templates/config.yaml b/charts/metallb/templates/config.yaml
+index 3ff3137a..7612e5dc 100644
+--- a/charts/metallb/templates/config.yaml
++++ b/charts/metallb/templates/config.yaml
+@@ -1,11 +1,22 @@
+-{{- if .Values.configInline }}
+ apiVersion: v1
+ kind: ConfigMap
+ metadata:
+   name: {{ template "metallb.configMapName" . }}
++  namespace: {{ .Release.Namespace | default "metallb-system" | quote }}
+   labels:
+     {{- include "metallb.labels" . | nindent 4 }}
+ data:
+   config: |
+-{{- toYaml .Values.configInline | nindent 4 }}
+-{{- end }}
++    {{- with .Values.peers }}
++    peers:
++      {{- toYaml . | nindent 4 }}
++    {{- end }}
++    {{- with (index .Values "bgp-communities") }}
++    bgp-communities:
++      {{- toYaml . | nindent 4 }}
++    {{- end }}
++    {{- with (index .Values "address-pools") }}
++    address-pools:
++      {{- toYaml . | nindent 4 }}
++    {{- end }}
++
+diff --git a/charts/metallb/templates/controller.yaml b/charts/metallb/templates/controller.yaml
+index 0a7f817f..37cb9750 100644
+--- a/charts/metallb/templates/controller.yaml
++++ b/charts/metallb/templates/controller.yaml
+@@ -3,6 +3,7 @@ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+   name: {{ template "metallb.fullname" . }}-controller
++  namespace: {{ .Release.Namespace | default "metallb-system" | quote }}
+   labels:
+     {{- include "metallb.labels" . | nindent 4 }}
+     app.kubernetes.io/component: controller
+@@ -39,7 +40,7 @@ spec:
+ {{- end }}
+       containers:
+       - name: controller
+-        image: {{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag | default .Chart.AppVersion }}
++        image: {{ .Values.sourceRegistry }}/{{ .Values.controller.image.repository }}@{{ .Values.controller.image.digest }}
+         {{- if .Values.controller.image.pullPolicy }}
+         imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+         {{- end }}
+diff --git a/charts/metallb/templates/psp.yaml b/charts/metallb/templates/psp.yaml
+deleted file mode 100644
+index f8fce567..00000000
+--- a/charts/metallb/templates/psp.yaml
++++ /dev/null
+@@ -1,92 +0,0 @@
+-{{- if .Values.psp.create -}}
+----
+-apiVersion: policy/v1beta1
+-kind: PodSecurityPolicy
+-metadata:
+-  name: {{ template "metallb.fullname" . }}-controller
+-  labels:
+-    {{- include "metallb.labels" . | nindent 4 }}
+-spec:
+-  privileged: false
+-  # Host namespaces
+-  hostPID: false
+-  hostIPC: false
+-  hostNetwork: false
+-  # Volumes and file systems
+-  volumes:
+-  - configMap
+-  - secret
+-  - emptyDir
+-  allowedHostPaths: []
+-  readOnlyRootFilesystem: true
+-  # Users and groups
+-  runAsUser:
+-    rule: MustRunAsNonRoot
+-  supplementalGroups:
+-    rule: MustRunAs
+-    ranges:
+-    - min: 1
+-      max: 65535
+-  fsGroup:
+-    rule: MustRunAs
+-    ranges:
+-    - min: 1
+-      max: 65535
+-  # Privilege Escalation
+-  allowPrivilegeEscalation: false
+-  defaultAllowPrivilegeEscalation: false
+-  # Capabilities
+-  allowedCapabilities: []
+-  defaultAddCapabilities: []
+-  requiredDropCapabilities:
+-  - ALL
+-  # SELinux
+-  seLinux:
+-    rule: RunAsAny
+----
+-apiVersion: policy/v1beta1
+-kind: PodSecurityPolicy
+-metadata:
+-  name: {{ template "metallb.fullname" . }}-speaker
+-  labels:
+-    {{- include "metallb.labels" . | nindent 4 }}
+-spec:
+-  privileged: true
+-  # Host namespaces
+-  hostPID: false
+-  hostIPC: false
+-  hostNetwork: true
+-  hostPorts:
+-  - min: {{ .Values.prometheus.metricsPort }}
+-    max: {{ .Values.prometheus.metricsPort }}
+-  {{- if .Values.speaker.memberlist.enabled }}
+-  - max: {{ .Values.speaker.memberlist.mlBindPort }}
+-    min: {{ .Values.speaker.memberlist.mlBindPort }}
+-  {{- end }}
+-  # Volumes and file systems
+-  volumes:
+-  - configMap
+-  - secret
+-  - emptyDir
+-  allowedHostPaths: []
+-  readOnlyRootFilesystem: true
+-  # Users and groups
+-  runAsUser:
+-    rule: RunAsAny
+-  supplementalGroups:
+-    rule: RunAsAny
+-  fsGroup:
+-    rule: RunAsAny
+-  # Privilege Escalation
+-  allowPrivilegeEscalation: false
+-  defaultAllowPrivilegeEscalation: false
+-  # Capabilities
+-  allowedCapabilities:
+-  - NET_RAW
+-  defaultAddCapabilities: []
+-  requiredDropCapabilities:
+-  - ALL
+-  # SELinux
+-  seLinux:
+-    rule: RunAsAny
+-{{- end -}}
+diff --git a/charts/metallb/templates/rbac.yaml b/charts/metallb/templates/rbac.yaml
+index 271b73b1..6ccabbd8 100644
+--- a/charts/metallb/templates/rbac.yaml
++++ b/charts/metallb/templates/rbac.yaml
+@@ -1,4 +1,3 @@
+-{{- if .Values.rbac.create -}}
+ apiVersion: rbac.authorization.k8s.io/v1
+ kind: ClusterRole
+ metadata:
+@@ -15,12 +14,6 @@ rules:
+ - apiGroups: [""]
+   resources: ["events"]
+   verbs: ["create", "patch"]
+-{{- if .Values.psp.create }}
+-- apiGroups: ["policy"]
+-  resources: ["podsecuritypolicies"]
+-  resourceNames: ["{{ template "metallb.fullname" . }}-controller"]
+-  verbs: ["use"]
+-{{- end }}
+ ---
+ apiVersion: rbac.authorization.k8s.io/v1
+ kind: ClusterRole
+@@ -38,17 +31,12 @@ rules:
+ - apiGroups: [""]
+   resources: ["events"]
+   verbs: ["create", "patch"]
+-{{- if .Values.psp.create }}
+-- apiGroups: ["policy"]
+-  resources: ["podsecuritypolicies"]
+-  resourceNames: ["{{ template "metallb.fullname" . }}-speaker"]
+-  verbs: ["use"]
+-{{- end }}
+ ---
+ apiVersion: rbac.authorization.k8s.io/v1
+ kind: Role
+ metadata:
+   name: {{ template "metallb.fullname" . }}-config-watcher
++  namespace: {{ .Release.Namespace | default "metallb-system" | quote }}
+   labels:
+     {{- include "metallb.labels" . | nindent 4 }}
+ rules:
+@@ -60,6 +48,7 @@ apiVersion: rbac.authorization.k8s.io/v1
+ kind: Role
+ metadata:
+   name: {{ include "metallb.fullname" . }}-pod-lister
++  namespace: {{ .Release.Namespace | default "metallb-system" | quote }}
+   labels: {{- include "metallb.labels" . | nindent 4 }}
+ rules:
+ - apiGroups: [""]
+@@ -71,6 +60,7 @@ apiVersion: rbac.authorization.k8s.io/v1
+ kind: Role
+ metadata:
+   name: {{ include "metallb.fullname" . }}-controller
++  namespace: {{ .Release.Namespace | default "metallb-system" | quote }}
+   labels: {{- include "metallb.labels" . | nindent 4 }}
+ rules:
+ - apiGroups: [""]
+@@ -95,7 +85,7 @@ metadata:
+ subjects:
+ - kind: ServiceAccount
+   name: {{ template "metallb.controller.serviceAccountName" . }}
+-  namespace: {{ .Release.Namespace }}
++  namespace: {{ .Release.Namespace | default "metallb-system" | quote }}
+ roleRef:
+   apiGroup: rbac.authorization.k8s.io
+   kind: ClusterRole
+@@ -110,7 +100,7 @@ metadata:
+ subjects:
+ - kind: ServiceAccount
+   name: {{ template "metallb.speaker.serviceAccountName" . }}
+-  namespace: {{ .Release.Namespace }}
++  namespace: {{ .Release.Namespace | default "metallb-system" | quote }}
+ roleRef:
+   apiGroup: rbac.authorization.k8s.io
+   kind: ClusterRole
+@@ -120,6 +110,7 @@ apiVersion: rbac.authorization.k8s.io/v1
+ kind: RoleBinding
+ metadata:
+   name: {{ template "metallb.fullname" . }}-config-watcher
++  namespace: {{ .Release.Namespace | default "metallb-system" | quote }}
+   labels:
+     {{- include "metallb.labels" . | nindent 4 }}
+ subjects:
+@@ -136,6 +127,7 @@ apiVersion: rbac.authorization.k8s.io/v1
+ kind: RoleBinding
+ metadata:
+   name: {{ include "metallb.fullname" . }}-pod-lister
++  namespace: {{ .Release.Namespace | default "metallb-system" | quote }}
+   labels: {{- include "metallb.labels" . | nindent 4 }}
+ roleRef:
+   apiGroup: rbac.authorization.k8s.io
+@@ -150,6 +142,7 @@ apiVersion: rbac.authorization.k8s.io/v1
+ kind: RoleBinding
+ metadata:
+   name: {{ include "metallb.fullname" . }}-controller
++  namespace: {{ .Release.Namespace | default "metallb-system" | quote }}
+   labels: {{- include "metallb.labels" . | nindent 4 }}
+ roleRef:
+   apiGroup: rbac.authorization.k8s.io
+@@ -159,4 +152,3 @@ subjects:
+ - kind: ServiceAccount
+   name: {{ include "metallb.controller.serviceAccountName" . }}
+ {{- end -}}
+-{{- end -}}
+diff --git a/charts/metallb/templates/service-accounts.yaml b/charts/metallb/templates/service-accounts.yaml
+index 95609e5e..5d79cf10 100644
+--- a/charts/metallb/templates/service-accounts.yaml
++++ b/charts/metallb/templates/service-accounts.yaml
+@@ -4,6 +4,7 @@ apiVersion: v1
+ kind: ServiceAccount
+ metadata:
+   name: {{ template "metallb.controller.serviceAccountName" . }}
++  namespace: {{ .Release.Namespace | default "metallb-system" | quote }}
+   labels:
+     {{- include "metallb.labels" . | nindent 4 }}
+     app.kubernetes.io/component: controller
+@@ -18,6 +19,7 @@ apiVersion: v1
+ kind: ServiceAccount
+ metadata:
+   name: {{ template "metallb.speaker.serviceAccountName" . }}
++  namespace: {{ .Release.Namespace | default "metallb-system" | quote }}
+   labels:
+     {{- include "metallb.labels" . | nindent 4 }}
+     app.kubernetes.io/component: speaker
+diff --git a/charts/metallb/templates/speaker.yaml b/charts/metallb/templates/speaker.yaml
+index ef5bea72..54a4a533 100644
+--- a/charts/metallb/templates/speaker.yaml
++++ b/charts/metallb/templates/speaker.yaml
+@@ -1,112 +1,9 @@
+-{{- if .Values.speaker.frr.enabled }}
+-# FRR expects to have these files owned by frr:frr on startup.
+-# Having them in a ConfigMap allows us to modify behaviors: for example enabling more daemons on startup.
+-apiVersion: v1
+-kind: ConfigMap
+-metadata:
+-  name: {{ template "metallb.fullname" . }}-frr-startup
+-  labels:
+-    {{- include "metallb.labels" . | nindent 4 }}
+-    app.kubernetes.io/component: speaker
+-data:
+-  daemons: |
+-    # This file tells the frr package which daemons to start.
+-    #
+-    # Sample configurations for these daemons can be found in
+-    # /usr/share/doc/frr/examples/.
+-    #
+-    # ATTENTION:
+-    #
+-    # When activating a daemon for the first time, a config file, even if it is
+-    # empty, has to be present *and* be owned by the user and group "frr", else
+-    # the daemon will not be started by /etc/init.d/frr. The permissions should
+-    # be u=rw,g=r,o=.
+-    # When using "vtysh" such a config file is also needed. It should be owned by
+-    # group "frrvty" and set to ug=rw,o= though. Check /etc/pam.d/frr, too.
+-    #
+-    # The watchfrr and zebra daemons are always started.
+-    #
+-    bgpd=yes
+-    ospfd=no
+-    ospf6d=no
+-    ripd=no
+-    ripngd=no
+-    isisd=no
+-    pimd=no
+-    ldpd=no
+-    nhrpd=no
+-    eigrpd=no
+-    babeld=no
+-    sharpd=no
+-    pbrd=no
+-    bfdd=yes
+-    fabricd=no
+-    vrrpd=no
+-
+-    #
+-    # If this option is set the /etc/init.d/frr script automatically loads
+-    # the config via "vtysh -b" when the servers are started.
+-    # Check /etc/pam.d/frr if you intend to use "vtysh"!
+-    #
+-    vtysh_enable=yes
+-    zebra_options="  -A 127.0.0.1 -s 90000000"
+-    bgpd_options="   -A 127.0.0.1 -p 0"
+-    ospfd_options="  -A 127.0.0.1"
+-    ospf6d_options=" -A ::1"
+-    ripd_options="   -A 127.0.0.1"
+-    ripngd_options=" -A ::1"
+-    isisd_options="  -A 127.0.0.1"
+-    pimd_options="   -A 127.0.0.1"
+-    ldpd_options="   -A 127.0.0.1"
+-    nhrpd_options="  -A 127.0.0.1"
+-    eigrpd_options=" -A 127.0.0.1"
+-    babeld_options=" -A 127.0.0.1"
+-    sharpd_options=" -A 127.0.0.1"
+-    pbrd_options="   -A 127.0.0.1"
+-    staticd_options="-A 127.0.0.1"
+-    bfdd_options="   -A 127.0.0.1"
+-    fabricd_options="-A 127.0.0.1"
+-    vrrpd_options="  -A 127.0.0.1"
+-
+-    # configuration profile
+-    #
+-    #frr_profile="traditional"
+-    #frr_profile="datacenter"
+-
+-    #
+-    # This is the maximum number of FD's that will be available.
+-    # Upon startup this is read by the control files and ulimit
+-    # is called. Uncomment and use a reasonable value for your
+-    # setup if you are expecting a large number of peers in
+-    # say BGP.
+-    #MAX_FDS=1024
+-
+-    # The list of daemons to watch is automatically generated by the init script.
+-    #watchfrr_options=""
+-
+-    # for debugging purposes, you can specify a "wrap" command to start instead
+-    # of starting the daemon directly, e.g. to use valgrind on ospfd:
+-    #   ospfd_wrap="/usr/bin/valgrind"
+-    # or you can use "all_wrap" for all daemons, e.g. to use perf record:
+-    #   all_wrap="/usr/bin/perf record --call-graph -"
+-    # the normal daemon command is added to this at the end.
+-  vtysh.conf: |+
+-    service integrated-vtysh-config
+-  frr.conf: |+
+-    ! This file gets overriden the first time the speaker renders a config.
+-    ! So anything configured here is only temporary.
+-    frr version 7.5.1
+-    frr defaults traditional
+-    hostname Router
+-    line vty
+-    log file /etc/frr/frr.log informational
+-{{- end }}
+----
+ {{- if .Values.speaker.enabled }}
+ apiVersion: apps/v1
+ kind: DaemonSet
+ metadata:
+   name: {{ template "metallb.fullname" . }}-speaker
++  namespace: {{ .Release.Namespace | default "metallb-system" | quote }}
+   labels:
+     {{- include "metallb.labels" . | nindent 4 }}
+     app.kubernetes.io/component: speaker
+@@ -143,51 +40,9 @@ spec:
+       serviceAccountName: {{ template "metallb.speaker.serviceAccountName" . }}
+       terminationGracePeriodSeconds: 0
+       hostNetwork: true
+-      {{- if .Values.speaker.frr.enabled }}
+-      volumes:
+-        - name: frr-sockets
+-          emptyDir: {}
+-        - name: frr-startup
+-          configMap:
+-            name: {{ template "metallb.fullname" . }}-frr-startup
+-        - name: frr-conf
+-          emptyDir: {}
+-        - name: reloader
+-          emptyDir: {}
+-        - name: metrics
+-          emptyDir: {}
+-      initContainers:
+-        # Copies the initial config files with the right permissions to the shared volume.
+-        - name: cp-frr-files
+-          image: {{ .Values.speaker.frr.image.repository }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
+-          securityContext:
+-            runAsUser: 100
+-            runAsGroup: 101
+-          command: ["/bin/sh", "-c", "cp -rLf /tmp/frr/* /etc/frr/"]
+-          volumeMounts:
+-            - name: frr-startup
+-              mountPath: /tmp/frr
+-            - name: frr-conf
+-              mountPath: /etc/frr
+-        # Copies the reloader to the shared volume between the speaker and reloader.
+-        - name: cp-reloader
+-          image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag | default .Chart.AppVersion }}
+-          command: ["/bin/sh", "-c", "cp -f /frr-reloader.sh /etc/frr_reloader/"]
+-          volumeMounts:
+-            - name: reloader
+-              mountPath: /etc/frr_reloader
+-        # Copies the metrics exporter
+-        - name: cp-metrics
+-          image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag | default .Chart.AppVersion }}
+-          command: ["/bin/sh", "-c", "cp -f /frr-metrics /etc/frr_metrics/"]
+-          volumeMounts:
+-            - name: metrics
+-              mountPath: /etc/frr_metrics
+-      shareProcessNamespace: true
+-      {{- end }}
+       containers:
+       - name: speaker
+-        image: {{ .Values.speaker.image.repository }}:{{ .Values.speaker.image.tag | default .Chart.AppVersion }}
++        image: {{ .Values.sourceRegistry }}/{{ .Values.speaker.image.repository }}@{{ .Values.speaker.image.digest }}
+         {{- if .Values.speaker.image.pullPolicy }}
+         imagePullPolicy: {{ .Values.speaker.image.pullPolicy }}
+         {{- end }}
+@@ -221,16 +76,6 @@ spec:
+               name: {{ include "metallb.secretName" . }}
+               key: secretkey
+         {{- end }}
+-        {{- if .Values.speaker.frr.enabled }}
+-        - name: FRR_CONFIG_FILE
+-          value: /etc/frr_reloader/frr.conf
+-        - name: FRR_RELOADER_PID_FILE
+-          value: /etc/frr_reloader/reloader.pid
+-        - name: METALLB_BGP_TYPE
+-          value: frr
+-        - name: FRR_LOGGING_LEVEL
+-          value: {{ .Values.speaker.frr.logLevel }}
+-        {{- end }}
+         ports:
+         - name: monitoring
+           containerPort: {{ .Values.prometheus.metricsPort }}
+@@ -276,75 +121,6 @@ spec:
+             - ALL
+             add:
+             - NET_RAW
+-        {{- if .Values.speaker.frr.enabled }}
+-        volumeMounts:
+-          - name: reloader
+-            mountPath: /etc/frr_reloader
+-         {{- end }}
+-      {{- if .Values.speaker.frr.enabled }}
+-      - name: frr
+-        securityContext:
+-          capabilities:
+-            add:
+-            - NET_ADMIN
+-            - NET_RAW
+-            - SYS_ADMIN
+-            - NET_BIND_SERVICE
+-        image: {{ .Values.speaker.frr.image.repository }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
+-        {{- if .Values.speaker.frr.image.pullPolicy }}
+-        imagePullPolicy: {{ .Values.speaker.frr.image.pullPolicy }}
+-        {{- end }}
+-        env:
+-          - name: TINI_SUBREAPER
+-            value: "true"
+-        volumeMounts:
+-          - name: frr-sockets
+-            mountPath: /var/run/frr
+-          - name: frr-conf
+-            mountPath: /etc/frr
+-        # The command is FRR's default entrypoint & waiting for the log file to appear and tailing it.
+-        # If the log file isn't created in 60 seconds the tail fails and the container is restarted.
+-        # This workaround is needed to have the frr logs as part of kubectl logs -c frr < speaker_pod_name >.
+-        command:
+-          - /bin/sh
+-          - -c
+-          - |
+-            /sbin/tini -- /usr/lib/frr/docker-start &
+-            attempts=0
+-            until [[ -f /etc/frr/frr.log || $attempts -eq 60 ]]; do
+-              sleep 1
+-              attempts=$(( $attempts + 1 ))
+-            done
+-            tail -f /etc/frr/frr.log
+-      - name: reloader
+-        image: {{ .Values.speaker.frr.image.repository }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
+-        {{- if .Values.speaker.frr.image.pullPolicy }}
+-        imagePullPolicy: {{ .Values.speaker.frr.image.pullPolicy }}
+-        {{- end }}
+-        command: ["/etc/frr_reloader/frr-reloader.sh"]
+-        volumeMounts:
+-          - name: frr-sockets
+-            mountPath: /var/run/frr
+-          - name: frr-conf
+-            mountPath: /etc/frr
+-          - name: reloader
+-            mountPath: /etc/frr_reloader
+-      - name: frr-metrics
+-        image: {{ .Values.speaker.frr.image.repository }}:{{ .Values.speaker.frr.image.tag | default .Chart.AppVersion }}
+-        command: ["/etc/frr_metrics/frr-metrics"]
+-        args:
+-          - --metrics-port=7473
+-        ports:
+-          - containerPort: 7473
+-            name: monitoring
+-        volumeMounts:
+-          - name: frr-sockets
+-            mountPath: /var/run/frr
+-          - name: frr-conf
+-            mountPath: /etc/frr
+-          - name: metrics
+-            mountPath: /etc/frr_metrics
+-      {{- end }}
+       nodeSelector:
+         "kubernetes.io/os": linux
+         {{- with .Values.speaker.nodeSelector }}
+diff --git a/charts/metallb/values.schema.json b/charts/metallb/values.schema.json
+index 6f959e49..bc71e91f 100644
+--- a/charts/metallb/values.schema.json
++++ b/charts/metallb/values.schema.json
+@@ -62,11 +62,8 @@
+             "repository": {
+               "type": "string"
+             },
+-            "tag": {
+-              "anyOf": [
+-                { "type": "string" },
+-                { "type": "null" }
+-              ]
++            "digest": {
++              "type": "string"
+             },
+             "pullPolicy": {
+               "anyOf": [
+@@ -271,13 +268,13 @@
+       },
+       "required": [ "podMonitor", "prometheusRule" ]
+     },
+-    "controller": { 
++    "controller": {
+       "allOf": [
+         { "$ref": "#/definitions/component" },
+         { "description": "MetalLB Controller" }
+       ]
+     },
+-    "speaker": { 
++    "speaker": {
+       "allOf": [
+         { "$ref": "#/definitions/component" },
+         { "description": "MetalLB Controller",
+@@ -302,26 +299,32 @@
+             },
+             "secretName": {
+               "type": "string"
+-            },
+-            "frr": {
+-              "description": "Install FRR container in speaker deployment",
+-              "type": "object",
+-              "properties": {
+-                "enabled": {
+-                  "type": "boolean"
+-                },
+-                "logLevel": {
+-                  "type": "string",
+-                  "enum": [ "informational", "warning", "errors", "debugging" ]
+-                },
+-                "image": { "$ref": "#/definitions/component/properties/image" }
+-              },
+-              "required": [ "enabled" ]
+             }
+           },
+           "required": [ "tolerateMaster" ]
+         }
+       ]
++    },
++    "peers": {
++      "description": "BGP Peers",
++      "type": "array",
++      "items": {
++        "type": "object"
++      }
++    },
++    "bgp-communities": {
++      "description": "BGP communities",
++      "type": "array",
++      "items": {
++        "type": "object"
++      }
++    },
++    "address-pools": {
++      "description": "Address pools",
++      "type": "array",
++      "items": {
++        "type": "object"
++      }
+     }
+   },
+   "required": [
+diff --git a/charts/metallb/values.yaml b/charts/metallb/values.yaml
+index d0913ea3..497a39cd 100644
+--- a/charts/metallb/values.yaml
++++ b/charts/metallb/values.yaml
+@@ -27,10 +27,6 @@ rbac:
+   # create specifies whether to install and use RBAC rules.
+   create: true
+ 
+-psp:
+-  # create specifies whether to install and use Pod Security Policies.
+-  create: true
+-
+ prometheus:
+   # scrape annotations specifies whether to add Prometheus metric
+   # auto-collection annotations to pods. See
+@@ -138,8 +134,8 @@ controller:
+   # -- Controller log level. Must be one of: `all`, `debug`, `info`, `warn`, `error` or `none`
+   logLevel: info
+   image:
+-    repository: quay.io/metallb/controller
+-    tag:
++    repository: metallb/controller
++    digest: {{metallb/controller}}
+     pullPolicy:
+   serviceAccount:
+     # Specifies whether a ServiceAccount should be created
+@@ -188,7 +184,8 @@ speaker:
+     enabled: true
+     mlBindPort: 7946
+   image:
+-    repository: quay.io/metallb/speaker
++    repository: metallb/speaker
++    digest: {{metallb/speaker}}
+     tag:
+     pullPolicy:
+   serviceAccount:
+@@ -227,15 +224,3 @@ speaker:
+     periodSeconds: 10
+     successThreshold: 1
+     timeoutSeconds: 1
+-  # frr contains configuration specific to the MetalLB FRR container,
+-  # for speaker running alongside FRR.
+-  frr:
+-    enabled: false
+-    # FRR_LOGGING_LEVEL used to set logging level for all running frr processes.
+-    # Possible settings are :-
+-    #  informational, warning, errors and debugging.
+-    logLevel: informational
+-    image:
+-      repository: quay.io/frrouting/frr
+-      tag: stable_7.5
+-      pullPolicy:
+-- 
+2.25.1
+

--- a/projects/metallb/metallb/helm/sedfile.template
+++ b/projects/metallb/metallb/helm/sedfile.template
@@ -1,0 +1,2 @@
+s/appVersion: v\(.*\)$/appVersion: "\1"/
+s/version: .*$/version: ${IMAGE_TAG}/


### PR DESCRIPTION
*Description of changes:*

Add metallb helm chart.
This chart removes FRR support and does not allow creating deprecated PodSecurityPolicy resources.
Only in-line configuration is allowed and should be configured in the package definition.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
