### PR TITLE
Update Golang version for CAPX

### DIFF
--- a/projects/nutanix-cloud-native/cluster-api-provider-nutanix/ATTRIBUTION.txt
+++ b/projects/nutanix-cloud-native/cluster-api-provider-nutanix/ATTRIBUTION.txt
@@ -843,7 +843,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/go; version go1.18.6 --
+** golang.org/go; version go1.19.1 --
 https://github.com/golang/go
 
 ** golang.org/x/crypto/pkcs12; version v0.0.0-20220411220226-7b82a4e95df4 --

--- a/projects/nutanix-cloud-native/cluster-api-provider-nutanix/CHECKSUMS
+++ b/projects/nutanix-cloud-native/cluster-api-provider-nutanix/CHECKSUMS
@@ -1,2 +1,2 @@
-5ee54635a33dd5a05bf42f08c9069179ed09e3bfd65666040ccb9b476c5dd04b  _output/bin/cluster-api-provider-nutanix/linux-amd64/manager
-15c7a66441d8099de896f7f3bb60cd5820305ff9ba6d4c9c8d41c4f8ba694705  _output/bin/cluster-api-provider-nutanix/linux-arm64/manager
+a4ec21f231c2b81f2779d282f369586dfac45e1b6ae7fa933bb2855525aa9396  _output/bin/cluster-api-provider-nutanix/linux-amd64/manager
+38d7682070c2ef216021f15ba345596d12d2d20039fc4c7952f8a2b8a90c4ded  _output/bin/cluster-api-provider-nutanix/linux-arm64/manager

--- a/projects/nutanix-cloud-native/cluster-api-provider-nutanix/Makefile
+++ b/projects/nutanix-cloud-native/cluster-api-provider-nutanix/Makefile
@@ -1,6 +1,6 @@
 BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
 GIT_TAG:=$(shell cat GIT_TAG)
-GOLANG_VERSION?="1.18"
+GOLANG_VERSION?="1.19"
 
 REPO=cluster-api-provider-nutanix
 REPO_OWNER=nutanix-cloud-native


### PR DESCRIPTION
Update Makefile to set Go Version to 1.19

Generated checksums using `make update-attribution-checksums-docker`.