### PR TITLE
Fix Raw builds on CI

### DIFF
--- a/projects/kubernetes-sigs/image-builder/build/build_image.sh
+++ b/projects/kubernetes-sigs/image-builder/build/build_image.sh
@@ -23,9 +23,10 @@ source "${MAKE_ROOT}/build/setup_image_builder_cli.sh"
 image_os="${1?Specify the first argument - image os}"
 release_channel="${2?Specify the second argument - release channel}"
 image_format="${3?Specify the third argument - image format}"
+artifacts_bucket=${4-$ARTIFACTS_BUCKET}
 
 # Download and setup latest image-builder cli
-image_build::common::download_latest_dev_image_builder_cli "${HOME}"
+image_build::common::download_latest_dev_image_builder_cli "${HOME}" $artifacts_bucket
 
 if [[ $image_format == "ova" ]]; then
   # Setup vsphere config

--- a/projects/kubernetes-sigs/image-builder/build/build_raw_image.sh
+++ b/projects/kubernetes-sigs/image-builder/build/build_raw_image.sh
@@ -118,7 +118,7 @@ if [ "$CODEBUILD_CI" = "false" ]; then
     exit 0
 fi
 
-SSH_COMMANDS="sudo usermod -a -G kvm ec2-user; sudo chmod 666 /dev/kvm; sudo chown root:kvm /dev/kvm; $REMOTE_PROJECT_PATH/build/build_image.sh $IMAGE_OS $RELEASE_BRANCH raw"
+SSH_COMMANDS="sudo usermod -a -G kvm ec2-user; sudo chmod 666 /dev/kvm; sudo chown root:kvm /dev/kvm; $REMOTE_PROJECT_PATH/build/build_image.sh $IMAGE_OS $RELEASE_BRANCH raw $ARTIFACTS_BUCKET"
 if [[ "$IMAGE_OS" =~ "rhel" ]]; then
     echo "Cannot build rhel image, as image-builder cli does not support it yet"
     exit 1


### PR DESCRIPTION
*Description of changes:*
CI builds were failing on unbound $ARTIFACTS_BUCKET. This fixes to consume the env var as an argument instead of relying on the environment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
