### PR TITLE
Align Image Pull Secrets to Convention

### DIFF
--- a/projects/kubernetes-sigs/metrics-server/1-21/helm/schema.json
+++ b/projects/kubernetes-sigs/metrics-server/1-21/helm/schema.json
@@ -42,34 +42,30 @@
                     "examples": [
                         "IfNotPresent"
                     ]
-                },
-                "imagePullSecrets": {
-                    "type": "array",
-                    "default": ["regcred"],
-                    "title": "The imagePullSecrets Schema",
-                    "items": {
-                        "type": "string",
-                        "default": "",
-                        "title": "A Schema",
-                        "examples": [
-                            "regcred"
-                        ]
-                    },
-                    "examples": [
-                        [
-                            "regcred"]
-                    ]
                 }
             },
             "examples": [{
                 "sourceRegistry": "public.ecr.aws/eks-anywhere",
                 "repository": "metrics-server/eks-distro/kubernetes-sigs/metrics-server",
                 "digest": "sha256:46a80fd791bb08dfaa68728f50d086b09bd7a355cd0a16a075fd11eb876c2b80",
-                "pullPolicy": "IfNotPresent",
-                "imagePullSecrets": [
-                    "regcred"
-                ]
+                "pullPolicy": "IfNotPresent"
             }]
+        },
+        "imagePullSecrets": {
+            "type": "array",
+            "default": [],
+            "title": "The imagePullSecrets Schema",
+            "items": {
+                "type": "string",
+                "default": "",
+                "title": "A Schema",
+                "examples": [
+                    "ecr-token"
+                ]
+            },
+            "examples": [
+                ["ecr-token"]
+            ]
         },
         "nameOverride": {
             "type": "string",
@@ -698,11 +694,11 @@
             "sourceRegistry": "public.ecr.aws/eks-anywhere",
             "repository": "metrics-server/eks-distro/kubernetes-sigs/metrics-server",
             "digest": "sha256:46a80fd791bb08dfaa68728f50d086b09bd7a355cd0a16a075fd11eb876c2b80",
-            "pullPolicy": "IfNotPresent",
-            "imagePullSecrets": [
-                "regcred"
-            ]
+            "pullPolicy": "IfNotPresent"
         },
