### PR TITLE
Overriding kube-rbac-proxy image repo provided by CAPC with EKS-A default repo.

### DIFF
--- a/projects/kubernetes-sigs/cluster-api-provider-cloudstack/build/create_manifests.sh
+++ b/projects/kubernetes-sigs/cluster-api-provider-cloudstack/build/create_manifests.sh
@@ -32,6 +32,10 @@ source "${MAKE_ROOT}/../../../build/lib/common.sh"
 build::common::use_go_version ${GOLANG_VERSION}
 
 cd $REPO
+
+KUBE_RBAC_PROXY_IMAGE_OVERRIDE=${IMAGE_REPO}/brancz/kube-rbac-proxy:latest
+sed -i 's,image: .*,image: '"${KUBE_RBAC_PROXY_IMAGE_OVERRIDE}"',' ./config/default-with-metrics-port/manager_auth_proxy_patch.yaml
+
 make release-manifests-metrics-port \
   RELEASE_DIR="out" \
   IMG="${IMAGE_REPO}/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:$IMAGE_TAG"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changes to CAPC create_manifests.sh to alter kube-rbac-proxy image provided by CAPC make.
Confirmed by building make targets in docker and examining resulting file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
