### PR TITLE
Added a patch of allowing insecure pull from local registry

### DIFF
--- a/projects/tinkerbell/hook/CHECKSUMS
+++ b/projects/tinkerbell/hook/CHECKSUMS
@@ -1,4 +1,4 @@
 da85b99cdecde315ac548f6d55c8dff8035e6abe0ae422f49410754dceb84031  _output/bin/hook/linux-amd64/bootkit
-1d10c24b7004cc08958d006af8cf63ef682f45278af80d123f91a48b334ccce3  _output/bin/hook/linux-amd64/tink-docker
+29a2234d80e9d8c337076a021a8d4bb5a71cffe29aa324d5b20605192c88b988  _output/bin/hook/linux-amd64/tink-docker
 93709bd523c6f0ed488725d14790aa8772268b97f549892b0def1d23f5df13a5  _output/bin/hook/linux-arm64/bootkit
-5afd0d364d728d78091d18ae19ccc48b4645fae072e64682fe4a5348ad10a5dd  _output/bin/hook/linux-arm64/tink-docker
+59f386328056b151bd6f59a301b4656b2e4413cf69888b1ebb2a5298b2341e32  _output/bin/hook/linux-arm64/tink-docker

--- a/projects/tinkerbell/hook/patches/0003-Added-support-for-allowing-image-pull-from-local-reg.patch
+++ b/projects/tinkerbell/hook/patches/0003-Added-support-for-allowing-image-pull-from-local-reg.patch
@@ -1,0 +1,76 @@
+From ed8b7ed630e87eb7655e19d2ca4f50c572b75fd9 Mon Sep 17 00:00:00 2001
+From: panktishah26 <shah.pankti2609@gmail.com>
+Date: Thu, 1 Sep 2022 17:11:07 +0000
+Subject: [PATCH] Added support for allowing image pull from local registry
+
+---
+ tink-docker/main.go | 33 ++++++++++++++++++++++++---------
+ 1 file changed, 24 insertions(+), 9 deletions(-)
+
+diff --git a/tink-docker/main.go b/tink-docker/main.go
+index 22d67a9..ef497bc 100644
+--- a/tink-docker/main.go
++++ b/tink-docker/main.go
+@@ -13,19 +13,21 @@ import (
+ )
+ 
+ type tinkConfig struct {
+-	registry      string
+-	baseURL       string
+-	tinkerbell    string
+-	syslogHost    string
+-	tinkServerTLS bool
++	registry            string
++	baseURL             string
++	tinkerbell          string
++	syslogHost          string
++	tinkServerTLS       bool
++	insecure_registries []string
+ 
+ 	// TODO add others
+ }
+ 
+ type dockerConfig struct {
+-	Debug     bool              `json:"debug"`
+-	LogDriver string            `json:"log-driver,omitempty"`
+-	LogOpts   map[string]string `json:"log-opts,omitempty"`
++	Debug               bool              `json:"debug"`
++	LogDriver           string            `json:"log-driver,omitempty"`
++	LogOpts             map[string]string `json:"log-opts,omitempty"`
++	Insecure_registries []string          `json:"insecure-registries,omitempty"`
+ }
+ 
+ func main() {
+@@ -63,8 +65,18 @@ func main() {
+ 		LogOpts: map[string]string{
+ 			"syslog-address": fmt.Sprintf("udp://%v:514", cfg.syslogHost),
+ 		},
++		Insecure_registries: cfg.insecure_registries,
+ 	}
+-	if err := d.writeToDisk("/etc/docker/daemon.json"); err != nil {
++	dockerPath := "/etc/docker/"
++
++	err = os.MkdirAll(dockerPath, os.ModeDir)
++	if err != nil {
++		panic(err)
++	}
++
++	daemonPath := fmt.Sprintf("%sdaemon.json", dockerPath)
++
++	if err := d.writeToDisk(daemonPath); err != nil {
+ 		fmt.Println("Failed to write docker config:", err)
+ 	}
+ 
+@@ -103,6 +115,9 @@ func parseCmdLine(cmdLines []string) (cfg tinkConfig) {
+ 		// Find Registry configuration
+ 		case "docker_registry":
+ 			cfg.registry = cmdLine[1]
++		case "insecure_registries":
++			registries := strings.Split(cmdLine[1], ",")
++			cfg.insecure_registries = registries
+ 		case "packet_base_url":
+ 			cfg.baseURL = cmdLine[1]
+ 		case "tinkerbell":
+-- 
+2.25.1
+


### PR DESCRIPTION
*Issue #, if available:*
This patch is for allowing pull from local registry for Tinkerbell provider. 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