+        "imagePullSecrets": [
+            "ecr-token"
+        ],
         "nameOverride": "",
         "fullnameOverride": "",
         "serviceAccount": {

--- a/projects/kubernetes-sigs/metrics-server/1-22/helm/schema.json
+++ b/projects/kubernetes-sigs/metrics-server/1-22/helm/schema.json
@@ -9,13 +9,7 @@
             "type": "object",
             "default": {},
             "title": "The image Schema",
-            "required": [
-                "sourceRegistry",
-                "repository",
-                "digest",
-                "pullPolicy",
-                "imagePullSecrets"
-            ],
+            "required": [],
             "properties": {
                 "sourceRegistry": {
                     "type": "string",
@@ -48,34 +42,30 @@
                     "examples": [
                         "IfNotPresent"
                     ]
-                },
-                "imagePullSecrets": {
-                    "type": "array",
-                    "default": ["regcred"],
-                    "title": "The imagePullSecrets Schema",
-                    "items": {
-                        "type": "string",
-                        "default": "",
-                        "title": "A Schema",
-                        "examples": [
-                            "regcred"
-                        ]
-                    },
-                    "examples": [
-                        [
-                            "regcred"]
-                    ]
                 }
             },
             "examples": [{
                 "sourceRegistry": "public.ecr.aws/eks-anywhere",
                 "repository": "metrics-server/eks-distro/kubernetes-sigs/metrics-server",
-                "digest": "sha256:5977656eb531018c2d9340f8611661d221d1bff51ad4d5951622e26ea3470adb",
-                "pullPolicy": "IfNotPresent",
-                "imagePullSecrets": [
-                    "regcred"
-                ]
+                "digest": "sha256:46a80fd791bb08dfaa68728f50d086b09bd7a355cd0a16a075fd11eb876c2b80",
+                "pullPolicy": "IfNotPresent"
             }]
+        },
+        "imagePullSecrets": {
+            "type": "array",
+            "default": [],
+            "title": "The imagePullSecrets Schema",
+            "items": {
+                "type": "string",
+                "default": "",
+                "title": "A Schema",
+                "examples": [
+                    "ecr-token"
+                ]
+            },
+            "examples": [
+                ["ecr-token"]
+            ]
         },
         "nameOverride": {
             "type": "string",
@@ -97,11 +87,7 @@
             "type": "object",
             "default": {},
             "title": "The serviceAccount Schema",
-            "required": [
-                "create",
-                "annotations",
-                "name"
-            ],
+            "required": [],
             "properties": {
                 "create": {
                     "type": "boolean",
@@ -138,10 +124,7 @@
             "type": "object",
             "default": {},
             "title": "The rbac Schema",
-            "required": [
-                "create",
-                "pspEnabled"
-            ],
+            "required": [],
             "properties": {
                 "create": {
                     "type": "boolean",
@@ -214,12 +197,7 @@
             "type": "object",
             "default": {},
             "title": "The securityContext Schema",
-            "required": [
-                "allowPrivilegeEscalation",
-                "readOnlyRootFilesystem",
-                "runAsNonRoot",
-                "runAsUser"
-            ],
+            "required": [],
             "properties": {
                 "allowPrivilegeEscalation": {
                     "type": "boolean",
@@ -263,7 +241,7 @@
         },
         "priorityClassName": {
             "type": "string",
-            "default": "",
+            "default": "system-cluster-critical",
             "title": "The priorityClassName Schema",
             "examples": [
                 "system-cluster-critical"
@@ -281,9 +259,7 @@
             "type": "object",
             "default": {},
             "title": "The hostNetwork Schema",
-            "required": [
-                "enabled"
-            ],
+            "required": [],
             "properties": {
                 "enabled": {
                     "type": "boolean",
@@ -318,11 +294,7 @@
             "type": "object",
             "default": {},
             "title": "The podDisruptionBudget Schema",
-            "required": [
-                "enabled",
-                "minAvailable",
-                "maxUnavailable"
-            ],
+            "required": [],
             "properties": {
                 "enabled": {
                     "type": "boolean",
@@ -333,16 +305,16 @@
                     ]
                 },
                 "minAvailable": {
-                    "type": "null",
-                    "default": null,
+                    "type": "integer",
+                    "default": 3,
                     "title": "The minAvailable Schema",
                     "examples": [
                         null
                     ]
                 },
                 "maxUnavailable": {
-                    "type": "null",
-                    "default": null,
+                    "type": "integer",
+                    "default": 1,
                     "title": "The maxUnavailable Schema",
                     "examples": [
                         null
@@ -390,12 +362,7 @@
             "type": "object",
             "default": {},
             "title": "The livenessProbe Schema",
-            "required": [
-                "httpGet",
-                "initialDelaySeconds",
-                "periodSeconds",
-                "failureThreshold"
-            ],
+            "required": [],
             "properties": {
                 "httpGet": {
                     "type": "object",
@@ -478,12 +445,7 @@
             "type": "object",
             "default": {},
             "title": "The readinessProbe Schema",
-            "required": [
-                "httpGet",
-                "initialDelaySeconds",
-                "periodSeconds",
-                "failureThreshold"
-            ],
+            "required": [],
             "properties": {
                 "httpGet": {
                     "type": "object",
@@ -566,12 +528,7 @@
             "type": "object",
             "default": {},
             "title": "The service Schema",
-            "required": [
-                "type",
-                "port",
-                "annotations",
-                "labels"
-            ],
+            "required": [],
             "properties": {
                 "type": {
                     "type": "string",
@@ -638,12 +595,7 @@
             "type": "object",
             "default": {},
             "title": "The serviceMonitor Schema",
-            "required": [
-                "enabled",
-                "additionalLabels",
-                "interval",
-                "scrapeTimeout"
-            ],
+            "required": ["enabled"],
             "properties": {
                 "enabled": {
                     "type": "boolean",
@@ -741,12 +693,12 @@
         "image": {
             "sourceRegistry": "public.ecr.aws/eks-anywhere",
             "repository": "metrics-server/eks-distro/kubernetes-sigs/metrics-server",
-            "digest": "sha256:5977656eb531018c2d9340f8611661d221d1bff51ad4d5951622e26ea3470adb",
-            "pullPolicy": "IfNotPresent",
-            "imagePullSecrets": [
-                "regcred"
-            ]
+            "digest": "sha256:46a80fd791bb08dfaa68728f50d086b09bd7a355cd0a16a075fd11eb876c2b80",
+            "pullPolicy": "IfNotPresent"
         },
+        "imagePullSecrets": [
+            "ecr-token"
+        ],
         "nameOverride": "",
         "fullnameOverride": "",
         "serviceAccount": {

--- a/projects/kubernetes-sigs/metrics-server/1-23/helm/schema.json
+++ b/projects/kubernetes-sigs/metrics-server/1-23/helm/schema.json
@@ -9,13 +9,7 @@
             "type": "object",
             "default": {},
             "title": "The image Schema",
-            "required": [
-                "sourceRegistry",
-                "repository",
-                "digest",
-                "pullPolicy",
-                "imagePullSecrets"
-            ],
+            "required": [],
             "properties": {
                 "sourceRegistry": {
                     "type": "string",
@@ -48,34 +42,30 @@
                     "examples": [
                         "IfNotPresent"
                     ]
-                },
-                "imagePullSecrets": {
-                    "type": "array",
-                    "default": ["regcred"],
-                    "title": "The imagePullSecrets Schema",
-                    "items": {
-                        "type": "string",
-                        "default": "",
-                        "title": "A Schema",
-                        "examples": [
-                            "regcred"
-                        ]
-                    },
-                    "examples": [
-                        [
-                            "regcred"]
-                    ]
                 }
             },
             "examples": [{
                 "sourceRegistry": "public.ecr.aws/eks-anywhere",
                 "repository": "metrics-server/eks-distro/kubernetes-sigs/metrics-server",
-                "digest": "sha256:21c7e2aea0555a9889021a50637c113bb7988922649bbed5634d4e95b5aa8b5d",
-                "pullPolicy": "IfNotPresent",
-                "imagePullSecrets": [
-                    "regcred"
-                ]
+                "digest": "sha256:46a80fd791bb08dfaa68728f50d086b09bd7a355cd0a16a075fd11eb876c2b80",
+                "pullPolicy": "IfNotPresent"
             }]
+        },
+        "imagePullSecrets": {
+            "type": "array",
+            "default": [],
+            "title": "The imagePullSecrets Schema",
+            "items": {
+                "type": "string",
+                "default": "",
+                "title": "A Schema",
+                "examples": [
+                    "ecr-token"
+                ]
+            },
+            "examples": [
+                ["ecr-token"]
+            ]
         },
         "nameOverride": {
             "type": "string",
@@ -97,11 +87,7 @@
             "type": "object",
             "default": {},
             "title": "The serviceAccount Schema",
-            "required": [
-                "create",
-                "annotations",
-                "name"
-            ],
+            "required": [],
             "properties": {
                 "create": {
                     "type": "boolean",
@@ -138,10 +124,7 @@
             "type": "object",
             "default": {},
             "title": "The rbac Schema",
-            "required": [
-                "create",
-                "pspEnabled"
-            ],
+            "required": [],
             "properties": {
                 "create": {
                     "type": "boolean",
@@ -214,12 +197,7 @@
             "type": "object",
             "default": {},
             "title": "The securityContext Schema",
-            "required": [
-                "allowPrivilegeEscalation",
-                "readOnlyRootFilesystem",
-                "runAsNonRoot",
-                "runAsUser"
-            ],
+            "required": [],
             "properties": {
                 "allowPrivilegeEscalation": {
                     "type": "boolean",
@@ -263,7 +241,7 @@
         },
         "priorityClassName": {
             "type": "string",
-            "default": "",
+            "default": "system-cluster-critical",
             "title": "The priorityClassName Schema",
             "examples": [
                 "system-cluster-critical"
@@ -281,9 +259,7 @@
             "type": "object",
             "default": {},
             "title": "The hostNetwork Schema",
-            "required": [
-                "enabled"
-            ],
+            "required": [],
             "properties": {
                 "enabled": {
                     "type": "boolean",
@@ -318,11 +294,7 @@
             "type": "object",
             "default": {},
             "title": "The podDisruptionBudget Schema",
-            "required": [
-                "enabled",
-                "minAvailable",
-                "maxUnavailable"
-            ],
+            "required": [],
             "properties": {
                 "enabled": {
                     "type": "boolean",
@@ -333,16 +305,16 @@
                     ]
                 },
                 "minAvailable": {
-                    "type": "null",
-                    "default": null,
+                    "type": "integer",
+                    "default": 3,
                     "title": "The minAvailable Schema",
                     "examples": [
                         null
                     ]
                 },
                 "maxUnavailable": {
-                    "type": "null",
-                    "default": null,
+                    "type": "integer",
+                    "default": 1,
                     "title": "The maxUnavailable Schema",
                     "examples": [
                         null
@@ -390,12 +362,7 @@
             "type": "object",
             "default": {},
             "title": "The livenessProbe Schema",
-            "required": [
-                "httpGet",
-                "initialDelaySeconds",
-                "periodSeconds",
-                "failureThreshold"
-            ],
+            "required": [],
             "properties": {
                 "httpGet": {
                     "type": "object",
@@ -478,12 +445,7 @@
             "type": "object",
             "default": {},
             "title": "The readinessProbe Schema",
-            "required": [
-                "httpGet",
-                "initialDelaySeconds",
-                "periodSeconds",
-                "failureThreshold"
-            ],
+            "required": [],
             "properties": {
                 "httpGet": {
                     "type": "object",
@@ -566,12 +528,7 @@
             "type": "object",
             "default": {},
             "title": "The service Schema",
-            "required": [
-                "type",
-                "port",
-                "annotations",
-                "labels"
-            ],
+            "required": [],
             "properties": {
                 "type": {
                     "type": "string",
@@ -638,12 +595,7 @@
             "type": "object",
             "default": {},
             "title": "The serviceMonitor Schema",
-            "required": [
-                "enabled",
-                "additionalLabels",
-                "interval",
-                "scrapeTimeout"
-            ],
+            "required": ["enabled"],
             "properties": {
                 "enabled": {
                     "type": "boolean",
@@ -741,12 +693,12 @@
         "image": {
             "sourceRegistry": "public.ecr.aws/eks-anywhere",
             "repository": "metrics-server/eks-distro/kubernetes-sigs/metrics-server",
-            "digest": "sha256:21c7e2aea0555a9889021a50637c113bb7988922649bbed5634d4e95b5aa8b5d",
-            "pullPolicy": "IfNotPresent",
-            "imagePullSecrets": [
-                "regcred"
-            ]
+            "digest": "sha256:46a80fd791bb08dfaa68728f50d086b09bd7a355cd0a16a075fd11eb876c2b80",
+            "pullPolicy": "IfNotPresent"
         },
+        "imagePullSecrets": [
+            "ecr-token"
+        ],
         "nameOverride": "",
         "fullnameOverride": "",
         "serviceAccount": {

--- a/projects/kubernetes-sigs/metrics-server/1-24/helm/schema.json
+++ b/projects/kubernetes-sigs/metrics-server/1-24/helm/schema.json
@@ -9,13 +9,7 @@
             "type": "object",
             "default": {},
             "title": "The image Schema",
-            "required": [
-                "sourceRegistry",
-                "repository",
-                "digest",
-                "pullPolicy",
-                "imagePullSecrets"
-            ],
+            "required": [],
             "properties": {
                 "sourceRegistry": {
                     "type": "string",
@@ -48,34 +42,30 @@
                     "examples": [
                         "IfNotPresent"
                     ]
-                },
-                "imagePullSecrets": {
-                    "type": "array",
-                    "default": ["regcred"],
-                    "title": "The imagePullSecrets Schema",
-                    "items": {
-                        "type": "string",
-                        "default": "",
-                        "title": "A Schema",
-                        "examples": [
-                            "regcred"
-                        ]
-                    },
-                    "examples": [
-                        [
-                            "regcred"]
-                    ]
                 }
             },
             "examples": [{
                 "sourceRegistry": "public.ecr.aws/eks-anywhere",
                 "repository": "metrics-server/eks-distro/kubernetes-sigs/metrics-server",
-                "digest": "sha256:21c7e2aea0555a9889021a50637c113bb7988922649bbed5634d4e95b5aa8b5d",
-                "pullPolicy": "IfNotPresent",
-                "imagePullSecrets": [
-                    "regcred"
-                ]
+                "digest": "sha256:46a80fd791bb08dfaa68728f50d086b09bd7a355cd0a16a075fd11eb876c2b80",
+                "pullPolicy": "IfNotPresent"
             }]
+        },
+        "imagePullSecrets": {
+            "type": "array",
+            "default": [],
+            "title": "The imagePullSecrets Schema",
+            "items": {
+                "type": "string",
+                "default": "",
+                "title": "A Schema",
+                "examples": [
+                    "ecr-token"
+                ]
+            },
+            "examples": [
+                ["ecr-token"]
+            ]
         },
         "nameOverride": {
             "type": "string",
@@ -97,11 +87,7 @@
             "type": "object",
             "default": {},
             "title": "The serviceAccount Schema",
-            "required": [
-                "create",
-                "annotations",
-                "name"
-            ],
+            "required": [],
             "properties": {
                 "create": {
                     "type": "boolean",
@@ -138,10 +124,7 @@
             "type": "object",
             "default": {},
             "title": "The rbac Schema",
-            "required": [
-                "create",
-                "pspEnabled"
-            ],
+            "required": [],
             "properties": {
                 "create": {
                     "type": "boolean",
@@ -214,12 +197,7 @@
             "type": "object",
             "default": {},
             "title": "The securityContext Schema",
-            "required": [
-                "allowPrivilegeEscalation",
-                "readOnlyRootFilesystem",
-                "runAsNonRoot",
-                "runAsUser"
-            ],
+            "required": [],
             "properties": {
                 "allowPrivilegeEscalation": {
                     "type": "boolean",
@@ -263,7 +241,7 @@
         },
         "priorityClassName": {
             "type": "string",
-            "default": "",
+            "default": "system-cluster-critical",
             "title": "The priorityClassName Schema",
             "examples": [
                 "system-cluster-critical"
@@ -281,9 +259,7 @@
             "type": "object",
             "default": {},
             "title": "The hostNetwork Schema",
-            "required": [
-                "enabled"
-            ],
+            "required": [],
             "properties": {
                 "enabled": {
                     "type": "boolean",
@@ -318,11 +294,7 @@
             "type": "object",
             "default": {},
             "title": "The podDisruptionBudget Schema",
-            "required": [
-                "enabled",
-                "minAvailable",
-                "maxUnavailable"
-            ],
+            "required": [],
             "properties": {
                 "enabled": {
                     "type": "boolean",
@@ -333,16 +305,16 @@
                     ]
                 },
                 "minAvailable": {
-                    "type": "null",
-                    "default": null,
+                    "type": "integer",
+                    "default": 3,
                     "title": "The minAvailable Schema",
                     "examples": [
                         null
                     ]
                 },
                 "maxUnavailable": {
-                    "type": "null",
-                    "default": null,
+                    "type": "integer",
+                    "default": 1,
                     "title": "The maxUnavailable Schema",
                     "examples": [
                         null
@@ -390,12 +362,7 @@
             "type": "object",
             "default": {},
             "title": "The livenessProbe Schema",
-            "required": [
-                "httpGet",
-                "initialDelaySeconds",
-                "periodSeconds",
-                "failureThreshold"
-            ],
+            "required": [],
             "properties": {
                 "httpGet": {
                     "type": "object",
@@ -478,12 +445,7 @@
             "type": "object",
             "default": {},
             "title": "The readinessProbe Schema",
-            "required": [
-                "httpGet",
-                "initialDelaySeconds",
-                "periodSeconds",
-                "failureThreshold"
-            ],
+            "required": [],
             "properties": {
                 "httpGet": {
                     "type": "object",
@@ -566,12 +528,7 @@
             "type": "object",
             "default": {},
             "title": "The service Schema",
-            "required": [
-                "type",
-                "port",
-                "annotations",
-                "labels"
-            ],
+            "required": [],
             "properties": {
                 "type": {
                     "type": "string",
@@ -638,12 +595,7 @@
             "type": "object",
             "default": {},
             "title": "The serviceMonitor Schema",
-            "required": [
-                "enabled",
-                "additionalLabels",
-                "interval",
-                "scrapeTimeout"
-            ],
+            "required": ["enabled"],
             "properties": {
                 "enabled": {
                     "type": "boolean",
@@ -741,12 +693,12 @@
         "image": {
             "sourceRegistry": "public.ecr.aws/eks-anywhere",
             "repository": "metrics-server/eks-distro/kubernetes-sigs/metrics-server",
-            "digest": "sha256:21c7e2aea0555a9889021a50637c113bb7988922649bbed5634d4e95b5aa8b5d",
-            "pullPolicy": "IfNotPresent",
-            "imagePullSecrets": [
-                "regcred"
-            ]
+            "digest": "sha256:46a80fd791bb08dfaa68728f50d086b09bd7a355cd0a16a075fd11eb876c2b80",
+            "pullPolicy": "IfNotPresent"
         },
+        "imagePullSecrets": [
+            "ecr-token"
+        ],
         "nameOverride": "",
         "fullnameOverride": "",
         "serviceAccount": {

--- a/projects/kubernetes/autoscaler/1-21/helm/patches/0005-Use-imagePullSecrets-instead-of-pullSecrets.patch
+++ b/projects/kubernetes/autoscaler/1-21/helm/patches/0005-Use-imagePullSecrets-instead-of-pullSecrets.patch
@@ -1,0 +1,61 @@
+From d760d1c9a549ea6ee838d9da82e1225b970651f3 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Wed, 12 Oct 2022 13:12:22 -0400
+Subject: [PATCH] Use imagePullSecrets instead of pullSecrets
+
+---
+ charts/cluster-autoscaler/templates/deployment.yaml | 10 ++++------
+ charts/cluster-autoscaler/values.yaml               | 10 +++-------
+ 2 files changed, 7 insertions(+), 13 deletions(-)
+
+diff --git a/charts/cluster-autoscaler/templates/deployment.yaml b/charts/cluster-autoscaler/templates/deployment.yaml
+index bbd22d27f..5cfca0daf 100644
+--- a/charts/cluster-autoscaler/templates/deployment.yaml
++++ b/charts/cluster-autoscaler/templates/deployment.yaml
+@@ -36,6 +36,10 @@ spec:
+ {{ toYaml .Values.podLabels | indent 8 }}
+       {{- end }}
+     spec:
++      {{- with .Values.imagePullSecrets }}
++      imagePullSecrets:
++        {{- toYaml . | nindent 8 }}
++      {{- end }}
+       {{- if .Values.priorityClassName }}
+       priorityClassName: "{{ .Values.priorityClassName }}"
+       {{- end }}
+@@ -288,11 +292,5 @@ spec:
+           secret:
+             secretName: {{ .Values.clusterAPIKubeconfigSecret }}
+       {{- end }}
+-      {{- end }}
+-      {{- if .Values.image.pullSecrets }}
+-      imagePullSecrets:
+-      {{- range .Values.image.pullSecrets }}
+-        - name: {{ . }}
+-      {{- end }}
+     {{- end }}
+ {{- end }}
+diff --git a/charts/cluster-autoscaler/values.yaml b/charts/cluster-autoscaler/values.yaml
+index e556795f2..f88d5e60d 100644
+--- a/charts/cluster-autoscaler/values.yaml
++++ b/charts/cluster-autoscaler/values.yaml
+@@ -238,13 +238,9 @@ image:
+   digest: {{kubernetes/autoscaler}}
+   # image.pullPolicy -- Image pull policy
+   pullPolicy: IfNotPresent
+-  ## Optionally specify an array of imagePullSecrets.
+-  ## Secrets must be manually created in the namespace.
+-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+-  ##
+-  # image.pullSecrets -- Image pull secrets
+-  pullSecrets:
+-    - regcred
++
++# image pull secrets
++imagePullSecrets: []
+ 
+ # kubeTargetVersionOverride -- Allow overriding the `.Capabilities.KubeVersion.GitVersion` check. Useful for `helm template` commands.
+ kubeTargetVersionOverride: ""
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/kubernetes/autoscaler/1-21/helm/schema.json
+++ b/projects/kubernetes/autoscaler/1-21/helm/schema.json
@@ -473,34 +473,30 @@
                     "examples": [
                         "IfNotPresent"
                     ]
-                },
-                "pullSecrets": {
-                    "type": "array",
-                    "default": ["regcred"],
-                    "title": "The pullSecrets Schema",
-                    "items": {
-                        "type": "string",
-                        "default": "",
-                        "title": "A Schema",
-                        "examples": [
-                            "regcred"
-                        ]
-                    },
-                    "examples": [
-                        [
-                            "regcred"]
-                    ]
                 }
             },
             "examples": [{
                 "sourceRegistry": "public.ecr.aws",
                 "repository": "kubernetes/autoscaler",
                 "digest": "sha256:7264e721263a683313271d874fe80984fdbeb5b60af5e0a6c9ab2f4e8bf802c5",
-                "pullPolicy": "IfNotPresent",
-                "pullSecrets": [
-                    "regcred"
-                ]
+                "pullPolicy": "IfNotPresent"
             }]
+        },
+        "imagePullSecrets": {
+            "type": "array",
+            "default": [],
+            "title": "The imagePullSecrets Schema",
+            "items": {
+                "type": "string",
+                "default": "",
+                "title": "A Schema",
+                "examples": [
+                    "ecr-token"
+                ]
+            },
+            "examples": [
+                ["ecr-token"]
+            ]
         },
         "kubeTargetVersionOverride": {
             "type": "string",
@@ -1017,11 +1013,9 @@
             "sourceRegistry": "public.ecr.aws",
             "repository": "kubernetes/autoscaler",
             "digest": "sha256:7264e721263a683313271d874fe80984fdbeb5b60af5e0a6c9ab2f4e8bf802c5",
-            "pullPolicy": "IfNotPresent",
-            "pullSecrets": [
-                "regcred"
-            ]
+            "pullPolicy": "IfNotPresent"
         },
+        "imagePullSecrets": ["ecr-token"],
         "kubeTargetVersionOverride": "",
         "nameOverride": "",
         "nodeSelector": {},

--- a/projects/kubernetes/autoscaler/1-22/helm/patches/0005-Use-imagePullSecrets-instead-of-pullSecrets.patch
+++ b/projects/kubernetes/autoscaler/1-22/helm/patches/0005-Use-imagePullSecrets-instead-of-pullSecrets.patch
@@ -1,0 +1,61 @@
+From d760d1c9a549ea6ee838d9da82e1225b970651f3 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Wed, 12 Oct 2022 13:12:22 -0400
+Subject: [PATCH] Use imagePullSecrets instead of pullSecrets
+
+---
+ charts/cluster-autoscaler/templates/deployment.yaml | 10 ++++------
+ charts/cluster-autoscaler/values.yaml               | 10 +++-------
+ 2 files changed, 7 insertions(+), 13 deletions(-)
+
+diff --git a/charts/cluster-autoscaler/templates/deployment.yaml b/charts/cluster-autoscaler/templates/deployment.yaml
+index bbd22d27f..5cfca0daf 100644
+--- a/charts/cluster-autoscaler/templates/deployment.yaml
++++ b/charts/cluster-autoscaler/templates/deployment.yaml
+@@ -36,6 +36,10 @@ spec:
+ {{ toYaml .Values.podLabels | indent 8 }}
+       {{- end }}
+     spec:
++      {{- with .Values.imagePullSecrets }}
++      imagePullSecrets:
++        {{- toYaml . | nindent 8 }}
++      {{- end }}
+       {{- if .Values.priorityClassName }}
+       priorityClassName: "{{ .Values.priorityClassName }}"
+       {{- end }}
+@@ -288,11 +292,5 @@ spec:
+           secret:
+             secretName: {{ .Values.clusterAPIKubeconfigSecret }}
+       {{- end }}
+-      {{- end }}
+-      {{- if .Values.image.pullSecrets }}
+-      imagePullSecrets:
+-      {{- range .Values.image.pullSecrets }}
+-        - name: {{ . }}
+-      {{- end }}
+     {{- end }}
+ {{- end }}
+diff --git a/charts/cluster-autoscaler/values.yaml b/charts/cluster-autoscaler/values.yaml
+index e556795f2..f88d5e60d 100644
+--- a/charts/cluster-autoscaler/values.yaml
++++ b/charts/cluster-autoscaler/values.yaml
+@@ -238,13 +238,9 @@ image:
+   digest: {{kubernetes/autoscaler}}
+   # image.pullPolicy -- Image pull policy
+   pullPolicy: IfNotPresent
+-  ## Optionally specify an array of imagePullSecrets.
+-  ## Secrets must be manually created in the namespace.
+-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+-  ##
+-  # image.pullSecrets -- Image pull secrets
+-  pullSecrets:
+-    - regcred
++
++# image pull secrets
++imagePullSecrets: []
+ 
+ # kubeTargetVersionOverride -- Allow overriding the `.Capabilities.KubeVersion.GitVersion` check. Useful for `helm template` commands.
+ kubeTargetVersionOverride: ""
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/kubernetes/autoscaler/1-22/helm/schema.json
+++ b/projects/kubernetes/autoscaler/1-22/helm/schema.json
@@ -20,11 +20,11 @@
             "required": [],
             "properties": {
                 "clusterName": {
-                    "type": "null",
-                    "default": null,
+                    "type": "string",
+                    "default": "",
                     "title": "The clusterName Schema",
                     "examples": [
-                        null
+                        "my-cluster-name"
                     ]
                 },
                 "tags": {
@@ -75,7 +75,7 @@
                 }
             },
             "examples": [{
-                "clusterName": null,
+                "clusterName": "my-cluster-name",
                 "tags": [
                     "k8s.io/cluster-autoscaler/enabled",
                     "k8s.io/cluster-autoscaler/{{ .Values.autoDiscovery.clusterName }}"
@@ -473,34 +473,30 @@
                     "examples": [
                         "IfNotPresent"
                     ]
-                },
-                "pullSecrets": {
-                    "type": "array",
-                    "default": ["regcred"],
-                    "title": "The pullSecrets Schema",
-                    "items": {
-                        "type": "string",
-                        "default": "",
-                        "title": "A Schema",
-                        "examples": [
-                            "regcred"
-                        ]
-                    },
-                    "examples": [
-                        [
-                            "regcred"]
-                    ]
                 }
             },
             "examples": [{
                 "sourceRegistry": "public.ecr.aws",
                 "repository": "kubernetes/autoscaler",
                 "digest": "sha256:7264e721263a683313271d874fe80984fdbeb5b60af5e0a6c9ab2f4e8bf802c5",
-                "pullPolicy": "IfNotPresent",
-                "pullSecrets": [
-                    "regcred"
-                ]
+                "pullPolicy": "IfNotPresent"
             }]
+        },
+        "imagePullSecrets": {
+            "type": "array",
+            "default": [],
+            "title": "The imagePullSecrets Schema",
+            "items": {
+                "type": "string",
+                "default": "",
+                "title": "A Schema",
+                "examples": [
+                    "ecr-token"
+                ]
+            },
+            "examples": [
+                ["ecr-token"]
+            ]
         },
         "kubeTargetVersionOverride": {
             "type": "string",
@@ -904,11 +900,11 @@
                     ]
                 },
                 "interval": {
-                    "type": "null",
-                    "default": null,
+                    "type": "string",
+                    "default": "10s",
                     "title": "The interval Schema",
                     "examples": [
-                        null
+                        "10s"
                     ]
                 },
                 "rules": {
@@ -925,7 +921,7 @@
                 "enabled": false,
                 "additionalLabels": {},
                 "namespace": "monitoring",
-                "interval": null,
+                "interval": "10s",
                 "rules": []
             }]
         },
@@ -1017,11 +1013,9 @@
             "sourceRegistry": "public.ecr.aws",
             "repository": "kubernetes/autoscaler",
             "digest": "sha256:7264e721263a683313271d874fe80984fdbeb5b60af5e0a6c9ab2f4e8bf802c5",
-            "pullPolicy": "IfNotPresent",
-            "pullSecrets": [
-                "regcred"
-            ]
+            "pullPolicy": "IfNotPresent"
         },
+        "imagePullSecrets": ["ecr-token"],
         "kubeTargetVersionOverride": "",
         "nameOverride": "",
         "nodeSelector": {},
@@ -1072,7 +1066,7 @@
             "enabled": false,
             "additionalLabels": {},
             "namespace": "monitoring",
-            "interval": null,
+            "interval": "10s",
             "rules": []
         },
         "tolerations": [],

--- a/projects/kubernetes/autoscaler/1-23/helm/patches/0005-Use-imagePullSecrets-instead-of-pullSecrets.patch
+++ b/projects/kubernetes/autoscaler/1-23/helm/patches/0005-Use-imagePullSecrets-instead-of-pullSecrets.patch
@@ -1,0 +1,61 @@
+From d760d1c9a549ea6ee838d9da82e1225b970651f3 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Wed, 12 Oct 2022 13:12:22 -0400
+Subject: [PATCH] Use imagePullSecrets instead of pullSecrets
+
+---
+ charts/cluster-autoscaler/templates/deployment.yaml | 10 ++++------
+ charts/cluster-autoscaler/values.yaml               | 10 +++-------
+ 2 files changed, 7 insertions(+), 13 deletions(-)
+
+diff --git a/charts/cluster-autoscaler/templates/deployment.yaml b/charts/cluster-autoscaler/templates/deployment.yaml
+index bbd22d27f..5cfca0daf 100644
+--- a/charts/cluster-autoscaler/templates/deployment.yaml
++++ b/charts/cluster-autoscaler/templates/deployment.yaml
+@@ -36,6 +36,10 @@ spec:
+ {{ toYaml .Values.podLabels | indent 8 }}
+       {{- end }}
+     spec:
++      {{- with .Values.imagePullSecrets }}
++      imagePullSecrets:
++        {{- toYaml . | nindent 8 }}
++      {{- end }}
+       {{- if .Values.priorityClassName }}
+       priorityClassName: "{{ .Values.priorityClassName }}"
+       {{- end }}
+@@ -288,11 +292,5 @@ spec:
+           secret:
+             secretName: {{ .Values.clusterAPIKubeconfigSecret }}
+       {{- end }}
+-      {{- end }}
+-      {{- if .Values.image.pullSecrets }}
+-      imagePullSecrets:
+-      {{- range .Values.image.pullSecrets }}
+-        - name: {{ . }}
+-      {{- end }}
+     {{- end }}
+ {{- end }}
+diff --git a/charts/cluster-autoscaler/values.yaml b/charts/cluster-autoscaler/values.yaml
+index e556795f2..f88d5e60d 100644
+--- a/charts/cluster-autoscaler/values.yaml
++++ b/charts/cluster-autoscaler/values.yaml
+@@ -238,13 +238,9 @@ image:
+   digest: {{kubernetes/autoscaler}}
+   # image.pullPolicy -- Image pull policy
+   pullPolicy: IfNotPresent
+-  ## Optionally specify an array of imagePullSecrets.
+-  ## Secrets must be manually created in the namespace.
+-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+-  ##
+-  # image.pullSecrets -- Image pull secrets
+-  pullSecrets:
+-    - regcred
++
++# image pull secrets
++imagePullSecrets: []
+ 
+ # kubeTargetVersionOverride -- Allow overriding the `.Capabilities.KubeVersion.GitVersion` check. Useful for `helm template` commands.
+ kubeTargetVersionOverride: ""
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/kubernetes/autoscaler/1-23/helm/schema.json
+++ b/projects/kubernetes/autoscaler/1-23/helm/schema.json
@@ -20,11 +20,11 @@
             "required": [],
             "properties": {
                 "clusterName": {
-                    "type": "null",
-                    "default": null,
+                    "type": "string",
+                    "default": "",
                     "title": "The clusterName Schema",
                     "examples": [
-                        null
+                        "my-cluster-name"
                     ]
                 },
                 "tags": {
@@ -75,7 +75,7 @@
                 }
             },
             "examples": [{
-                "clusterName": null,
+                "clusterName": "my-cluster-name",
                 "tags": [
                     "k8s.io/cluster-autoscaler/enabled",
                     "k8s.io/cluster-autoscaler/{{ .Values.autoDiscovery.clusterName }}"
@@ -473,34 +473,30 @@
                     "examples": [
                         "IfNotPresent"
                     ]
-                },
-                "pullSecrets": {
-                    "type": "array",
-                    "default": ["regcred"],
-                    "title": "The pullSecrets Schema",
-                    "items": {
-                        "type": "string",
-                        "default": "",
-                        "title": "A Schema",
-                        "examples": [
-                            "regcred"
-                        ]
-                    },
-                    "examples": [
-                        [
-                            "regcred"]
-                    ]
                 }
             },
             "examples": [{
                 "sourceRegistry": "public.ecr.aws",
                 "repository": "kubernetes/autoscaler",
                 "digest": "sha256:7264e721263a683313271d874fe80984fdbeb5b60af5e0a6c9ab2f4e8bf802c5",
-                "pullPolicy": "IfNotPresent",
-                "pullSecrets": [
-                    "regcred"
-                ]
+                "pullPolicy": "IfNotPresent"
             }]
+        },
+        "imagePullSecrets": {
+            "type": "array",
+            "default": [],
+            "title": "The imagePullSecrets Schema",
+            "items": {
+                "type": "string",
+                "default": "",
+                "title": "A Schema",
+                "examples": [
+                    "ecr-token"
+                ]
+            },
+            "examples": [
+                ["ecr-token"]
+            ]
         },
         "kubeTargetVersionOverride": {
             "type": "string",
@@ -904,11 +900,11 @@
                     ]
                 },
                 "interval": {
-                    "type": "null",
-                    "default": null,
+                    "type": "string",
+                    "default": "10s",
                     "title": "The interval Schema",
                     "examples": [
-                        null
+                        "10s"
                     ]
                 },
                 "rules": {
@@ -925,7 +921,7 @@
                 "enabled": false,
                 "additionalLabels": {},
                 "namespace": "monitoring",
-                "interval": null,
+                "interval": "10s",
                 "rules": []
             }]
         },
@@ -1017,11 +1013,9 @@
             "sourceRegistry": "public.ecr.aws",
             "repository": "kubernetes/autoscaler",
             "digest": "sha256:7264e721263a683313271d874fe80984fdbeb5b60af5e0a6c9ab2f4e8bf802c5",
-            "pullPolicy": "IfNotPresent",
-            "pullSecrets": [
-                "regcred"
-            ]
+            "pullPolicy": "IfNotPresent"
         },
+        "imagePullSecrets": ["ecr-token"],
         "kubeTargetVersionOverride": "",
         "nameOverride": "",
         "nodeSelector": {},
@@ -1072,7 +1066,7 @@
             "enabled": false,
             "additionalLabels": {},
             "namespace": "monitoring",
-            "interval": null,
+            "interval": "10s",
             "rules": []
         },
         "tolerations": [],

--- a/projects/kubernetes/autoscaler/1-24/helm/patches/0005-Use-imagePullSecrets-instead-of-pullSecrets.patch
+++ b/projects/kubernetes/autoscaler/1-24/helm/patches/0005-Use-imagePullSecrets-instead-of-pullSecrets.patch
@@ -1,0 +1,61 @@
+From d760d1c9a549ea6ee838d9da82e1225b970651f3 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Wed, 12 Oct 2022 13:12:22 -0400
+Subject: [PATCH] Use imagePullSecrets instead of pullSecrets
+
+---
+ charts/cluster-autoscaler/templates/deployment.yaml | 10 ++++------
+ charts/cluster-autoscaler/values.yaml               | 10 +++-------
+ 2 files changed, 7 insertions(+), 13 deletions(-)
+
+diff --git a/charts/cluster-autoscaler/templates/deployment.yaml b/charts/cluster-autoscaler/templates/deployment.yaml
+index bbd22d27f..5cfca0daf 100644
+--- a/charts/cluster-autoscaler/templates/deployment.yaml
++++ b/charts/cluster-autoscaler/templates/deployment.yaml
+@@ -36,6 +36,10 @@ spec:
+ {{ toYaml .Values.podLabels | indent 8 }}
+       {{- end }}
+     spec:
++      {{- with .Values.imagePullSecrets }}
++      imagePullSecrets:
++        {{- toYaml . | nindent 8 }}
++      {{- end }}
+       {{- if .Values.priorityClassName }}
+       priorityClassName: "{{ .Values.priorityClassName }}"
+       {{- end }}
+@@ -288,11 +292,5 @@ spec:
+           secret:
+             secretName: {{ .Values.clusterAPIKubeconfigSecret }}
+       {{- end }}
+-      {{- end }}
+-      {{- if .Values.image.pullSecrets }}
+-      imagePullSecrets:
+-      {{- range .Values.image.pullSecrets }}
+-        - name: {{ . }}
+-      {{- end }}
+     {{- end }}
+ {{- end }}
+diff --git a/charts/cluster-autoscaler/values.yaml b/charts/cluster-autoscaler/values.yaml
+index e556795f2..f88d5e60d 100644
+--- a/charts/cluster-autoscaler/values.yaml
++++ b/charts/cluster-autoscaler/values.yaml
+@@ -238,13 +238,9 @@ image:
+   digest: {{kubernetes/autoscaler}}
+   # image.pullPolicy -- Image pull policy
+   pullPolicy: IfNotPresent
+-  ## Optionally specify an array of imagePullSecrets.
+-  ## Secrets must be manually created in the namespace.
+-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+-  ##
+-  # image.pullSecrets -- Image pull secrets
+-  pullSecrets:
+-    - regcred
++
++# image pull secrets
++imagePullSecrets: []
+ 
+ # kubeTargetVersionOverride -- Allow overriding the `.Capabilities.KubeVersion.GitVersion` check. Useful for `helm template` commands.
+ kubeTargetVersionOverride: ""
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/kubernetes/autoscaler/1-24/helm/schema.json
+++ b/projects/kubernetes/autoscaler/1-24/helm/schema.json
@@ -20,11 +20,11 @@
             "required": [],
             "properties": {
                 "clusterName": {
-                    "type": "null",
-                    "default": null,
+                    "type": "string",
+                    "default": "",
                     "title": "The clusterName Schema",
                     "examples": [
-                        null
+                        "my-cluster-name"
                     ]
                 },
                 "tags": {
@@ -75,7 +75,7 @@
                 }
             },
             "examples": [{
-                "clusterName": null,
+                "clusterName": "my-cluster-name",
                 "tags": [
                     "k8s.io/cluster-autoscaler/enabled",
                     "k8s.io/cluster-autoscaler/{{ .Values.autoDiscovery.clusterName }}"
@@ -473,34 +473,30 @@
                     "examples": [
                         "IfNotPresent"
                     ]
-                },
-                "pullSecrets": {
-                    "type": "array",
-                    "default": ["regcred"],
-                    "title": "The pullSecrets Schema",
-                    "items": {
-                        "type": "string",
-                        "default": "",
-                        "title": "A Schema",
-                        "examples": [
-                            "regcred"
-                        ]
-                    },
-                    "examples": [
-                        [
-                            "regcred"]
-                    ]
                 }
             },
             "examples": [{
                 "sourceRegistry": "public.ecr.aws",
                 "repository": "kubernetes/autoscaler",
                 "digest": "sha256:7264e721263a683313271d874fe80984fdbeb5b60af5e0a6c9ab2f4e8bf802c5",
-                "pullPolicy": "IfNotPresent",
-                "pullSecrets": [
-                    "regcred"
-                ]
+                "pullPolicy": "IfNotPresent"
             }]
+        },
+        "imagePullSecrets": {
+            "type": "array",
+            "default": [],
+            "title": "The imagePullSecrets Schema",
+            "items": {
+                "type": "string",
+                "default": "",
+                "title": "A Schema",
+                "examples": [
+                    "ecr-token"
+                ]
+            },
+            "examples": [
+                ["ecr-token"]
+            ]
         },
         "kubeTargetVersionOverride": {
             "type": "string",
@@ -904,11 +900,11 @@
                     ]
                 },
                 "interval": {
-                    "type": "null",
-                    "default": null,
+                    "type": "string",
+                    "default": "10s",
                     "title": "The interval Schema",
                     "examples": [
-                        null
+                        "10s"
                     ]
                 },
                 "rules": {
@@ -925,7 +921,7 @@
                 "enabled": false,
                 "additionalLabels": {},
                 "namespace": "monitoring",
-                "interval": null,
+                "interval": "10s",
                 "rules": []
             }]
         },
@@ -1017,11 +1013,9 @@
             "sourceRegistry": "public.ecr.aws",
             "repository": "kubernetes/autoscaler",
             "digest": "sha256:7264e721263a683313271d874fe80984fdbeb5b60af5e0a6c9ab2f4e8bf802c5",
-            "pullPolicy": "IfNotPresent",
-            "pullSecrets": [
-                "regcred"
-            ]
+            "pullPolicy": "IfNotPresent"
         },
+        "imagePullSecrets": ["ecr-token"],
         "kubeTargetVersionOverride": "",
         "nameOverride": "",
         "nodeSelector": {},
@@ -1072,7 +1066,7 @@
             "enabled": false,
             "additionalLabels": {},
             "namespace": "monitoring",
-            "interval": null,
+            "interval": "10s",
             "rules": []
         },
         "tolerations": [],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We needed to update the metrics-server and cluster-autoscaler helm charts to accept imagePullSecrets argument in order to work with auth.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.