### PR TITLE
Build metrics-server With Correct Image Tags

### DIFF
--- a/build/lib/eksd_releases.sh
+++ b/build/lib/eksd_releases.sh
@@ -163,7 +163,7 @@ function build::eksd_releases::get_eksd_kubernetes_image_url() {
 function build::eksd_releases::get_eksd_component_asset_image_tag() {
     local -r component=$1
     local -r asset=$2
-    local -r release_branch=${3-$(build::eksd_releases::get_release_branch)}
+    local -r release_branch=$3
     local -r arch=${4-amd64}
 
     build::eksd_releases::get_eksd_component_asset_path $component $release_branch ".image.uri" $arch $asset | awk -F: '{print $2}'

--- a/projects/kubernetes-sigs/metrics-server/Makefile
+++ b/projects/kubernetes-sigs/metrics-server/Makefile
@@ -1,5 +1,5 @@
 BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
-GIT_TAG=$(shell source $(BUILD_LIB)/common.sh && build::eksd_releases::get_eksd_component_asset_image_tag metrics-server metrics-server-image)
+GIT_TAG=$(shell source $(BUILD_LIB)/common.sh && build::eksd_releases::get_eksd_component_asset_image_tag metrics-server metrics-server-image $(RELEASE_BRANCH))
 HELM_GIT_TAG:=$(shell cat $(RELEASE_BRANCH)/HELM_GIT_TAG)
  # Upstream images are used directly without re-building and re-tagging in build
  # tooling, so the IMAGE_TAG needs to be overwritten to match upstream ECR tags.


### PR DESCRIPTION
*Issue #, if available:*
Epic: https://github.com/aws/eks-anywhere/issues/3186

*Description of changes:*
A bug in the previous implementation led to helm charts always being build with 1-22 images locally.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->