### PR TITLE
Fixes pause image baked into kind image

### DIFF
--- a/projects/kubernetes-sigs/kind/Makefile
+++ b/projects/kubernetes-sigs/kind/Makefile
@@ -108,7 +108,6 @@ kind-node/images/push: BASE_IMAGE=$(VERSIONED_BASE_IMAGE)
 kind-node/images/push: BASE_IMAGE_NAME=$(MINIMAL_BASE_KIND_IMAGE_NAME)
 kind-node/images/push: IMAGE_TAG=$(NODE_IMAGE_TAG)
 kind-node/images/push: LATEST_TAG=$(NODE_IMAGE_LATEST_TAG)
-kind-node/images/push: IMAGE_BUILD_ARGS=PAUSE_IMAGE_TAG_OVERRIDE PAUSE_IMAGE_TAG
 kind-node/images/push: IMAGE_TARGET=node
 kind-node/images/push: $(KIND_NODE_BUILD_AMD64_TARGET) $(KIND_NODE_BUILD_ARM64_TARGET) $(ARM_ENV_CONF_TARGET)
 

--- a/projects/kubernetes-sigs/kind/build/build-kind-node-image.sh
+++ b/projects/kubernetes-sigs/kind/build/build-kind-node-image.sh
@@ -190,7 +190,8 @@ function build::kind::load_images(){
 	sed -i "s,image: $LOCAL_PATH_PROVISONER_IMAGE_TAG,image: $LOCAL_PATH_PROVISONER_RELEASE_OVERRIDE," $ROOT_FS/kind/manifests/default-storage.yaml
 	sed -i "s,$LOCAL_PATH_HELPER_IMAGE_TAG,$AL2_HELPER_IMAGE," $ROOT_FS/kind/manifests/default-storage.yaml
 	sed -i "s,image: $KINDNETD_IMAGE_TAG,image: $KIND_KINDNETD_RELEASE_OVERRIDE," $ROOT_FS/kind/manifests/default-cni.yaml
-
+	# Update containerd config to have eks-d pause image tag
+	sed -i "s,$PAUSE_IMAGE_TAG,$PAUSE_IMAGE_TAG_OVERRIDE," $ROOT_FS/etc/containerd/config.toml
 }
 
 if command -v docker &> /dev/null && docker info > /dev/null 2>&1 ; then

--- a/projects/kubernetes-sigs/kind/images/node/Dockerfile
+++ b/projects/kubernetes-sigs/kind/images/node/Dockerfile
@@ -17,15 +17,10 @@ FROM base-${TARGETARCH} as node
 ARG TARGETOS
 ARG TARGETARCH
 
-ARG PAUSE_IMAGE_TAG_OVERRIDE
-ARG PAUSE_IMAGE_TAG
-
 RUN set -x && \
 	# remove kubeadm override script and containerd/runc
 	rm /usr/local/bin/kubeadm && \
 	rm /etc/kubeadm.config && \
-	# Update containerd config to have eks-d pause image tag
-	sed -i "s,$PAUSE_IMAGE_TAG,$PAUSE_IMAGE_TAG_OVERRIDE," /etc/containerd/config.toml && \
 	# During base image build using buildkit the /tmp directory's perms get changed from
 	# 1777 to 3777.  This probably isnt normally an issue however there is a 
 	# k8s conformance test that checks for 1777 specifically


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When updating kind, to handle the change in the way 1.24 in kind supports a different cgroup, the containerd.toml config needed to be handled a bit differently. This caused the sed for the pause image to happen to early (or late depending on how you look at it) and therefore did not take affect in the final image. This meant images would pull pause from gcr instead of our ecr repos, which sorta break airgapped envs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
