### PR TITLE
[ImageBuilder] Set codebuild env vars appropriately

### DIFF
--- a/projects/aws/image-builder/CHECKSUMS
+++ b/projects/aws/image-builder/CHECKSUMS
@@ -1,2 +1,2 @@
-73ac4cf7575eca8b4e690fc7efe6137b74d0ac35671b1907a62c4bce2acc906a  _output/bin/image-builder/linux-amd64/image-builder
-817c9960a4d99332aab5a74d043b6f312a38ecf87d2cc4eee7e1b2c766433c12  _output/bin/image-builder/linux-arm64/image-builder
+2fbfbfcf320c1608d15780fa568772bfa432f92c9ce0869d8dfaeeb6596089af  _output/bin/image-builder/linux-amd64/image-builder
+0c63cee2d529b18eb4411697a713d371586f3efdba3aac29e449704001a02c27  _output/bin/image-builder/linux-arm64/image-builder

--- a/projects/aws/image-builder/builder/builder.go
+++ b/projects/aws/image-builder/builder/builder.go
@@ -33,11 +33,7 @@ func (b *BuildOptions) BuildImage() {
 		}
 		log.Println("Cloned eks-anywhere-build-tooling repo")
 	} else {
-		if b.Hypervisor == VSphere {
-			buildToolingRepoPath = os.Getenv("CODEBUILD_SRC_DIR")
-		} else if b.Hypervisor == Baremetal {
-			buildToolingRepoPath = filepath.Join(os.Getenv("HOME"), "eks-anywhere-build-tooling")
-		}
+		buildToolingRepoPath = os.Getenv("CODEBUILD_SRC_DIR")
 		log.Println("Using repo checked out from code commit")
 	}
 

--- a/projects/kubernetes-sigs/image-builder/build/build_raw_image.sh
+++ b/projects/kubernetes-sigs/image-builder/build/build_raw_image.sh
@@ -118,7 +118,7 @@ if [ "$CODEBUILD_CI" = "false" ]; then
     exit 0
 fi
 
-SSH_COMMANDS="sudo usermod -a -G kvm ubuntu; sudo chmod 666 /dev/kvm; sudo chown root:kvm /dev/kvm; CODEBUILD_CI=true ARTIFACTS_PATH=/home/ubuntu/$PROJECT_PATH/artifacts $REMOTE_PROJECT_PATH/build/build_image.sh $IMAGE_OS $RELEASE_BRANCH raw $ARTIFACTS_BUCKET"
+SSH_COMMANDS="sudo usermod -a -G kvm ubuntu; sudo chmod 666 /dev/kvm; sudo chown root:kvm /dev/kvm; CODEBUILD_CI=true CODEBUILD_SRC_DIR=$CODEBUILD_SRC_DIR ARTIFACTS_PATH=/home/ubuntu/$PROJECT_PATH/artifacts $REMOTE_PROJECT_PATH/build/build_image.sh $IMAGE_OS $RELEASE_BRANCH raw $ARTIFACTS_BUCKET"
 if [[ "$IMAGE_OS" =~ "rhel" ]]; then
     echo "Cannot build rhel image, as image-builder cli does not support it yet"
     exit 1


### PR DESCRIPTION
*Description of changes:*
Instead of trying to deduce the pre-cloned directory use already set env variable to correctly figure out the proper path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
