### PR TITLE
Hardcode HOME env var to root directory

### DIFF
--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -113,7 +113,7 @@ PROJECT_DEPENDENCIES=eksa/kubernetes-sigs/etcdadm eksa/kubernetes-sigs/cri-tools
 include $(BASE_DIRECTORY)/Common.mk
 
 
-export PATH:=$(HOME)/.cargo/bin:$(MAKE_ROOT)/$(IMAGE_BUILDER_DIR)/.local/bin:$(PATH)
+export PATH:=/root/.cargo/bin:$(MAKE_ROOT)/$(IMAGE_BUILDER_DIR)/.local/bin:$(PATH)
 export GOVC_INSECURE?=true
 
 # Since we do not build the ova in presubmit but want to validate upload-artifacts behavior

--- a/projects/kubernetes-sigs/image-builder/build/get_bottlerocket_artifacts.sh
+++ b/projects/kubernetes-sigs/image-builder/build/get_bottlerocket_artifacts.sh
@@ -53,7 +53,7 @@ if [[ $VARIANT == "metal" ]]; then
 fi
 rm -rf $OS_DOWNLOAD_PATH
 # Downloading the TARGET from the Bottlerocket target location using Tuftool
-$HOME/.cargo/bin/tuftool download "${OS_DOWNLOAD_PATH}" \
+tuftool download "${OS_DOWNLOAD_PATH}" \
     --target-name "${TARGET}" \
     --root "${BOTTLEROCKET_DOWNLOAD_PATH}/root.json" \
     --metadata-url "${BOTTLEROCKET_METADATA_URL}" \


### PR DESCRIPTION
We override HOME to `/home/imagebuilder` in the buildspec.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
