### PR TITLE
Set proxy environment in HTTP client

### DIFF
--- a/projects/helm/helm/CHECKSUMS
+++ b/projects/helm/helm/CHECKSUMS
@@ -1,2 +1,2 @@
-79250d8a9adeab1d8e47c291f59a183f0fc34d44d5994013f3b100ce000fc1bd  _output/bin/helm/linux-amd64/helm
-6dc6cda492bd43bcae56093348e29d87b46a8e31342d6c4c05ba85a10e257880  _output/bin/helm/linux-arm64/helm
+48e99ca5e9e92c99c07f857a6261f7dd61cf9134126a96f5e822d69bb212c237  _output/bin/helm/linux-amd64/helm
+ea79f607c192e604a88e4f47d25afc2ac603f7afe36116c7cc9851282b0dca2d  _output/bin/helm/linux-arm64/helm

--- a/projects/helm/helm/patches/0002-Set-proxy-environment-in-HTTP-client.patch
+++ b/projects/helm/helm/patches/0002-Set-proxy-environment-in-HTTP-client.patch
@@ -1,0 +1,24 @@
+From 702d74591628e058871c9e63436187b4623f02dc Mon Sep 17 00:00:00 2001
+From: Pooja Trivedi <tripooja@amazon.com>
+Date: Thu, 4 Aug 2022 12:28:51 -0700
+Subject: [PATCH] Set proxy environment in HTTP client
+
+---
+ pkg/registry/client.go | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/pkg/registry/client.go b/pkg/registry/client.go
+index 4fb55020..6acf27e7 100644
+--- a/pkg/registry/client.go
++++ b/pkg/registry/client.go
+@@ -178,6 +178,7 @@ func (c *Client) newResolver(insecure, plainHTTP bool) (remotes.Resolver, error)
+ 			TLSClientConfig: &tls.Config{
+ 				InsecureSkipVerify: true,
+ 			},
++			Proxy:		    http.ProxyFromEnvironment,
+ 		}
+ 		opts = append(opts, auth.WithResolverClient(httpClient))
+ 	}
+-- 
+2.33.0
+


### PR DESCRIPTION
Without passing proxy environment to http client again, proxy will not be honored.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
