### PR TITLE
Add skip-checks argument to sparse-checkout for individual file support

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -421,7 +421,7 @@ ifneq ($(REPO_NO_CLONE),true)
 $(REPO):
 ifneq ($(REPO_SPARSE_CHECKOUT),)
 	git clone --depth 1 --filter=blob:none --sparse -b $(GIT_TAG) $(CLONE_URL) $(REPO)
-	git -C $(REPO) sparse-checkout set $(REPO_SPARSE_CHECKOUT) --cone
+	git -C $(REPO) sparse-checkout set $(REPO_SPARSE_CHECKOUT) --cone --skip-checks
 else
 	git clone $(CLONE_URL) $(REPO)
 endif


### PR DESCRIPTION
The new builder-base updated Git from 2.34.3 to 2.37.1, which added [this commit](https://github.com/git/git/commit/4ce504360bc3b240e570281fabe00a85027532c3) to validate that the arguments to the `set` command are directories. The attribution job with the updated builder-base failed building the bootconfig binary with the error
```bash
git -C linux sparse-checkout set tools lib/bootconfig.c include/linux/bootconfig.h --cone
fatal: 'lib/bootconfig.c' is not a directory; to treat it as a directory anyway, rerun with --skip-checks
```
This should fix it for future usecases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
