### PR TITLE
Correct cluster-autoscaler Default Source Registry

### DIFF
--- a/projects/kubernetes/autoscaler/1-21/helm/patches/0004-Use-eks-anywhere-default-registry.patch
+++ b/projects/kubernetes/autoscaler/1-21/helm/patches/0004-Use-eks-anywhere-default-registry.patch
@@ -1,0 +1,25 @@
+From 18bf22cfaee14b6c475049f75593ea5dfc46bb5d Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Fri, 30 Sep 2022 16:46:03 -0400
+Subject: [PATCH] Use eks-anywhere default registry
+
+---
+ charts/cluster-autoscaler/values.yaml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/charts/cluster-autoscaler/values.yaml b/charts/cluster-autoscaler/values.yaml
+index f4adbc00c..e556795f2 100644
+--- a/charts/cluster-autoscaler/values.yaml
++++ b/charts/cluster-autoscaler/values.yaml
+@@ -231,7 +231,7 @@ fullnameOverride: ""
+ 
+ image:
+   # image.sourceRegistry -- Image registry
+-  sourceRegistry: public.ecr.aws
++  sourceRegistry: public.ecr.aws/eks-anywhere
+   # image.repository -- Image repository
+   repository: kubernetes/autoscaler
+   # image.digest -- Image digest
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/kubernetes/autoscaler/1-22/helm/patches/0004-Use-eks-anywhere-default-registry.patch
+++ b/projects/kubernetes/autoscaler/1-22/helm/patches/0004-Use-eks-anywhere-default-registry.patch
@@ -1,0 +1,25 @@
+From 18bf22cfaee14b6c475049f75593ea5dfc46bb5d Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Fri, 30 Sep 2022 16:46:03 -0400
+Subject: [PATCH] Use eks-anywhere default registry
+
+---
+ charts/cluster-autoscaler/values.yaml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/charts/cluster-autoscaler/values.yaml b/charts/cluster-autoscaler/values.yaml
+index f4adbc00c..e556795f2 100644
+--- a/charts/cluster-autoscaler/values.yaml
++++ b/charts/cluster-autoscaler/values.yaml
+@@ -231,7 +231,7 @@ fullnameOverride: ""
+ 
+ image:
+   # image.sourceRegistry -- Image registry
+-  sourceRegistry: public.ecr.aws
++  sourceRegistry: public.ecr.aws/eks-anywhere
+   # image.repository -- Image repository
+   repository: kubernetes/autoscaler
+   # image.digest -- Image digest
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/kubernetes/autoscaler/1-23/helm/patches/0004-Use-eks-anywhere-default-registry.patch
+++ b/projects/kubernetes/autoscaler/1-23/helm/patches/0004-Use-eks-anywhere-default-registry.patch
@@ -1,0 +1,25 @@
+From 18bf22cfaee14b6c475049f75593ea5dfc46bb5d Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Fri, 30 Sep 2022 16:46:03 -0400
+Subject: [PATCH] Use eks-anywhere default registry
+
+---
+ charts/cluster-autoscaler/values.yaml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/charts/cluster-autoscaler/values.yaml b/charts/cluster-autoscaler/values.yaml
+index f4adbc00c..e556795f2 100644
+--- a/charts/cluster-autoscaler/values.yaml
++++ b/charts/cluster-autoscaler/values.yaml
+@@ -231,7 +231,7 @@ fullnameOverride: ""
+ 
+ image:
+   # image.sourceRegistry -- Image registry
+-  sourceRegistry: public.ecr.aws
++  sourceRegistry: public.ecr.aws/eks-anywhere
+   # image.repository -- Image repository
+   repository: kubernetes/autoscaler
+   # image.digest -- Image digest
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/kubernetes/autoscaler/1-24/helm/patches/0004-Use-eks-anywhere-default-registry.patch
+++ b/projects/kubernetes/autoscaler/1-24/helm/patches/0004-Use-eks-anywhere-default-registry.patch
@@ -1,0 +1,25 @@
+From 18bf22cfaee14b6c475049f75593ea5dfc46bb5d Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Fri, 30 Sep 2022 16:46:03 -0400
+Subject: [PATCH] Use eks-anywhere default registry
+
+---
+ charts/cluster-autoscaler/values.yaml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/charts/cluster-autoscaler/values.yaml b/charts/cluster-autoscaler/values.yaml
+index f4adbc00c..e556795f2 100644
+--- a/charts/cluster-autoscaler/values.yaml
++++ b/charts/cluster-autoscaler/values.yaml
+@@ -231,7 +231,7 @@ fullnameOverride: ""
+ 
+ image:
+   # image.sourceRegistry -- Image registry
+-  sourceRegistry: public.ecr.aws
++  sourceRegistry: public.ecr.aws/eks-anywhere
+   # image.repository -- Image repository
+   repository: kubernetes/autoscaler
+   # image.digest -- Image digest
+-- 
+2.30.1 (Apple Git-130)
+


### PR DESCRIPTION
*Issue #, if available:*
Epic: https://github.com/aws/eks-anywhere/issues/3186

*Description of changes:*
Default source registry was previously `public.ecr.aws` when it should have been `public.ecr.aws/eks-anywhere`. This PR corrects the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.