### PR TITLE
Fallback to $SEMVER, not literal SEMVER

### DIFF
--- a/build/lib/helm_push.sh
+++ b/build/lib/helm_push.sh
@@ -35,7 +35,7 @@ SEMVER="${HELM_TAG#[^0-9]}" # remove any leading non-digits
 SEMVER_REGEX='^([0-9]+\.){0,2}(\*|[0-9]+)$'
 if [[ ! $SEMVER_GIT_TAG =~ $SEMVER_REGEX ]]; then
   # if not a valid semver, fallback to helm tag semver
-  SEMVER_GIT_TAG=SEMVER
+  SEMVER_GIT_TAG=$SEMVER
 fi
 
 HELM_DESTINATION_OWNER=$(dirname ${HELM_DESTINATION_REPOSITORY})


### PR DESCRIPTION
*Issue #, if available:*
Epic: https://github.com/aws/eks-anywhere/issues/3187
Ticket: https://github.com/aws/eks-anywhere/issues/3414

*Description of changes:*
Bug introduced in https://github.com/aws/eks-anywhere-build-tooling/pull/1326

We should fallback to the variable $SEMVER in `helm_push.sh`, not the literal string SEMVER, when a GIT_TAG value is not a valid semantic version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.