### PR TITLE
Create actual path instead of parent path

### DIFF
--- a/projects/aws/eks-a-admin-image/Makefile
+++ b/projects/aws/eks-a-admin-image/Makefile
@@ -12,7 +12,7 @@ REPO=eks-a-admin-image
 REPO_OWNER=aws
 
 BUILD_TARGETS=validate
-RELEASE_TARGETS=build-raw-image
+RELEASE_TARGETS=latest-snow-raw-image
 
 PACKER_VERSION=1.8.0
 
@@ -58,13 +58,13 @@ $(PACKER):
 	rm packer.zip
 
 $(FULL_OUTPUT_DIR):
-	mkdir -p $(@D)
+	mkdir -p $@
 
 $(AMI_OUTPUT_DIR): $(FULL_OUTPUT_DIR)
-	mkdir -p $(@D)
+	mkdir -p $@
 
 $(OVA_OUTPUT_DIR): $(FULL_OUTPUT_DIR)
-	mkdir -p $(@D)
+	mkdir -p $@
 
 .PHONY: latest-snow-raw-image
 latest-snow-raw-image: EKSA_VERSION?=$(shell EKSA_RELEASE_MANIFEST_URL=$(EKSA_RELEASE_MANIFEST_URL) ./build/get_latest_eksa_version_by_date.sh)


### PR DESCRIPTION
This fixes the deletion of the _output directory during build.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
