### PR TITLE
Update helm_requires for special HELM_TAGs

### DIFF
--- a/build/lib/helm_require.sh
+++ b/build/lib/helm_require.sh
@@ -39,7 +39,7 @@ cat >${REQUIRES_FILE} <<!
 ---
 kind: EksaPackageRequires
 metadata:
-  name: ${HELM_DESTINATION_REPOSITORY}-${IMAGE_TAG/v}
+  name: ${HELM_DESTINATION_REPOSITORY}-${HELM_TAG/v}
   namespace: eksa-packages
 spec:
   images:
@@ -71,8 +71,19 @@ do
   else
     USE_TAG=$TAG
   fi
+  # If IMAGE_TAG is different from HELM_TAG, we are using images from upstream.
+  # Though we pull images directly from upstream for build tooling checks (i.e.
+  # get images shasums), we will use cached images in the helm charts. Cached
+  # images follow the convention of ${PROJECT_NAME}/${UPSTREAM_IMAGE_NAME}.
+  if [ "${IMAGE_TAG}" != "${HELM_TAG}" ]
+  then
+    PROJECT_NAME=$(echo "$HELM_DESTINATION_REPOSITORY" | awk -F "/" '{print $1}')
+    IMAGE_REPO="${PROJECT_NAME}/${IMAGE}"
+  else
+    IMAGE_REPO="${IMAGE}"
+  fi
   cat >>${REQUIRES_FILE} <<!
-  - repository: ${IMAGE}
+  - repository: ${IMAGE_REPO}
     tag: ${USE_TAG}
     digest: ${IMAGE_SHASUM}
 !


### PR DESCRIPTION
When we have cases where the HELM_TAG is different from the IMAGE_TAG, we are pulling images from upstream. Though we pull images directly from upstream for build tooling checks (i.e. get images shasums), we will use cached images in the helm charts. Therefore we added special handling in helm_require for this scenario.

This change should have no impact on existing projects.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
