### PR TITLE
Patch to exclude kernel updates for Redhat

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0010-Exclude-kernel-updates-for-Redhat.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0010-Exclude-kernel-updates-for-Redhat.patch
@@ -1,0 +1,25 @@
+From adc763b3916e367c3e2d31c831adfc872dcd998c Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Thu, 6 Oct 2022 11:16:47 -0500
+Subject: [PATCH] Exclude kernel updates for Redhat
+
+Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
+---
+ images/capi/ansible/roles/setup/tasks/redhat.yml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/images/capi/ansible/roles/setup/tasks/redhat.yml b/images/capi/ansible/roles/setup/tasks/redhat.yml
+index 2914fa80d..70721c6cb 100644
+--- a/images/capi/ansible/roles/setup/tasks/redhat.yml
++++ b/images/capi/ansible/roles/setup/tasks/redhat.yml
+@@ -40,6 +40,7 @@
+     name: '*'
+     state: latest
+     lock_timeout: 60
++    exclude: 'kernel*'
+ 
+ - name: install baseline dependencies
+   yum:
+-- 
+2.24.3 (Apple Git-128)
+


### PR DESCRIPTION
*Description of changes:*
Redhat updates for 8.6 includes kernel updates for which firmware drivers are not out yet. This causes failures in image-builds, cluster operations, etc. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
