### PR TITLE
Use Linuxkit binary from GOPATH

### DIFF
--- a/projects/tinkerbell/hook/CHECKSUMS
+++ b/projects/tinkerbell/hook/CHECKSUMS
@@ -1,4 +1,4 @@
-7e803f264a165fc407dcb74eb0eed09f34c19ee2915de72948ec7ce48e4e12ba  _output/bin/hook/linux-amd64/bootkit
-1b06eaa4dd027de410eaf5b5a04126970d7e16e0a080e5d4e051b40295e03e44  _output/bin/hook/linux-amd64/tink-docker
-b66034a6476260ba5f593446f09eb1f0f092e13a1befaaf6147ae596b24edfb6  _output/bin/hook/linux-arm64/bootkit
-612db3cd5fd40071edd626430994b790eb8833a4ecbea94e861f12edd91819f5  _output/bin/hook/linux-arm64/tink-docker
+da85b99cdecde315ac548f6d55c8dff8035e6abe0ae422f49410754dceb84031  _output/bin/hook/linux-amd64/bootkit
+1d10c24b7004cc08958d006af8cf63ef682f45278af80d123f91a48b334ccce3  _output/bin/hook/linux-amd64/tink-docker
+93709bd523c6f0ed488725d14790aa8772268b97f549892b0def1d23f5df13a5  _output/bin/hook/linux-arm64/bootkit
+5afd0d364d728d78091d18ae19ccc48b4645fae072e64682fe4a5348ad10a5dd  _output/bin/hook/linux-arm64/tink-docker

--- a/projects/tinkerbell/hook/Makefile
+++ b/projects/tinkerbell/hook/Makefile
@@ -53,7 +53,7 @@ $(CREATE_HOOK_FILES): tarballs
 # Modify the linuxkit config file hook/hook.yaml to point to IMAGE_REPO.
 # Upstream make target `dist-existing-images` is triggered to perform linuxkit build and generate OSIE files.
 	sed -i -E -e 's,quay.io/tinkerbell/hook-(bootkit|docker|kernel).*,$(IMAGE_REPO)/tinkerbell/hook-\1:$(LATEST_TAG),g' $(REPO)/hook.yaml
-	make dist-existing-images -C $(REPO)
+	source $(BUILD_LIB)/common.sh && build::common::use_go_version "1.16" && make dist-existing-images -C $(REPO)
 	mkdir -p $(OUTPUT_DIR)/hook/$(GIT_TAG)
 	cp $(REPO)/dist/* $(OUTPUT_DIR)/hook/$(GIT_TAG)/
 	mkdir -p $(ARTIFACTS_PATH)


### PR DESCRIPTION
Linuxkit is in the 1.16 GOPATH, so need to get it from there.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
