### PR TITLE
Remove incorrect IMAGE_REPO setting

### DIFF
--- a/projects/kubernetes-sigs/metrics-server/Makefile
+++ b/projects/kubernetes-sigs/metrics-server/Makefile
@@ -19,7 +19,6 @@ IMAGE_NAMES=
 BUILD_TARGETS=helm/build
 RELEASE_TARGETS=helm/push
 EXCLUDE_FROM_STAGING_BUILDSPEC=true
-IMAGE_REPO=public.ecr.aws/eks-distro
 
 HAS_HELM_CHART=true
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
IMAGE_REPO was set to upstream image repo incorrectly, causing helm/push builds to fail.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.