### PR TITLE
Fix S3 tarball URI construction when falling back to main

### DIFF
--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -284,7 +284,7 @@ function build::common::get_latest_eksa_asset_url() {
   if [[ "$http_code" == "200" ]]; then 
     echo "$url"
   else
-    echo "https://$(basename $artifact_bucket).s3-us-west-2.amazonaws.com/projects/$project/latest/$(basename $project)-linux-$arch-${git_tag}.tar.gz"
+    echo "https://$(basename $artifact_bucket).s3-us-west-2.amazonaws.com/projects/$project/latest/$tar_file_prefix-linux-$arch-${git_tag}.tar.gz"
   fi
 }
 


### PR DESCRIPTION
In some cases, the tar file prefix may be overriden to be other than the name of the project.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
