### PR TITLE
Clean up apt package cache before upgrade

### DIFF
--- a/projects/aws/eks-a-admin-image/provisioners/upgrade_linux.sh
+++ b/projects/aws/eks-a-admin-image/provisioners/upgrade_linux.sh
@@ -5,6 +5,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+sudo apt-get clean
 sudo apt-get update
 sudo apt-get upgrade -y
 


### PR DESCRIPTION
This might prevent some apt issues arising due to shortage of space.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
