### PR TITLE
Add proxy configuration to common.json

### DIFF
--- a/projects/kubernetes-sigs/image-builder/README.md
+++ b/projects/kubernetes-sigs/image-builder/README.md
@@ -64,6 +64,10 @@ Currently this process only supports building RHEL images for KVM hypervisor.
   * export RHSM_PASSWORD=&lt;RedHat password&gt;
   * export IMAGE_OS=&lt;ubuntu or rhel&gt;
   * export ARTIFACTS_BUCKET=s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f
+- Setup exports for proxy configuration (optional)
+  * export HTTP_PROXY=&lt;HTTP proxy URL e.g. http://proxy.corp.com:80&gt;
+  * export HTTPS_PROXY=&lt;HTTPS proxy URL e.g. http://proxy.corp.com:443&gt;
+  * export NO_PROXY=&lt;No proxy&gt;
 - Run the local build make command. This command will verify required build dependencies and run the image building process.
     ```
     make build-qemu-rhel-local

--- a/projects/kubernetes-sigs/image-builder/build/setup_packer_configs.sh
+++ b/projects/kubernetes-sigs/image-builder/build/setup_packer_configs.sh
@@ -59,7 +59,7 @@ envsubst '$CNI_SHA:$PLUGINS_ASSET_BASE_URL:$CNI_VERSION:$CNI_HOST_DEVICE_SHA256'
     > "$OUTPUT_CONFIGS/cni.json"
 
 export PAUSE_IMAGE=$(build::eksd_releases::get_eksd_kubernetes_image_url 'pause-image' $RELEASE_BRANCH)
-envsubst '$PAUSE_IMAGE' \
+envsubst '$PAUSE_IMAGE:$HTTP_PROXY:$HTTPS_PROXY:$NO_PROXY' \
     < "$MAKE_ROOT/packer/config/common.json.tmpl" \
     > "$OUTPUT_CONFIGS/common.json"
 

--- a/projects/kubernetes-sigs/image-builder/packer/config/common.json.tmpl
+++ b/projects/kubernetes-sigs/image-builder/packer/config/common.json.tmpl
@@ -1,4 +1,7 @@
 {
   "pause_image": "$PAUSE_IMAGE",
-  "extra_debs": "nfs-common xfsprogs"
+  "extra_debs": "nfs-common xfsprogs",
+  "http_proxy": "$HTTP_PROXY",
+  "https_proxy": "$HTTPS_PROXY",
+  "no_proxy": "$NO_PROXY"
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
To make Ansible support proxy configuration the proxy settings are in one of the JSON files passed via `PACKER_VAR_FILES` environment variable 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
