### PR TITLE
Fix makefile to use redhat instead of rhel string

### DIFF
--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -86,7 +86,7 @@ ifeq ($(IMAGE_FORMAT),ova)
 	else ifeq ($(IMAGE_OS),bottlerocket)
 		S3_TARGET_PREREQUISITES=$(FINAL_BOTTLEROCKET_OVA_PATH)
 		RELEASE_TARGETS=download-bottlerocket-ova upload-bottlerocket-ova
-	else ifeq ($(IMAGE_OS),rhel)
+	else ifeq ($(IMAGE_OS),redhat)
 		S3_TARGET_PREREQUISITES=$(FINAL_OVA_PATH)
 		RELEASE_TARGETS=release-ova-$(IMAGE_OS) upload-artifacts-ova
 	else


### PR DESCRIPTION


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
