### PR TITLE
Bump Snow Admin AMI generation wait time to 2 hours

### DIFF
--- a/projects/aws/eks-a-admin-image/eks-a-admin-snow.pkr.hcl
+++ b/projects/aws/eks-a-admin-image/eks-a-admin-snow.pkr.hcl
@@ -42,7 +42,7 @@ source "amazon-ebs" "ubuntu" {
   // the AMI is very big in size
   aws_polling {
     delay_seconds = 5
-    max_attempts  = 800
+    max_attempts  = 1440
   }
 }
 


### PR DESCRIPTION
This increases the maximum retry attempts for the AMI generation step so it doesn't time out. Timeout is effectively bumped to 2 hours with this change.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
