### PR TITLE
Adds docker option for cgo builds

### DIFF
--- a/projects/fluxcd/flux2/Makefile
+++ b/projects/fluxcd/flux2/Makefile
@@ -16,16 +16,8 @@ EXTRA_GO_LDFLAGS=-X main.VERSION=$(GIT_TAG:v%=%)
 FLUX_MANIFESTS_TARGET=$(REPO)/cmd/flux/manifests
 
 HAS_S3_ARTIFACTS=true
-# HAS_HELM_CHART=true
-# HELM_DESTINATION_REPOSITORY=fluxcd/flux2
-# HELM_SOURCE_OWNER=fluxcd-community
-# HELM_SOURCE_REPOSITORY=helm-charts
-# HELM_GIT_TAG?=$(shell cat HELM_GIT_TAG)
-# HELM_DIRECTORY=charts/flux2
-# HELM_IMAGE_LIST="fluxcd/flux-cli fluxcd/helm-controller fluxcd/kustomize-controller fluxcd/notification-controller fluxcd/source-controller"
 
-# Needed to be built for the helm chart build, which happens in this project
-PROJECT_DEPENDENCIES=eksa/fluxcd/source-controller eksd/kubernetes/client
+PROJECT_DEPENDENCIES=eksd/kubernetes/client
 
 include $(BASE_DIRECTORY)/Common.mk
 

--- a/projects/fluxcd/source-controller/Makefile
+++ b/projects/fluxcd/source-controller/Makefile
@@ -16,6 +16,11 @@ CGO_DEPS_TARGET=$(CGO_SOURCE)/linux-%/lib64/libgit2.so
 CGO_CREATE_BINARIES=true
 EXTRA_GOBUILD_FLAGS=-x -tags netgo,osusergo,static_build
 
+# This is an artificial dep so that during the staging batch build the source-controller
+# falls into the second "batch" of builds, not blocking the first batch from finishing
+# since it takes significantly longer
+PROJECT_DEPENDENCIES=eksa/kubernetes-sigs/etcdadm
+
 include $(BASE_DIRECTORY)/Common.mk
 
 

--- a/release/staging-build.yml
+++ b/release/staging-build.yml
@@ -120,8 +120,6 @@ batch:
           PROJECT_PATH: projects/envoyproxy/envoy
     - identifier: fluxcd_flux2
       buildspec: buildspec.yml
-      depend-on:
-        - fluxcd_source_controller
       env:
         variables:
           PROJECT_PATH: projects/fluxcd/flux2
@@ -146,6 +144,8 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/fluxcd.notification-controller
     - identifier: fluxcd_source_controller
       buildspec: buildspec.yml
+      depend-on:
+        - kubernetes_sigs_etcdadm
       env:
         variables:
           PROJECT_PATH: projects/fluxcd/source-controller


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Due to common build failures in codebuild we are trying to see if using docker instead of buildctl to build the cgo binaries will be more consistent.

This also removes the source-controller dep from flux since we arent building that helm chart anymore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
