### PR TITLE
Check if GIT_TAG is semver

### DIFF
--- a/build/lib/helm_push.sh
+++ b/build/lib/helm_push.sh
@@ -29,9 +29,14 @@ HELM_TAG="${3?Third argument is helm tag}"
 GIT_TAG="${4?Fourth arguement is the Git Tag}"
 OUTPUT_DIR="${5?Fifth arguement is output directory}"
 LATEST_TAG="${6?Sixth arguement is latest tag}"
+SEMVER_GIT_TAG="${GIT_TAG#[^0-9:main]}"
 
 SEMVER="${HELM_TAG#[^0-9]}" # remove any leading non-digits
-SEMVER_GIT_TAG="${GIT_TAG#[^0-9:main]}"
+SEMVER_REGEX='^([0-9]+\.){0,2}(\*|[0-9]+)$'
+if [[ ! $SEMVER_GIT_TAG =~ $SEMVER_REGEX ]]; then
+  # if not a valid semver, fallback to helm tag semver
+  SEMVER_GIT_TAG=SEMVER
+fi
 
 HELM_DESTINATION_OWNER=$(dirname ${HELM_DESTINATION_REPOSITORY})
 CHART_NAME=$(basename ${HELM_DESTINATION_REPOSITORY})


### PR DESCRIPTION
Epic: https://github.com/aws/eks-anywhere/issues/3186

*Description of changes:*
Fallback to HELM_TAG if not.

This fixes an issue we were experiencing where GIT_TAG was a hash, not a semver.

When the bundle promotion process tried to pull that helm chart tagged by the hash, the pull failed because it was not a valid semver.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.