### PR TITLE
[ImageBuilder] Extracting tarball directly to download location

### DIFF
--- a/projects/kubernetes-sigs/image-builder/build/setup_image_builder_cli.sh
+++ b/projects/kubernetes-sigs/image-builder/build/setup_image_builder_cli.sh
@@ -29,7 +29,6 @@ function image_build::common::download_latest_dev_image_builder_cli() {
     echo "Error downloading latest image builder cli"
     exit 1
   fi
-  tar -xvf image-builder.tar.gz ./image-builder
-  mv image-builder $download_location/
+  tar -xvf image-builder.tar.gz --directory $download_location/ ./image-builder
   rm -rf image-builder.tar.gz
 }


### PR DESCRIPTION
*Description of changes:*
Instead of extracting and then moving the image-builder executable, directly extracting to location to make it neater and less error prone.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
