### PR TITLE
Create distinct tags for each helm chart

### DIFF
--- a/projects/kubernetes/autoscaler/Makefile
+++ b/projects/kubernetes/autoscaler/Makefile
@@ -19,7 +19,7 @@ EXCLUDE_FROM_STAGING_BUILDSPEC=true
 HAS_HELM_CHART=true
 
 HELM_GIT_TAG=$(shell cat ./$(RELEASE_BRANCH)/HELM_GIT_TAG)
-HELM_TAG=$(subst cluster-autoscaler-chart-,,$(HELM_GIT_TAG))
+HELM_TAG=$(subst cluster-autoscaler-chart-,,$(HELM_GIT_TAG))-$(subst -,.,$(RELEASE_BRANCH))
 HELM_SOURCE_OWNER=kubernetes
 HELM_SOURCE_REPOSITORY=autoscaler
 HELM_DIRECTORY=charts/cluster-autoscaler


### PR DESCRIPTION
*Issue #, if available:*
Epic: https://github.com/aws/eks-anywhere/issues/3186

*Description of changes:*
Right now, all helm charts have the same tag, so helm_push.sh only ends up tagging the 1.24 helm chart with the 9.21.0 tag.

By suffixing the kubernetes version we can distinguish tags on the charts.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->