### PR TITLE
Remove envoy image name override

### DIFF
--- a/projects/envoyproxy/envoy/Makefile
+++ b/projects/envoyproxy/envoy/Makefile
@@ -7,9 +7,6 @@ IMAGE_BUILD_ARGS=ENVOY_IMAGE
 REPO=envoy
 REPO_OWNER=envoyproxy
 
-IMAGE_COMPONENT=envoy
-IMAGE_NAMES=$(IMAGE_COMPONENT)
-
 BASE_IMAGE_NAME?=eks-distro-minimal-base-glibc
 
 REPO_NO_CLONE=true


### PR DESCRIPTION
*Description of changes:*
Remove envoy image name override
Default name works okay

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
