### PR TITLE
Replacing CAPC commit hash with tag

### DIFF
--- a/UPSTREAM_PROJECTS.yaml
+++ b/UPSTREAM_PROJECTS.yaml
@@ -121,7 +121,7 @@ projects:
           - tag: v0.6.4
       - name: cluster-api-provider-cloudstack
         versions:
-          - commit: c0d5e8d3735f2dace5997ed9515e437a5ec30a6a
+          - tag: v0.4.5-rc5
       - name: cluster-api-provider-vsphere
         versions:
           - tag: v1.1.1

--- a/projects/kubernetes-sigs/cluster-api-provider-cloudstack/GIT_TAG
+++ b/projects/kubernetes-sigs/cluster-api-provider-cloudstack/GIT_TAG
@@ -1,1 +1,1 @@
-c0d5e8d3735f2dace5997ed9515e437a5ec30a6a
+v0.4.5-rc5

--- a/projects/kubernetes-sigs/cluster-api-provider-cloudstack/README.md
+++ b/projects/kubernetes-sigs/cluster-api-provider-cloudstack/README.md
@@ -1,5 +1,5 @@
 ## **Cluster API Provider for CloudStack**
-![Version](https://img.shields.io/badge/version-c0d5e8d3735f2dace5997ed9515e437a5ec30a6a-blue)
+![Version](https://img.shields.io/badge/version-v0.4.5-rc5-blue)
 [![Go Report Card](https://goreportcard.com/badge/kubernetes-sigs/cluster-api-provider-cloudstack)](https://goreportcard.com/report/kubernetes-sigs/cluster-api-provider-cloudstack)
 ![Build Status](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiS0M4VGRyK0xWM2ZZY0pRbVMvY0pHRWlVSEJ3M1I4SXNRaVNxSnB5blVYTHpHSkNFWlpXcWhHSmdlSkhCVnVwSXJyVm16NFlSUzVSRC9vN2g2bmY5NjVnPSIsIml2UGFyYW1ldGVyU3BlYyI6ImQ4ZldMWnMweEIyTmxrTk8iLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=main)
 
@@ -10,7 +10,7 @@ The [Cluster API Provider for CloudStack (CAPC)](https://github.com/kubernetes-s
 1. Review releases and changelogs in upstream [repo](https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack) and decide on the new version.
    Please review carefully and if there are questions about changes necessary to eks-anywhere to support the new version
    and/or automatically update between eks-anywhere version reach out to @jaxesn, @vignesh-goutham, or @g-gaston
-1. Update the `GIT_TAG` file to have the new desired version based on the upstream release tags.
+1. Update the `GIT_TAG` file to have the new desired version based on the upstream release tags. **Make sure the value in GIT_TAG follows [Semantic Versioning](http://semver.org/) (e.g. v0.4.5-rc4) in order for clusterctl to work properly**
 1. Compare the old tag to the new, looking specifically for Makefile changes. Check if the [manifests](https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack/blob/v0.3.0/Makefile#L51)
    target has changed in the Makefile, and make the required changes in create_manifests.sh
 1. Check the go.mod file to see if the golang version has changed when updating a version. Update the field `GOLANG_VERSION` in


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
EKS-A e2e tests failed when using the commit hash with clusterctl init with error message

```
    cluster.go:677: Command eksctl anywhere [create cluster -f release-i-06a23-1ff28bb/cluster.yaml -v 4 --bundles-override bin/local-bundle-release.yaml] failed with error: exit status 255: Error: failed to get provider components for the 
"cloudstack:c0d5e8d3735f2dace5997ed9515e437a5ec30a6a+e3b0c44" provider: failed to get repository client for the InfrastructureProvider with name cloudstack: error creating the local filesystem repository client: invalid version: 
"c0d5e8d3735f2dace5997ed9515e437a5ec30a6a+e3b0c44". Version must obey the syntax and semantics of the "Semantic Versioning" specification (http://semver.org/) and path format {basepath}/{provider-name}/{version}/{components.yaml}
```

So we need to use a tag instead. I've added a note in the readme to hopefully prevent this issue from happening again in the future


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
