### PR TITLE
Remove Tuftool install prerequisite for Bottlerocket downloads

### DIFF
--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -10,10 +10,6 @@ RAW_IMAGE_BUILD_INSTANCE_TYPE?=t1.micro
 RAW_IMAGE_BUILD_KEY_NAME?=raw-image-build
 
 FULL_OUTPUT_DIR=
-
-# Force non release-branched
-CARGO_HOME=$(MAKE_ROOT)/_output/cargo
-RUSTUP_HOME=$(MAKE_ROOT)/_output/rustup
 export BOTTLEROCKET_DOWNLOAD_PATH?=$(FULL_OUTPUT_DIR)/bottlerocket/downloads
 
 RHSM_USERNAME?=
@@ -57,7 +53,6 @@ SIMPLE_CREATE_TARBALLS=false
 
 # to support a no op attribution target
 TARGETS_ALLOWED_WITH_NO_RELEASE_BRANCH=build release clean help binaries checksums attribution release-ami-ubuntu-2004
-TUFTOOL_TARGET=$(CARGO_HOME)/bin/tuftool
 BOTTLEROCKET_SETUP_TARGET=$(BOTTLEROCKET_DOWNLOAD_PATH)/bottlerocket-root-json-checksum
 
 FINAL_OVA_PATH=$(ARTIFACTS_PATH)/ova/$(IMAGE_OS)/$(IMAGE_OS).ova
@@ -118,7 +113,7 @@ PROJECT_DEPENDENCIES=eksa/kubernetes-sigs/etcdadm eksa/kubernetes-sigs/cri-tools
 include $(BASE_DIRECTORY)/Common.mk
 
 
-export PATH:=$(CARGO_HOME)/bin:$(MAKE_ROOT)/$(IMAGE_BUILDER_DIR)/.local/bin:$(PATH)
+export PATH:=$(MAKE_ROOT)/$(IMAGE_BUILDER_DIR)/.local/bin:$(PATH)
 export GOVC_INSECURE?=true
 
 # Since we do not build the ova in presubmit but want to validate upload-artifacts behavior
@@ -159,16 +154,6 @@ setup-ami-share:
 .PHONY: setup-vsphere
 setup-vsphere:
 	echo $(VSPHERE_CONNECTION_DATA) > $(PACKER_OVA_CONF_FILE)
-
-$(TUFTOOL_TARGET):
-	# This code installs the Rust toolchain manager called rustup along
-	# with other Rust binaries such as rustc, rustfmt. It also installs Cargo,
-	# the Rust package manager which is then used to install Tuftool.
-	@mkdir -p $(CARGO_HOME)
-	@mkdir -p $(RUSTUP_HOME)
-	curl https://sh.rustup.rs -sSf | CARGO_HOME=$(CARGO_HOME) RUSTUP_HOME=$(RUSTUP_HOME) sh -s -- -y
-	$(CARGO_HOME)/bin/rustup default stable
-	CARGO_NET_GIT_FETCH_WITH_CLI=true $(CARGO_HOME)/bin/cargo install --force --root $(CARGO_HOME) tuftool
 
 $(BOTTLEROCKET_SETUP_TARGET): FULL_OUTPUT_DIR=$(MAKE_ROOT)/$(OUTPUT_DIR)/bottlerocket
 $(BOTTLEROCKET_SETUP_TARGET): export BOTTLEROCKET_ROOT_JSON_PATH=$(BOTTLEROCKET_DOWNLOAD_PATH)/root.json
@@ -222,8 +207,8 @@ release-ova-%: deps-ova setup-vsphere setup-packer-configs-ova
 
 .PHONY: download-bottlerocket-%
 download-bottlerocket-%: FULL_OUTPUT_DIR=$(MAKE_ROOT)/$(OUTPUT_DIR)/bottlerocket
-download-bottlerocket-%: $(TUFTOOL_TARGET) $(BOTTLEROCKET_SETUP_TARGET)
-	build/get_bottlerocket_artifacts.sh $(RELEASE_BRANCH) $* $(BOTTLEROCKET_DOWNLOAD_PATH) $(CARGO_HOME) $(PROJECT_PATH)/$(RELEASE_BRANCH) $(LATEST_TAG)
+download-bottlerocket-%: $(BOTTLEROCKET_SETUP_TARGET)
+	build/get_bottlerocket_artifacts.sh $(RELEASE_BRANCH) $* $(BOTTLEROCKET_DOWNLOAD_PATH) $(PROJECT_PATH)/$(RELEASE_BRANCH) $(LATEST_TAG)
 
 .PHONY: upload-bottlerocket-%
 upload-bottlerocket-%: IMAGE_OS=bottlerocket

--- a/projects/kubernetes-sigs/image-builder/build/get_bottlerocket_artifacts.sh
+++ b/projects/kubernetes-sigs/image-builder/build/get_bottlerocket_artifacts.sh
@@ -22,9 +22,8 @@ set -o pipefail
 RELEASE_CHANNEL="${1?Specify first argument - EKS-D release channel}"
 FORMAT="${2?Specify second argument - Image format}"
 BOTTLEROCKET_DOWNLOAD_PATH="${3?Specify third argument - Download path for Bottlerocket-related files}"
-CARGO_HOME="${4?Specify fourth argument - Root directory for Cargo installation}"
-PROJECT_PATH="${5?Specify fifth argument - Project path}"
-LATEST_TAG="${6?Specify sixth argument - S3 destination folder for latest artifact upload}"
+PROJECT_PATH="${4?Specify fourth argument - Project path}"
+LATEST_TAG="${5?Specify fifth argument - S3 destination folder for latest artifact upload}"
 
 MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 CODEBUILD_CI="${CODEBUILD_CI:-false}"
@@ -54,7 +53,7 @@ if [[ $VARIANT == "metal" ]]; then
 fi
 rm -rf $OS_DOWNLOAD_PATH
 # Downloading the TARGET from the Bottlerocket target location using Tuftool
-$CARGO_HOME/bin/tuftool download "${OS_DOWNLOAD_PATH}" \
+tuftool download "${OS_DOWNLOAD_PATH}" \
     --target-name "${TARGET}" \
     --root "${BOTTLEROCKET_DOWNLOAD_PATH}/root.json" \
     --metadata-url "${BOTTLEROCKET_METADATA_URL}" \


### PR DESCRIPTION
Tuftool is now in builder-base so we don't need to install it prior to Bottlerocket downloads in CI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
