### PR TITLE
Include json schema for release branched helm charts

### DIFF
--- a/build/lib/helm_require.sh
+++ b/build/lib/helm_require.sh
@@ -46,7 +46,7 @@ metadata:
 spec:
   images:
 !
-JSON_SCHEMA_FILE=helm/schema.json
+JSON_SCHEMA_FILE=$PROJECT_ROOT/helm/schema.json
 SEDFILE=${OUTPUT_DIR}/helm/sedfile
 export IMAGE_TAG
 export HELM_TAG


### PR DESCRIPTION
*Issue #, if available:*
Epic: https://github.com/aws/eks-anywhere/issues/3186

*Description of changes:*
Had a bug in build process that did not include schema.json in release-branched helm charts.

Manually tested by building metalb and autoscaler to verify that schema.json was properly included in both release branched and non release branched helm charts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.