### PR TITLE
now patching the repo before building nutanix image

### DIFF
--- a/projects/aws/image-builder/CHECKSUMS
+++ b/projects/aws/image-builder/CHECKSUMS
@@ -1,2 +1,2 @@
-5731f20633dbd91697c0beece1b90d6b1d19620a28bdbf9c6906972a7bcb2b3a  _output/bin/image-builder/linux-amd64/image-builder
-588dbfdabc8c9e536a9aafcd9b4c894e69af7a82ef407196d8e43d937987fde3  _output/bin/image-builder/linux-arm64/image-builder
+1ba1660bdcd88187fbced6e1ce8114e0d3970fc6f0270bb800f71ede26f78cb1  _output/bin/image-builder/linux-amd64/image-builder
+7967accc1e787ea2ea09982c8aa0aab57fba0b84d9426fe9db8ddda6e095394f  _output/bin/image-builder/linux-arm64/image-builder

--- a/projects/aws/image-builder/builder/builder.go
+++ b/projects/aws/image-builder/builder/builder.go
@@ -106,7 +106,7 @@ func (b *BuildOptions) BuildImage() {
 
 		if b.Os == Ubuntu {
 			// Patch firmware config for tool
-			upstreamPatchCommand := fmt.Sprintf("make -C %s image-builder/eks-anywhere-patched", imageBuilderProjectPath)
+			upstreamPatchCommand := fmt.Sprintf("make -C %s patch-repo", imageBuilderProjectPath)
 			if err = executeMakeBuildCommand(upstreamPatchCommand, commandEnvVars...); err != nil {
 				log.Fatalf("Error executing upstream patch command")
 			}
@@ -156,7 +156,7 @@ func (b *BuildOptions) BuildImage() {
 		outputArtifactPath = filepath.Join(cwd, fmt.Sprintf("%s.gz", b.Os))
 	} else if b.Hypervisor == Nutanix {
 		// Patch firmware config for tool
-		upstreamPatchCommand := fmt.Sprintf("make -C %s image-builder/eks-anywhere-patched", imageBuilderProjectPath)
+		upstreamPatchCommand := fmt.Sprintf("make -C %s patch-repo", imageBuilderProjectPath)
 		if err = executeMakeBuildCommand(upstreamPatchCommand, commandEnvVars...); err != nil {
 			log.Fatalf("Error executing upstream patch command")
 		}

--- a/projects/aws/image-builder/builder/builder.go
+++ b/projects/aws/image-builder/builder/builder.go
@@ -155,6 +155,12 @@ func (b *BuildOptions) BuildImage() {
 
 		outputArtifactPath = filepath.Join(cwd, fmt.Sprintf("%s.gz", b.Os))
 	} else if b.Hypervisor == Nutanix {
+		// Patch firmware config for tool
+		upstreamPatchCommand := fmt.Sprintf("make -C %s image-builder/eks-anywhere-patched", imageBuilderProjectPath)
+		if err = executeMakeBuildCommand(upstreamPatchCommand, commandEnvVars...); err != nil {
+			log.Fatalf("Error executing upstream patch command")
+		}
+
 		// Read and set the nutanix connection data
 		nutanixConfigData, err := json.Marshal(b.NutanixConfig)
 		if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
step of patching is now automated.
ran following to test
<pre>
ubuntu@ubuntu:~/go/src/github.com/nutanix-cloud-native/aws-eks-anywhere-build-tooling/projects/aws/image-builder$ /home/ubuntu/go/src/github.com/nutanix-cloud-native/aws-eks-anywhere-build-tooling/projects/aws/image-builder/_output/bin/image-builder/linux-amd64/image-builder build --os ubuntu --hypervisor nutanix --nutanix-config ./nutanix-connection-1.20.json --release-channel 1-20
Creating builder config
2022/10/06 20:33:26 Using repo checked out from code commit
2022/10/06 20:33:26 Executing command: /usr/bin/git -C /home/ubuntu/go/src/github.com/nutanix-cloud-native/aws-eks-anywhere-build-tooling rev-parse --show-toplevel
2022/10/06 20:33:26 Initiating Image Build
 Image OS: ubuntu
 Hypervisor: nutanix
2022/10/06 20:33:26 Executing command: /usr/bin/bash -c make -C /home/ubuntu/go/src/github.com/nutanix-cloud-native/aws-eks-anywhere-build-tooling/projects/kubernetes-sigs/image-builder patch-repo
make: Entering directory '/home/ubuntu/go/src/github.com/nutanix-cloud-native/aws-eks-anywhere-build-tooling/projects/kubernetes-sigs/image-builder'
(cd image-builder && /home/ubuntu/go/src/github.com/nutanix-cloud-native/aws-eks-anywhere-build-tooling/build/lib/wait_for_tag.sh ef9fed11d164c58dcb9e56699c56b0fe953f40d9)
Checking for tag ef9fed11d164c58dcb9e56699c56b0fe953f40d9...
ef9fed11d164c58dcb9e56699c56b0fe953f40d9
Tag ef9fed11d164c58dcb9e56699c56b0fe953f40d9 exists!
git -C image-builder checkout -f ef9fed11d164c58dcb9e56699c56b0fe953f40d9
Note: switching to 'ef9fed11d164c58dcb9e56699c56b0fe953f40d9'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at ef9fed11d Merge pull request #982 from nutanix-cloud-native/nutanix_imagebuilder
touch image-builder/eks-anywhere-checkout-ef9fed11d164c58dcb9e56699c56b0fe953f40d9
git -C image-builder config user.email prow@amazonaws.com
git -C image-builder config user.name "Prow Bot"
git -C image-builder am --committer-date-is-author-date /home/ubuntu/go/src/github.com/nutanix-cloud-native/aws-eks-anywhere-build-tooling/projects/kubernetes-sigs/image-builder/patches/*
Applying: Add goss validations for EKS-D artifacts
Applying: Install containerd from apt for Ubuntu
Applying: Output vsphere builds to content library instead of exports
Applying: Create /etc/pki/tls/certs dir as part of image-builds
Applying: Add etcdadm and etcd.tar.gz to image for unstacked etcd support
Applying: Additional EKS-A specific goss validations
Applying: Tweak Product info in OVF
Applying: Add support for RHEL 8 RAW image builds
Applying: Support crictl validation from input checksum
Applying: Exclude kernel updates for Redhat
make: Leaving directory '/home/ubuntu/go/src/github.com/nutanix-cloud-native/aws-eks-anywhere-build-tooling/projects/kubernetes-sigs/image-builder'
2022/10/06 20:33:27 Executing command: /usr/bin/bash -c make -C /home/ubuntu/go/src/github.com/nutanix-cloud-native/aws-eks-anywhere-build-tooling/projects/kubernetes-sigs/image-builder local-build-nutanix-ubuntu-2004
make: Entering directory '/home/ubuntu/go/src/github.com/nutanix-cloud-native/aws-eks-anywhere-build-tooling/projects/kubernetes-sigs/image-builder'
make -C image-builder/images/capi deps-nutanix
..
..
Build 'nutanix' finished after 6 minutes 30 seconds.

==> Wait completed after 6 minutes 30 seconds

==> Builds finished. The artifacts of successful builds are:
--> nutanix: ubuntu-2004-kube-v1.20.15
--> nutanix: ubuntu-2004-kube-v1.20.15
make[1]: Leaving directory '/home/ubuntu/go/src/github.com/nutanix-cloud-native/aws-eks-anywhere-build-tooling/projects/kubernetes-sigs/image-builder/image-builder/images/capi'
make: Leaving directory '/home/ubuntu/go/src/github.com/nutanix-cloud-native/aws-eks-anywhere-build-tooling/projects/kubernetes-sigs/image-builder'
2022/10/06 18:32:00 Image Build Successful
 Please find the image uploaded under Nutanix Image Service with name eksa-dm-image-ubuntu-2004-kube-v1.20
2022/10/06 18:32:00 Build Successful. Output artifacts located at current working directory
</pre>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
