### PR TITLE
Fixing CAPC affinity group deletion bug

### DIFF
--- a/UPSTREAM_PROJECTS.yaml
+++ b/UPSTREAM_PROJECTS.yaml
@@ -121,7 +121,7 @@ projects:
           - tag: v0.6.4
       - name: cluster-api-provider-cloudstack
         versions:
-          - tag: v0.4.5-rc4
+          - commit: c0d5e8d3735f2dace5997ed9515e437a5ec30a6a
       - name: cluster-api-provider-vsphere
         versions:
           - tag: v1.1.1

--- a/projects/kubernetes-sigs/cluster-api-provider-cloudstack/CHECKSUMS
+++ b/projects/kubernetes-sigs/cluster-api-provider-cloudstack/CHECKSUMS
@@ -1,2 +1,2 @@
-f4720ea5154c6c2bd0c65fb3421e0c5aa0b15c6bdaf0a355465e628b8c2bcabc  _output/bin/cluster-api-provider-cloudstack/linux-amd64/manager
-375612badeef1c89f8b963b5e36a2f2265360559e4843153f769c78c3d638c5e  _output/bin/cluster-api-provider-cloudstack/linux-arm64/manager
+653b9b5a207d05a90f013653d9116ce4e5618ab436ba733a518543584456fc6b  _output/bin/cluster-api-provider-cloudstack/linux-amd64/manager
+5c077473ca543f0a1a623af639327572d7f9e13f19de4771446d84a8c4834b68  _output/bin/cluster-api-provider-cloudstack/linux-arm64/manager

--- a/projects/kubernetes-sigs/cluster-api-provider-cloudstack/GIT_TAG
+++ b/projects/kubernetes-sigs/cluster-api-provider-cloudstack/GIT_TAG
@@ -1,1 +1,1 @@
-v0.4.5-rc4
+c0d5e8d3735f2dace5997ed9515e437a5ec30a6a

--- a/projects/kubernetes-sigs/cluster-api-provider-cloudstack/README.md
+++ b/projects/kubernetes-sigs/cluster-api-provider-cloudstack/README.md
@@ -1,5 +1,5 @@
 ## **Cluster API Provider for CloudStack**
-![Version](https://img.shields.io/badge/version-v0.4.5--rc4-blue)
+![Version](https://img.shields.io/badge/version-c0d5e8d3735f2dace5997ed9515e437a5ec30a6a-blue)
 [![Go Report Card](https://goreportcard.com/badge/kubernetes-sigs/cluster-api-provider-cloudstack)](https://goreportcard.com/report/kubernetes-sigs/cluster-api-provider-cloudstack)
 ![Build Status](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiS0M4VGRyK0xWM2ZZY0pRbVMvY0pHRWlVSEJ3M1I4SXNRaVNxSnB5blVYTHpHSkNFWlpXcWhHSmdlSkhCVnVwSXJyVm16NFlSUzVSRC9vN2g2bmY5NjVnPSIsIml2UGFyYW1ldGVyU3BlYyI6ImQ4ZldMWnMweEIyTmxrTk8iLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=main)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

*Testing performed:*

E2e test with bundle overrides

```
--- PASS: TestCloudStackKubernetes121SimpleFlow (1766.35s)
PASS
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
