### PR TITLE
Fix kind dependency for CLI tools image in staging build

### DIFF
--- a/build/lib/generate_staging_buildspec.sh
+++ b/build/lib/generate_staging_buildspec.sh
@@ -65,12 +65,16 @@ for project in "${PROJECTS[@]}"; do
         DEPS=(${PROJECT_DEPENDENCIES// / })
         for dep in "${DEPS[@]}"; do
             DEP_PRODUCT="$(cut -d/ -f1 <<< $dep)"
-            DEP_ORG="$(cut -d/ -f2 <<< $dep)"
-            DEP_REPO="$(cut -d/ -f3 <<< $dep)"
             if [[ "$DEP_PRODUCT" == "eksd" ]]; then
                 continue
             fi
-            DEPEND_ON+="\"${DEP_ORG//-/_}_${DEP_REPO//-/_}\","
+            DEP_ORG="$(cut -d/ -f2 <<< $dep)"
+            DEP_REPO="$(cut -d/ -f3 <<< $dep)"
+            if [[ "$DEP_REPO" == "kind" ]]; then
+                DEPEND_ON+="\"kubernetes_sigs_kind_1_24_buildspec\","
+            else
+                DEPEND_ON+="\"${DEP_ORG//-/_}_${DEP_REPO//-/_}\","
+            fi
 
             if [ ! -d $MAKE_ROOT/projects/$DEP_ORG/$DEP_REPO ]; then
                 echo "Non-existent project dependency: $dep!!!"

--- a/release/staging-build.yml
+++ b/release/staging-build.yml
@@ -52,7 +52,7 @@ batch:
       depend-on:
         - fluxcd_flux2
         - kubernetes_sigs_cluster_api
-        - kubernetes_sigs_kind
+        - kubernetes_sigs_kind_1_24_buildspec
         - replicatedhq_troubleshoot
         - vmware_govmomi
         - helm_helm


### PR DESCRIPTION
Fix kind dependency for CLI tools image in staging build


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
