### PR TITLE
Fix OVA builds on CI

### DIFF
--- a/projects/kubernetes-sigs/image-builder/build/build_ova_image_cli.sh
+++ b/projects/kubernetes-sigs/image-builder/build/build_ova_image_cli.sh
@@ -32,7 +32,7 @@ echo "${VSPHERE_CONNECTION_DATA}" > $vsphere_config_file
 
 # Run image-builder cli
 if [[ $image_os == "ubuntu" ]]; then
-  image-builder build --hypervisor vsphere --os $image_os --vsphere-config $vsphere_config_file --release-channel $release_channel --force
+  ./image-builder build --hypervisor vsphere --os $image_os --vsphere-config $vsphere_config_file --release-channel $release_channel --force
 elif [[ $image_os == "rhel" ]]; then
   echo "Redhat image building is not yet supported"
   exit 1

--- a/projects/kubernetes-sigs/image-builder/build/build_ova_image_cli.sh
+++ b/projects/kubernetes-sigs/image-builder/build/build_ova_image_cli.sh
@@ -24,15 +24,15 @@ image_os="${1?Specify the first argument - image os}"
 release_channel="${2?Specify the second argument - release channel}"
 
 # Download and setup latest image-builder cli
-image_build::common::download_latest_dev_image_builder_cli
+image_build::common::download_latest_dev_image_builder_cli "${HOME}"
 
 # Setup vsphere config
-vsphere_config_file="/vsphere_config_file"
+vsphere_config_file="${HOME}/vsphere_config_file"
 echo "${VSPHERE_CONNECTION_DATA}" > $vsphere_config_file
 
 # Run image-builder cli
 if [[ $image_os == "ubuntu" ]]; then
-  ./image-builder build --hypervisor vsphere --os $image_os --vsphere-config $vsphere_config_file --release-channel $release_channel --force
+  "${HOME}"/image-builder build --hypervisor vsphere --os $image_os --vsphere-config $vsphere_config_file --release-channel $release_channel --force
 elif [[ $image_os == "rhel" ]]; then
   echo "Redhat image building is not yet supported"
   exit 1

--- a/projects/kubernetes-sigs/image-builder/build/setup_image_builder_cli.sh
+++ b/projects/kubernetes-sigs/image-builder/build/setup_image_builder_cli.sh
@@ -29,6 +29,5 @@ function image_build::common::download_latest_dev_image_builder_cli() {
     exit 1
   fi
   tar -xvf image-builder.tar.gz ./image-builder
-  mv image-builder /usr/bin/
   rm -rf image-builder.tar.gz
 }

--- a/projects/kubernetes-sigs/image-builder/build/setup_image_builder_cli.sh
+++ b/projects/kubernetes-sigs/image-builder/build/setup_image_builder_cli.sh
@@ -17,8 +17,9 @@ MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 source "${MAKE_ROOT}/../../../build/lib/common.sh"
 
 function image_build::common::download_latest_dev_image_builder_cli() {
-  local -r artifacts_bucket=${1-$ARTIFACTS_BUCKET}
-  local -r arch=${2-amd64}
+  local -r download_location=${1-/usr/bin}
+  local -r artifacts_bucket=${2-$ARTIFACTS_BUCKET}
+  local -r arch=${3-amd64}
 
   local -r latest_tar_url=$(build::common::get_latest_eksa_asset_url $artifacts_bucket 'aws/image-builder' $arch 'latest')
 
@@ -29,5 +30,6 @@ function image_build::common::download_latest_dev_image_builder_cli() {
     exit 1
   fi
   tar -xvf image-builder.tar.gz ./image-builder
+  mv image-builder $download_location/
   rm -rf image-builder.tar.gz
 }


### PR DESCRIPTION
*Description of changes:*
Setting up image-builder cli on /usr/bin requires root perms on CI. Changing the setup phase to take in an argument for download location to support CI process.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
