### PR TITLE
Revert 1-20 and 1-21 latest eks-d

### DIFF
--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -6,10 +6,10 @@ releases:
   number: 22
   kubeVersion: v1.19.16
 - branch: 1-20
-  number: 21
+  number: 20
   kubeVersion: v1.20.15
 - branch: 1-21
-  number: 19
+  number: 18
   kubeVersion: v1.21.14
 - branch: 1-22
   number: 11


### PR DESCRIPTION
We found an issue upgrading etcd nodes due to a bug in etcd 3.4.20 which was shipped with the latest eks-d versions.  This bug is fixed in 3.4.21 which will be included in the next eks-d releases.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
