### PR TITLE
bugfix: Override existing go-licenses binaries when building

### DIFF
--- a/build/lib/install_go_versions.sh
+++ b/build/lib/install_go_versions.sh
@@ -54,5 +54,4 @@ build::common::use_go_version "1.18"
 GOBIN=${GOPATH}/go1.18/bin go install github.com/google/go-licenses@v1.2.1
 
 # 1.16 is the default so symlink it to /go/bin
-unlink ${GOPATH}/bin/go-licenses
-ln -s ${GOPATH}/go1.16/bin/go-licenses ${GOPATH}/bin
+ln -sf ${GOPATH}/go1.16/bin/go-licenses ${GOPATH}/bin


### PR DESCRIPTION
This should maintain the previous behavior of deleting an existing go-licenses if its already there, but with the added bonus of not aborting if there isn't a go-licenses binary already there.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
