### PR TITLE
Update bottlerocket to v1.10.0 and update bottlerocket-admin-container to v1.9.2

### DIFF
--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_ADMIN_CONTAINER_METADATA
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_ADMIN_CONTAINER_METADATA
@@ -1,2 +1,2 @@
-tag: v0.9.0
-imageDigest: sha256:d7a394014cd60caa821d7c748637d1bf21ed955eb06a8cef7864c9a5f2e75b02
+tag: v0.9.2
+imageDigest: sha256:bf56c9712189f5fc65d35544e2a84d3a7a1a2c05f2840fab54c57e8a3f8b57a4

--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
@@ -1,11 +1,11 @@
 1-20:
-    ova-release-version: v1.9.2
+    ova-release-version: v1.10.0
 1-21:
-    ova-release-version: v1.9.2
-    raw-release-version: v1.9.2
+    ova-release-version: v1.10.0
+    raw-release-version: v1.10.0
 1-22:
-    ova-release-version: v1.9.2
-    raw-release-version: v1.9.2
+    ova-release-version: v1.10.0
+    raw-release-version: v1.10.0
 1-23:
-    ova-release-version: v1.9.2
-    raw-release-version: v1.9.2
+    ova-release-version: v1.10.0
+    raw-release-version: v1.10.0


### PR DESCRIPTION
Updated bottlerocket to v1.10.0 and updated bottlerocket-admin-container to v1.9.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
