### PR TITLE
Run release branch specific builds for kind in staging

### DIFF
--- a/projects/kubernetes-sigs/kind/Makefile
+++ b/projects/kubernetes-sigs/kind/Makefile
@@ -52,6 +52,10 @@ IMAGE_NAMES=haproxy kindnetd kind-base
 
 FIX_LICENSES_KINDNETD_TARGET=$(REPO)/images/kindnetd/LICENSE
 
+BUILDSPEC_VARS_KEYS=RELEASE_BRANCH
+BUILDSPEC_VARS_VALUES=SUPPORTED_K8S_VERSIONS
+
+
 include $(BASE_DIRECTORY)/Common.mk
 
 # Do not need to import if running clean or any var-value-% targets

--- a/release/staging-build.yml
+++ b/release/staging-build.yml
@@ -308,7 +308,7 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.image-builder
           IMAGE_OS: bottlerocket
           RELEASE_BRANCH: 1-24
-    - identifier: kubernetes_sigs_kind
+    - identifier: kubernetes_sigs_kind_1_20_buildspec
       buildspec: buildspec.yml
       depend-on:
         - kubernetes_sigs_etcdadm
@@ -317,6 +317,47 @@ batch:
         variables:
           PROJECT_PATH: projects/kubernetes-sigs/kind
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
+          RELEASE_BRANCH: 1-20
+    - identifier: kubernetes_sigs_kind_1_21_buildspec
+      buildspec: buildspec.yml
+      depend-on:
+        - kubernetes_sigs_etcdadm
+        - kubernetes_sigs_cri_tools
+      env:
+        variables:
+          PROJECT_PATH: projects/kubernetes-sigs/kind
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
+          RELEASE_BRANCH: 1-21
+    - identifier: kubernetes_sigs_kind_1_22_buildspec
+      buildspec: buildspec.yml
+      depend-on:
+        - kubernetes_sigs_etcdadm
+        - kubernetes_sigs_cri_tools
+      env:
+        variables:
+          PROJECT_PATH: projects/kubernetes-sigs/kind
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
+          RELEASE_BRANCH: 1-22
+    - identifier: kubernetes_sigs_kind_1_23_buildspec
+      buildspec: buildspec.yml
+      depend-on:
+        - kubernetes_sigs_etcdadm
+        - kubernetes_sigs_cri_tools
+      env:
+        variables:
+          PROJECT_PATH: projects/kubernetes-sigs/kind
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
+          RELEASE_BRANCH: 1-23
+    - identifier: kubernetes_sigs_kind_1_24_buildspec
+      buildspec: buildspec.yml
+      depend-on:
+        - kubernetes_sigs_etcdadm
+        - kubernetes_sigs_cri_tools
+      env:
+        variables:
+          PROJECT_PATH: projects/kubernetes-sigs/kind
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
+          RELEASE_BRANCH: 1-24
     - identifier: kubernetes_sigs_vsphere_csi_driver
       buildspec: buildspec.yml
       env:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Kind is the long pole when it comes to builds in the staging batch build. This breaks the build up by release branch

*NOTE* The binaries will build and publish in each build and since they are not released branch it will overwrite, this shouldn't be an issue since the checksums will all guarantee the resulting builds are all the same, but something to keep in mind just in case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
