### PR TITLE
Added script to mount an additional volume for container data

### DIFF
--- a/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/bootstrap-volume.sh
+++ b/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/bootstrap-volume.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+source /etc/eks/logging.sh
+
+set -uxo pipefail
+
+SCRIPT_LOG=/var/log/eks-bootstrap.log
+touch $SCRIPT_LOG
+
+# save stdout and stderr to file descriptors 3 and 4,
+# then redirect them to "$SCRIPT_LOG"
+# restore stdout and stderr at bottom of script
+exec 3>&1 4>&2 >>$SCRIPT_LOG 2>&1
+
+DEVICE=vda
+
+# stop containerd and kubelet
+systemctl stop containerd
+systemctl stop kubelet
+
+# backup containerd data
+mv /var/lib/containerd /var/lib/containerd_backup
+
+# recreate dir
+mkdir /var/lib/containerd
+
+# format disk
+mkfs -t ext4 /dev/$DEVICE
+
+# mount new device
+echo "/dev/$DEVICE /var/lib/containerd/     ext4    defaults        0 0" >>/etc/fstab
+mount -a
+
+# move containerd data back
+mv /var/lib/containerd_backup/* /var/lib/containerd/
+rm -rf /var/lib/containerd_backup
+
+# restart containerd and kubelet
+systemctl restart containerd
+systemctl restart kubelet
+
+log::info "successfully mounted new device /dev/$DEVICE"

--- a/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/bootstrap.sh
+++ b/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 source /etc/eks/logging.sh
 
-set -euxo pipefail
+set -uxo pipefail
 
 SCRIPT_LOG=/var/log/eks-bootstrap.log
 touch $SCRIPT_LOG

--- a/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/logging.sh
+++ b/projects/kubernetes-sigs/image-builder/packer/ami/additional_files/logging.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euxo pipefail
+set -uxo pipefail
 
 log::error() {
   local message="${1}"

--- a/projects/kubernetes-sigs/image-builder/packer/ami/ansible_extra_vars.yaml
+++ b/projects/kubernetes-sigs/image-builder/packer/ami/ansible_extra_vars.yaml
@@ -21,3 +21,8 @@ additional_files_list:
   owner: root
   group: root
   mode: 744
+- src: "{{ builder_root }}/packer/ami/additional_files/bootstrap-volume.sh"
+  dest: /etc/eks/
+  owner: root
+  group: root
+  mode: 744


### PR DESCRIPTION
*Issue #, if available:*
25G default root volume size for eks-d AMI may not be enough to support larger containers.

*Description of changes:*
Added a script to bootstrap additional volume, on detecting a new volume, the script will stop containerd, backup the data, mount the new volume to containerd data directory, move the backup data back and then restart containerd

*Testing:*
Manually built an ami with the script, and successfully provisioned a snow cluster with addition volume.

* provisioned a workload cluster with ContainersVolume set to 100G for worker nodes

```
[ec2-user@ip-34-223-14-194 ~]$ kubectl get machines -owide -A
NAMESPACE   NAME                                    CLUSTER            NODENAME                PROVIDERID                                        PHASE     AGE     VERSION
default     capas-quickstart-control-plane-ldrkr    capas-quickstart   s-i-8a789b5efc898b62e   aws-snow:///10.111.60.212/s.i-8a789b5efc898b62e   Running   3m44s   v1.21.9-eks-1-21-11
default     capas-quickstart-control-plane-qcsqw    capas-quickstart   s-i-805230097c877bda6   aws-snow:///10.111.60.195/s.i-805230097c877bda6   Running   12m     v1.21.9-eks-1-21-11
default     capas-quickstart-control-plane-xbv2z    capas-quickstart   s-i-88092f03325df1051   aws-snow:///10.111.60.212/s.i-88092f03325df1051   Running   16m     v1.21.9-eks-1-21-11
default     capas-quickstart-md-0-68b576695-mxnc5   capas-quickstart   s-i-81569419424ef091d   aws-snow:///10.111.60.212/s.i-81569419424ef091d   Running   16m     v1.21.9-eks-1-21-11
default     capas-quickstart-md-0-68b576695-v8wmt   capas-quickstart   s-i-80d0bce0060e5c27f   aws-snow:///10.111.60.212/s.i-80d0bce0060e5c27f   Running   16m     v1.21.9-eks-1-21-11
default     capas-quickstart-md-0-68b576695-wpcdh   capas-quickstart   s-i-852af1df3bf608ba0   aws-snow:///10.111.60.195/s.i-852af1df3bf608ba0   Running   16m     v1.21.9-eks-1-21-11
[ec2-user@ip-34-223-14-194 ~]$
[ec2-user@ip-34-223-14-194 ~]$ kubectl --kubeconfig=/tmp/config get nodes -o wide
NAME                    STATUS   ROLES                  AGE     VERSION                INTERNAL-IP     EXTERNAL-IP   OS-IMAGE             KERNEL-VERSION    CONTAINER-RUNTIME
s-i-805230097c877bda6   Ready    control-plane,master   9m30s   v1.21.12-eks-6d55a22   10.111.60.147   <none>        Ubuntu 20.04.4 LTS   5.13.0-1025-aws   containerd://1.5.9
s-i-80d0bce0060e5c27f   Ready    <none>                 11m     v1.21.12-eks-6d55a22   10.111.60.129   <none>        Ubuntu 20.04.4 LTS   5.13.0-1025-aws   containerd://1.5.9
s-i-81569419424ef091d   Ready    <none>                 14m     v1.21.12-eks-6d55a22   10.111.62.120   <none>        Ubuntu 20.04.4 LTS   5.13.0-1025-aws   containerd://1.5.9
s-i-852af1df3bf608ba0   Ready    <none>                 12m     v1.21.12-eks-6d55a22   10.111.60.111   <none>        Ubuntu 20.04.4 LTS   5.13.0-1025-aws   containerd://1.5.9
s-i-88092f03325df1051   Ready    control-plane,master   18m     v1.21.12-eks-6d55a22   10.111.62.121   <none>        Ubuntu 20.04.4 LTS   5.13.0-1025-aws   containerd://1.5.9
s-i-8a789b5efc898b62e   Ready    control-plane,master   5m2s    v1.21.12-eks-6d55a22   10.111.62.110   <none>        Ubuntu 20.04.4 LTS   5.13.0-1025-aws   containerd://1.5.9
[ec2-user@ip-34-223-14-194 ~]$
```

ContainersVolume was successfully mounted
```
ubuntu@s-i-80d0bce0060e5c27f:~$ lsblk
NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
loop0    7:0    0 25.1M  1 loop /snap/amazon-ssm-agent/5656
loop1    7:1    0 61.9M  1 loop /snap/core20/1518
loop2    7:2    0 61.9M  1 loop /snap/core20/1434
loop3    7:3    0 55.5M  1 loop /snap/core18/2409
loop4    7:4    0 67.8M  1 loop /snap/lxd/22753
loop5    7:5    0 44.7M  1 loop /snap/snapd/15534
loop6    7:6    0   47M  1 loop /snap/snapd/16292
sda      8:0    0   25G  0 disk
└─sda1   8:1    0   25G  0 part /
vda    252:0    0  100G  0 disk /var/lib/containerd
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
