### PR TITLE
Rename cluster-autoscaler helm destination repo

### DIFF
--- a/projects/kubernetes/autoscaler/Makefile
+++ b/projects/kubernetes/autoscaler/Makefile
@@ -24,7 +24,7 @@ HELM_TAG=$(subst cluster-autoscaler-chart-,,$(HELM_GIT_TAG))-$(subst -,.,$(RELEA
 HELM_SOURCE_OWNER=kubernetes
 HELM_SOURCE_REPOSITORY=autoscaler
 HELM_DIRECTORY=charts/cluster-autoscaler
-HELM_DESTINATION_REPOSITORY=autoscaler/charts/cluster-autoscaler
+HELM_DESTINATION_REPOSITORY=cluster-autoscaler/charts/cluster-autoscaler
 HELM_IMAGE_LIST=kubernetes/autoscaler
 
 


### PR DESCRIPTION
*Issue #, if available:*
Epic: https://github.com/aws/eks-anywhere/issues/3186

*Description of changes:*
Renames cluster-autoscaler's helm repo to align with convention.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.