### PR TITLE
Remove null types from metrics-cluster schema.json

### DIFF
--- a/projects/kubernetes-sigs/metrics-server/1-21/helm/schema.json
+++ b/projects/kubernetes-sigs/metrics-server/1-21/helm/schema.json
@@ -310,7 +310,7 @@
                 },
                 "minAvailable": {
                     "type": "integer",
-                    "default": null,
+                    "default": 3,
                     "title": "The minAvailable Schema",
                     "examples": [
                         null
@@ -318,7 +318,7 @@
                 },
                 "maxUnavailable": {
                     "type": "integer",
-                    "default": null,
+                    "default": 1,
                     "title": "The maxUnavailable Schema",
                     "examples": [
                         null

--- a/projects/kubernetes-sigs/metrics-server/1-21/helm/schema.json
+++ b/projects/kubernetes-sigs/metrics-server/1-21/helm/schema.json
@@ -309,7 +309,7 @@
                     ]
                 },
                 "minAvailable": {
-                    "type": "null",
+                    "type": "integer",
                     "default": null,
                     "title": "The minAvailable Schema",
                     "examples": [
@@ -317,7 +317,7 @@
                     ]
                 },
                 "maxUnavailable": {
-                    "type": "null",
+                    "type": "integer",
                     "default": null,
                     "title": "The maxUnavailable Schema",
                     "examples": [


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/3187

*Description of changes:*
metrics-server's schema.json contained null types, which does not allow a user to configure the fields with anything other than null.
This PR replaces those with appropriate integer types.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.