### PR TITLE
Skip Bottlerocket Raw release targets for 1-20 release branch

### DIFF
--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -92,6 +92,8 @@ else ifeq ($(IMAGE_FORMAT),raw)
 		ifneq ($(RELEASE_BRANCH),1-20)
 			S3_TARGET_PREREQUISITES=$(FINAL_BOTTLEROCKET_RAW_PATH)
 			RELEASE_TARGETS=download-bottlerocket-raw upload-bottlerocket-raw
+		else
+			RELEASE_TARGETS=
 		endif
 	else ifeq ($(IMAGE_OS),rhel)
 		S3_TARGET_PREREQUISITES=$(FINAL_RAW_IMAGE_PATH)


### PR DESCRIPTION
Skip Bottlerocket Raw release targets for 1-20 release branch.

/cherrypick release-0.11


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
