### PR TITLE
Use more robust filtering for skipped release branches

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -74,6 +74,8 @@ REPO_SPARSE_CHECKOUT?=
 HAS_RELEASE_BRANCHES?=false
 RELEASE_BRANCH?=
 SUPPORTED_K8S_VERSIONS:=$(shell cat $(BASE_DIRECTORY)/release/SUPPORTED_RELEASE_BRANCHES)
+# Comma-separated list of Kubernetes versions to skip building artifacts for
+SKIPPED_K8S_VERSIONS?=
 BINARIES_ARE_RELEASE_BRANCHED?=true
 IS_RELEASE_BRANCH_BUILD=$(filter true,$(HAS_RELEASE_BRANCHES))
 IS_UNRELEASE_BRANCH_TARGET=$(and $(filter false,$(BINARIES_ARE_RELEASE_BRANCHED)),$(filter binaries attribution checksums,$(MAKECMDGOALS)))
@@ -690,11 +692,11 @@ build: $(BUILD_TARGETS)
 .PHONY: release
 release: $(RELEASE_TARGETS)
 
-# Iterate over release branch versions, skipping version if directory not present
+# Iterate over release branch versions, avoiding branches explicitly marked as skipped
 .PHONY: %/release-branches/all
 %/release-branches/all:
 	@for version in $(SUPPORTED_K8S_VERSIONS) ; do \
-	    if [ -d "$$version" ]; then \
+	    if ! [[ "$(SKIPPED_K8S_VERSIONS)" =~ $$version  ]]; then \
 			$(MAKE) $* RELEASE_BRANCH=$$version; \
 		fi \
 	done;

--- a/projects/kubernetes/autoscaler/Makefile
+++ b/projects/kubernetes/autoscaler/Makefile
@@ -6,6 +6,7 @@ REPO=autoscaler
 REPO_OWNER=kubernetes
 
 BASE_IMAGE_NAME?=eks-distro-minimal-base
+SKIPPED_K8S_VERSIONS=1-20
 
 BINARY_TARGET_FILES=cluster-autoscaler
 SOURCE_PATTERNS=.


### PR DESCRIPTION
Some projects like `kind` and `image-builder` are classified as release-branched, but don't have separate folders for release branch since they don't have release branch specific git tags or Golang versions like `cloud-provider-vsphere` or `autoscaler`. The current check was skipping the build for these projects since the directory pertaining to the release branch was non-existent. This PR modifies the check, introducing a new variable for skipped Kubernetes release branches that can be set at a project level.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
