### PR TITLE
Add support for dependencies in requires.yaml

### DIFF
--- a/build/lib/helm_require.sh
+++ b/build/lib/helm_require.sh
@@ -32,6 +32,7 @@ HELM_IMAGE_LIST="${@:9}"
 CHART_NAME=$(basename ${HELM_DESTINATION_REPOSITORY})
 DEST_DIR=${OUTPUT_DIR}/helm/${CHART_NAME}
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+PACKAGE_DEPENDENCIES=${PACKAGE_DEPENDENCIES:=""}
 
 #
 # Image tags
@@ -97,4 +98,11 @@ then
   cat >>${REQUIRES_FILE} <<!
   schema: ${JSON_SCHEMA}
 !
+fi
+
+if [ -n ${PACKAGE_DEPENDENCIES} ]; then
+  echo "  dependencies:" >> ${REQUIRES_FILE}
+  echo ${PACKAGE_DEPENDENCIES} | tr ',' '\n'  | while read dep; do
+      echo "  - ${dep}"
+  done >> ${REQUIRES_FILE}
 fi

--- a/projects/metallb/metallb/Makefile
+++ b/projects/metallb/metallb/Makefile
@@ -30,15 +30,15 @@ include $(BASE_DIRECTORY)/Common.mk
 helm/build: $(LICENSES_TARGETS_FOR_PREREQ)
 helm/build: $(if $(filter true,$(REPO_NO_CLONE)),,$(HELM_GIT_CHECKOUT_TARGET))
 helm/build: $(if $(wildcard $(PROJECT_ROOT)/helm/patches),$(HELM_GIT_PATCH_TARGET),)
-	$(BUILD_LIB)/helm_copy.sh $(HELM_SOURCE_REPOSITORY) $(HELM_DESTINATION_REPOSITORY) $(HELM_DIRECTORY) $(OUTPUT_DIR)
-	$(BUILD_LIB)/helm_require.sh $(HELM_SOURCE_IMAGE_REPO) $(HELM_DESTINATION_REPOSITORY) $(OUTPUT_DIR) $(IMAGE_TAG) $(HELM_TAG) $(PROJECT_ROOT) $(LATEST) $(HELM_USE_UPSTREAM_IMAGE) $(HELM_IMAGE_LIST)
-	$(BUILD_LIB)/helm_replace.sh $(HELM_DESTINATION_REPOSITORY) $(OUTPUT_DIR)
-	$(BUILD_LIB)/helm_build.sh $(OUTPUT_DIR) $(HELM_DESTINATION_REPOSITORY)
 	# Metallb requires 2 charts. Consider this a temporary work-around.
 	$(BUILD_LIB)/helm_copy.sh $(HELM_SOURCE_REPOSITORY) metallb/crds charts/crds $(OUTPUT_DIR)
 	$(BUILD_LIB)/helm_require.sh $(HELM_SOURCE_IMAGE_REPO) metallb/crds  $(OUTPUT_DIR) $(IMAGE_TAG) $(HELM_TAG) $(PROJECT_ROOT) $(LATEST) $(HELM_USE_UPSTREAM_IMAGE) $(HELM_IMAGE_LIST)
 	$(BUILD_LIB)/helm_replace.sh metallb/crds $(OUTPUT_DIR)
 	$(BUILD_LIB)/helm_build.sh $(OUTPUT_DIR) metallb/crds
+	$(BUILD_LIB)/helm_copy.sh $(HELM_SOURCE_REPOSITORY) $(HELM_DESTINATION_REPOSITORY) $(HELM_DIRECTORY) $(OUTPUT_DIR)
+	PACKAGE_DEPENDENCIES=metallb/crds $(BUILD_LIB)/helm_require.sh $(HELM_SOURCE_IMAGE_REPO) $(HELM_DESTINATION_REPOSITORY) $(OUTPUT_DIR) $(IMAGE_TAG) $(HELM_TAG) $(PROJECT_ROOT) $(LATEST) $(HELM_USE_UPSTREAM_IMAGE) $(HELM_IMAGE_LIST)
+	$(BUILD_LIB)/helm_replace.sh $(HELM_DESTINATION_REPOSITORY) $(OUTPUT_DIR)
+	$(BUILD_LIB)/helm_build.sh $(OUTPUT_DIR) $(HELM_DESTINATION_REPOSITORY)
 
 # Build helm chart and push to registry defined in IMAGE_REPO.
 .PHONY: helm/push


### PR DESCRIPTION
*Description of changes:*
Pass the dependencies down to requires.yaml to be picked up by the bundle creation process.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
