### PR TITLE
Specify correct appVersion in Cluster Autoscaler

### DIFF
--- a/projects/kubernetes/autoscaler/1-21/helm/sedfile.template
+++ b/projects/kubernetes/autoscaler/1-21/helm/sedfile.template
@@ -1,2 +1,2 @@
-s/appVersion: 1.23.0/appVersion: 1.21/
+s/appVersion: 1.23.0/appVersion: 1.21.3/
 s/version: .*$/version: ${HELM_TAG}/

--- a/projects/kubernetes/autoscaler/1-21/helm/sedfile.template
+++ b/projects/kubernetes/autoscaler/1-21/helm/sedfile.template
@@ -1,1 +1,2 @@
+s/appVersion: 1.23.0/appVersion: 1.21/
 s/version: .*$/version: ${HELM_TAG}/

--- a/projects/kubernetes/autoscaler/1-22/helm/sedfile.template
+++ b/projects/kubernetes/autoscaler/1-22/helm/sedfile.template
@@ -1,2 +1,2 @@
-s/appVersion: 1.23.0/appVersion: 1.22/
+s/appVersion: 1.23.0/appVersion: 1.22.3/
 s/version: .*$/version: ${HELM_TAG}/

--- a/projects/kubernetes/autoscaler/1-22/helm/sedfile.template
+++ b/projects/kubernetes/autoscaler/1-22/helm/sedfile.template
@@ -1,1 +1,2 @@
+s/appVersion: 1.23.0/appVersion: 1.22/
 s/version: .*$/version: ${HELM_TAG}/

--- a/projects/kubernetes/autoscaler/1-23/helm/sedfile.template
+++ b/projects/kubernetes/autoscaler/1-23/helm/sedfile.template
@@ -1,1 +1,2 @@
+s/appVersion: 1.23.0/appVersion: 1.23.1/
 s/version: .*$/version: ${HELM_TAG}/

--- a/projects/kubernetes/autoscaler/1-24/helm/sedfile.template
+++ b/projects/kubernetes/autoscaler/1-24/helm/sedfile.template
@@ -1,1 +1,2 @@
+s/appVersion: 1.23.0/appVersion: 1.24/
 s/version: .*$/version: ${HELM_TAG}/

--- a/projects/kubernetes/autoscaler/1-24/helm/sedfile.template
+++ b/projects/kubernetes/autoscaler/1-24/helm/sedfile.template
@@ -1,2 +1,2 @@
-s/appVersion: 1.23.0/appVersion: 1.24/
+s/appVersion: 1.23.0/appVersion: 1.24.0/
 s/version: .*$/version: ${HELM_TAG}/

--- a/projects/kubernetes/autoscaler/README.md
+++ b/projects/kubernetes/autoscaler/README.md
@@ -15,3 +15,4 @@ You can find the latest version of this image [on ECR Public Gallery](https://ga
 4. Run `make update-attribution-checksums-docker` for each release version in this folder.
 5. Update CHECKSUMS as necessary (updated by default).
 6. Update the versions at the top of this Readme.
+7. Update the hardcoded appVersion values in sedfile.template


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Previously, we were not updating the chart's default appVersion of `1.23.0`.

Unfortunately, we do not have access to the specific cluster autoscaler version tags because we tie our builds to git hashes.
We have to do this because the upstream project has messed up their tagging.

This is far from an ideal solution, and I am open to alternatives.

I tried generating a Major.Minor vesion based on the RELEASE_BRANCH, but passing that variable down into helm_require.sh is non trivial.