### PR TITLE
Add 1.24 BR ova release

### DIFF
--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
@@ -9,3 +9,6 @@
 1-23:
     ova-release-version: v1.10.0
     raw-release-version: v1.10.0
+1-24:
+    ova-release-version: v1.10.0
+    raw-release-version: v1.10.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bottlerocket released their latest ova with 1.24 support 🎉

https://github.com/bottlerocket-os/bottlerocket/releases

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
