### PR TITLE
Add verbose logging to source-controller build

### DIFF
--- a/projects/fluxcd/source-controller/Makefile
+++ b/projects/fluxcd/source-controller/Makefile
@@ -14,7 +14,7 @@ BASE_IMAGE_NAME?=eks-distro-minimal-base-git
 
 CGO_DEPS_TARGET=$(CGO_SOURCE)/linux-%/lib64/libgit2.so
 CGO_CREATE_BINARIES=true
-EXTRA_GOBUILD_FLAGS=-tags netgo,osusergo,static_build
+EXTRA_GOBUILD_FLAGS=-x -tags netgo,osusergo,static_build
 
 include $(BASE_DIRECTORY)/Common.mk
 


### PR DESCRIPTION
* Add Prowjob log links to bot-authored PRs (same as aws/eks-distro-build-tooling#488)
* Add `-x` flag to Flux source-controller build invocation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
