### PR TITLE
Support Building Helm Charts From EKS-D Images

### DIFF
--- a/build/lib/eksd_releases.sh
+++ b/build/lib/eksd_releases.sh
@@ -34,7 +34,7 @@ function build::eksd_releases::load_release_yaml() {
     if $echo; then
         echo "${RELEASE_YAML[$release_branch]}"
     fi
-    set -$oldopt
+    set -$(echo $oldopt | sed 's/c//') # remove -c from options for when this is invoked with bash -c
 }
 
 function build::eksd_releases::get_release_yaml_url() {
@@ -122,7 +122,7 @@ function build::eksd_releases::get_eksd_component_asset_path() {
 
     echo "$yaml" | yq e "$query" -
     
-    set -$oldopt
+    set -$(echo $oldopt | sed 's/c//') # remove -c from options for when this is invoked with bash -c
 }
 
 function build::eksd_releases::get_eksd_component_asset_url() {
@@ -158,6 +158,15 @@ function build::eksd_releases::get_eksd_kubernetes_image_url() {
     local -r arch=${3-amd64}
 
     build::eksd_releases::get_eksd_component_asset_path "kubernetes" $release_branch ".image.uri" $arch $asset 
+}
+
+function build::eksd_releases::get_eksd_component_asset_image_tag() {
+    local -r component=$1
+    local -r asset=$2
+    local -r release_branch=${3-$(build::eksd_releases::get_release_branch)}
+    local -r arch=${4-amd64}
+
+    build::eksd_releases::get_eksd_component_asset_path $component $release_branch ".image.uri" $arch $asset | awk -F: '{print $2}'
 }
 
 function build::eksd_releases::get_eksd_component_url() {

--- a/build/lib/generate_projects_list.sh
+++ b/build/lib/generate_projects_list.sh
@@ -48,6 +48,9 @@ for org_path in projects/*; do
         if [ "$org" = "aws" ] & [[ $repo =~ "eks-anywhere" ]]; then # Ignore self-referential repos
             continue
         fi
+        if [ "$org" = "kubernetes-sigs" ] & [[ "$repo" =~ "metrics-server" ]]; then # Ignore helm builds backed by eks-d images to reduce toil
+            continue
+        fi
         if curl --retry 5 -fIsS https://github.com/$org/$repo &> /dev/null; then # Check if org/repo combination is a Github repo
             repos+=("$repo")
         fi


### PR DESCRIPTION
*Issue #, if available:*
Epic: https://github.com/aws/eks-anywhere/issues/3187
Ticket: https://github.com/aws/eks-anywhere/issues/3414

*Description of changes:*
- Adds functionality to automatically pull latest EKS-D project tag
- Adds functionality to skip metrics-server project, our first EKS-D backed helm chart, when generating UPSTREAM_PROJECTS.yaml

Supports https://github.com/aws/eks-anywhere-build-tooling/pull/1331.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.