### PR TITLE
Redhat packer http endpoint for boot media

### DIFF
--- a/projects/kubernetes-sigs/image-builder/build/setup_packer_configs.sh
+++ b/projects/kubernetes-sigs/image-builder/build/setup_packer_configs.sh
@@ -113,12 +113,12 @@ envsubst '$EKSD_NAME' \
 
 # This is the IP address that Packer will create the server on to host the local
 # directory containing the kickstart config
-if [ "$IMAGE_FORMAT" = "ova" ] && [ "$IMAGE_OS" = "rhel" ]; then
+if [ "$IMAGE_FORMAT" = "ova" ] && [ "$IMAGE_OS" = "redhat" ]; then
     ACTIVE_INTERFACE=""
     if [ "$(uname -s)" = "Linux" ]; then
         INTERFACES=($(ls /sys/class/net))
         for interface in "${INTERFACES[@]}"; do
-            if [ "$interface" = "eth0" ] || [ "$interface" = "en0" ]; then
+            if [ "$interface" = "eth0" ] || [ "$interface" = "en0" ] || [ "$interface" = "eno1" ]; then
                 ACTIVE_INTERFACE=$interface
                 break
             fi
@@ -132,7 +132,7 @@ if [ "$IMAGE_FORMAT" = "ova" ] && [ "$IMAGE_OS" = "rhel" ]; then
         exit 1
     fi
     export PACKER_HTTP_SERVER_IP=$(ip a l $ACTIVE_INTERFACE | awk '/inet / {print $2}' | cut -d/ -f1)
-    envsubst '$PACKER_HTTP_SERVER_IP' \
-        < "$MAKE_ROOT/$IMAGE_BUILDER_DIR/packer/ova/rhel-8.json" |
-        tee "$MAKE_ROOT/$IMAGE_BUILDER_DIR/packer/ova/rhel-8.json"
+    rhel_ova_config_file="${MAKE_ROOT}/${IMAGE_BUILDER_DIR}/packer/ova/rhel-8.json"
+    cat <<< $(jq --arg httpendpoint "http://$PACKER_HTTP_SERVER_IP:{{ .HTTPPort }}" \
+             '.boot_media_path=$httpendpoint' $rhel_ova_config_file) > $rhel_ova_config_file
 fi


### PR DESCRIPTION
*Description of changes:*
Packer's vsphere plugin does not work well in figuring our the ip address on our CI environment. There is currently no way to control this from the user. This change figures out the ip address in the image build workflows and sets the appropriate endpoint.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
