### PR TITLE
Changes for dev package build

### DIFF
--- a/build/lib/helm_push.sh
+++ b/build/lib/helm_push.sh
@@ -31,7 +31,7 @@ OUTPUT_DIR="${5?Fifth arguement is output directory}"
 LATEST_TAG="${6?Sixth arguement is latest tag}"
 
 SEMVER="${HELM_TAG#[^0-9]}" # remove any leading non-digits
-SEMVER_GIT_TAG="${GIT_TAG#[^0-9]}"
+SEMVER_GIT_TAG="${GIT_TAG#[^0-9:main]}"
 
 HELM_DESTINATION_OWNER=$(dirname ${HELM_DESTINATION_REPOSITORY})
 CHART_NAME=$(basename ${HELM_DESTINATION_REPOSITORY})

--- a/projects/aws/eks-anywhere-packages/Makefile
+++ b/projects/aws/eks-anywhere-packages/Makefile
@@ -1,5 +1,5 @@
 BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
-GIT_TAG:=$(shell cat GIT_TAG)
+GIT_TAG?=$(shell cat GIT_TAG)
 GOLANG_VERSION?="1.17"
 
 REPO=eks-anywhere-packages


### PR DESCRIPTION
Signed-off-by: jonahjon <jonahjones094@gmail.com>

`GIT_TAG?=$(shell cat GIT_TAG)` allows the var to be overwritten by codebuild

`${GIT_TAG#[^0-9:main]}"` makes it so the `m` won't get chopped off if the tag is main.