### PR TITLE
Add git hash to cluster autoscaler helm tags

### DIFF
--- a/projects/kubernetes/autoscaler/Makefile
+++ b/projects/kubernetes/autoscaler/Makefile
@@ -20,7 +20,7 @@ EXCLUDE_FROM_STAGING_BUILDSPEC=true
 HAS_HELM_CHART=true
 
 HELM_GIT_TAG=$(shell cat ./$(RELEASE_BRANCH)/HELM_GIT_TAG)
-HELM_TAG=$(subst cluster-autoscaler-chart-,,$(HELM_GIT_TAG))-$(subst -,.,$(RELEASE_BRANCH))
+HELM_TAG=$(subst cluster-autoscaler-chart-,,$(HELM_GIT_TAG))-$(subst -,.,$(RELEASE_BRANCH))-$(GIT_HASH)
 HELM_SOURCE_OWNER=kubernetes
 HELM_SOURCE_REPOSITORY=autoscaler
 HELM_DIRECTORY=charts/cluster-autoscaler


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/3186

*Description of changes:*
To avoid overwriting tags, we need to add the git hash of the build tooling repo at build time.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.