### PR TITLE
Fix CA & Metrics Server imagePullSecrets Schema

### DIFF
--- a/projects/kubernetes-sigs/metrics-server/1-21/helm/patches/0002-Make-imagePullSecrets-top-level-value.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-21/helm/patches/0002-Make-imagePullSecrets-top-level-value.patch
@@ -1,0 +1,27 @@
+From ecd33d35d845617423858cfaebed5fda6284f732 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Tue, 18 Oct 2022 18:11:57 -0400
+Subject: [PATCH] Make imagePullSecrets top-level value
+
+---
+ charts/metrics-server/values.yaml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
+index 7583ac6..70b6f7d 100644
+--- a/charts/metrics-server/values.yaml
++++ b/charts/metrics-server/values.yaml
+@@ -8,8 +8,8 @@ image:
+   digest: {{eks-distro/kubernetes-sigs/metrics-server}}
+ 
+   pullPolicy: IfNotPresent
+-  imagePullSecrets:
+-    - regcred
++
++imagePullSecrets: []
+ 
+ nameOverride: ""
+ fullnameOverride: ""
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/kubernetes-sigs/metrics-server/1-21/helm/schema.json
+++ b/projects/kubernetes-sigs/metrics-server/1-21/helm/schema.json
@@ -55,16 +55,9 @@
             "type": "array",
             "default": [],
             "title": "The imagePullSecrets Schema",
-            "items": {
-                "type": "string",
-                "default": "",
-                "title": "A Schema",
-                "examples": [
-                    "ecr-token"
-                ]
-            },
+            "items": {},
             "examples": [
-                ["ecr-token"]
+                []
             ]
         },
         "nameOverride": {
@@ -696,9 +689,7 @@
             "digest": "sha256:46a80fd791bb08dfaa68728f50d086b09bd7a355cd0a16a075fd11eb876c2b80",
             "pullPolicy": "IfNotPresent"
         },
-        "imagePullSecrets": [
-            "ecr-token"
-        ],
+        "imagePullSecrets": [],
         "nameOverride": "",
         "fullnameOverride": "",
         "serviceAccount": {

--- a/projects/kubernetes-sigs/metrics-server/1-22/helm/patches/0002-Make-imagePullSecrets-top-level-value.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-22/helm/patches/0002-Make-imagePullSecrets-top-level-value.patch
@@ -1,0 +1,27 @@
+From ecd33d35d845617423858cfaebed5fda6284f732 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Tue, 18 Oct 2022 18:11:57 -0400
+Subject: [PATCH] Make imagePullSecrets top-level value
+
+---
+ charts/metrics-server/values.yaml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
+index 7583ac6..70b6f7d 100644
+--- a/charts/metrics-server/values.yaml
++++ b/charts/metrics-server/values.yaml
+@@ -8,8 +8,8 @@ image:
+   digest: {{eks-distro/kubernetes-sigs/metrics-server}}
+ 
+   pullPolicy: IfNotPresent
+-  imagePullSecrets:
+-    - regcred
++
++imagePullSecrets: []
+ 
+ nameOverride: ""
+ fullnameOverride: ""
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/kubernetes-sigs/metrics-server/1-22/helm/schema.json
+++ b/projects/kubernetes-sigs/metrics-server/1-22/helm/schema.json
@@ -55,16 +55,9 @@
             "type": "array",
             "default": [],
             "title": "The imagePullSecrets Schema",
-            "items": {
-                "type": "string",
-                "default": "",
-                "title": "A Schema",
-                "examples": [
-                    "ecr-token"
-                ]
-            },
+            "items": {},
             "examples": [
-                ["ecr-token"]
+                []
             ]
         },
         "nameOverride": {
@@ -696,9 +689,7 @@
             "digest": "sha256:46a80fd791bb08dfaa68728f50d086b09bd7a355cd0a16a075fd11eb876c2b80",
             "pullPolicy": "IfNotPresent"
         },
-        "imagePullSecrets": [
-            "ecr-token"
-        ],
+        "imagePullSecrets": [],
         "nameOverride": "",
         "fullnameOverride": "",
         "serviceAccount": {

--- a/projects/kubernetes-sigs/metrics-server/1-23/helm/patches/0002-Make-imagePullSecrets-top-level-value.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-23/helm/patches/0002-Make-imagePullSecrets-top-level-value.patch
@@ -1,0 +1,27 @@
+From ecd33d35d845617423858cfaebed5fda6284f732 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Tue, 18 Oct 2022 18:11:57 -0400
+Subject: [PATCH] Make imagePullSecrets top-level value
+
+---
+ charts/metrics-server/values.yaml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
+index 7583ac6..70b6f7d 100644
+--- a/charts/metrics-server/values.yaml
++++ b/charts/metrics-server/values.yaml
+@@ -8,8 +8,8 @@ image:
+   digest: {{eks-distro/kubernetes-sigs/metrics-server}}
+ 
+   pullPolicy: IfNotPresent
+-  imagePullSecrets:
+-    - regcred
++
++imagePullSecrets: []
+ 
+ nameOverride: ""
+ fullnameOverride: ""
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/kubernetes-sigs/metrics-server/1-23/helm/schema.json
+++ b/projects/kubernetes-sigs/metrics-server/1-23/helm/schema.json
@@ -55,16 +55,9 @@
             "type": "array",
             "default": [],
             "title": "The imagePullSecrets Schema",
-            "items": {
-                "type": "string",
-                "default": "",
-                "title": "A Schema",
-                "examples": [
-                    "ecr-token"
-                ]
-            },
+            "items": {},
             "examples": [
-                ["ecr-token"]
+                []
             ]
         },
         "nameOverride": {
@@ -696,9 +689,7 @@
             "digest": "sha256:46a80fd791bb08dfaa68728f50d086b09bd7a355cd0a16a075fd11eb876c2b80",
             "pullPolicy": "IfNotPresent"
         },
-        "imagePullSecrets": [
-            "ecr-token"
-        ],
+        "imagePullSecrets": [],
         "nameOverride": "",
         "fullnameOverride": "",
         "serviceAccount": {

--- a/projects/kubernetes-sigs/metrics-server/1-24/helm/patches/0002-Make-imagePullSecrets-top-level-value.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-24/helm/patches/0002-Make-imagePullSecrets-top-level-value.patch
@@ -1,0 +1,27 @@
+From ecd33d35d845617423858cfaebed5fda6284f732 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Tue, 18 Oct 2022 18:11:57 -0400
+Subject: [PATCH] Make imagePullSecrets top-level value
+
+---
+ charts/metrics-server/values.yaml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
+index 7583ac6..70b6f7d 100644
+--- a/charts/metrics-server/values.yaml
++++ b/charts/metrics-server/values.yaml
+@@ -8,8 +8,8 @@ image:
+   digest: {{eks-distro/kubernetes-sigs/metrics-server}}
+ 
+   pullPolicy: IfNotPresent
+-  imagePullSecrets:
+-    - regcred
++
++imagePullSecrets: []
+ 
+ nameOverride: ""
+ fullnameOverride: ""
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/kubernetes-sigs/metrics-server/1-24/helm/schema.json
+++ b/projects/kubernetes-sigs/metrics-server/1-24/helm/schema.json
@@ -55,16 +55,9 @@
             "type": "array",
             "default": [],
             "title": "The imagePullSecrets Schema",
-            "items": {
-                "type": "string",
-                "default": "",
-                "title": "A Schema",
-                "examples": [
-                    "ecr-token"
-                ]
-            },
+            "items": {},
             "examples": [
-                ["ecr-token"]
+                []
             ]
         },
         "nameOverride": {
@@ -696,9 +689,7 @@
             "digest": "sha256:46a80fd791bb08dfaa68728f50d086b09bd7a355cd0a16a075fd11eb876c2b80",
             "pullPolicy": "IfNotPresent"
         },
-        "imagePullSecrets": [
-            "ecr-token"
-        ],
+        "imagePullSecrets": [],
         "nameOverride": "",
         "fullnameOverride": "",
         "serviceAccount": {

--- a/projects/kubernetes/autoscaler/1-21/helm/schema.json
+++ b/projects/kubernetes/autoscaler/1-21/helm/schema.json
@@ -486,16 +486,9 @@
             "type": "array",
             "default": [],
             "title": "The imagePullSecrets Schema",
-            "items": {
-                "type": "string",
-                "default": "",
-                "title": "A Schema",
-                "examples": [
-                    "ecr-token"
-                ]
-            },
+            "items": {},
             "examples": [
-                ["ecr-token"]
+                []
             ]
         },
         "kubeTargetVersionOverride": {
@@ -1015,7 +1008,7 @@
             "digest": "sha256:7264e721263a683313271d874fe80984fdbeb5b60af5e0a6c9ab2f4e8bf802c5",
             "pullPolicy": "IfNotPresent"
         },
-        "imagePullSecrets": ["ecr-token"],
+        "imagePullSecrets": [],
         "kubeTargetVersionOverride": "",
         "nameOverride": "",
         "nodeSelector": {},

--- a/projects/kubernetes/autoscaler/1-22/helm/schema.json
+++ b/projects/kubernetes/autoscaler/1-22/helm/schema.json
@@ -486,16 +486,9 @@
             "type": "array",
             "default": [],
             "title": "The imagePullSecrets Schema",
-            "items": {
-                "type": "string",
-                "default": "",
-                "title": "A Schema",
-                "examples": [
-                    "ecr-token"
-                ]
-            },
+            "items": {},
             "examples": [
-                ["ecr-token"]
+                []
             ]
         },
         "kubeTargetVersionOverride": {
@@ -1015,7 +1008,7 @@
             "digest": "sha256:7264e721263a683313271d874fe80984fdbeb5b60af5e0a6c9ab2f4e8bf802c5",
             "pullPolicy": "IfNotPresent"
         },
-        "imagePullSecrets": ["ecr-token"],
+        "imagePullSecrets": [],
         "kubeTargetVersionOverride": "",
         "nameOverride": "",
         "nodeSelector": {},

--- a/projects/kubernetes/autoscaler/1-23/helm/schema.json
+++ b/projects/kubernetes/autoscaler/1-23/helm/schema.json
@@ -486,16 +486,9 @@
             "type": "array",
             "default": [],
             "title": "The imagePullSecrets Schema",
-            "items": {
-                "type": "string",
-                "default": "",
-                "title": "A Schema",
-                "examples": [
-                    "ecr-token"
-                ]
-            },
+            "items": {},
             "examples": [
-                ["ecr-token"]
+                []
             ]
         },
         "kubeTargetVersionOverride": {
@@ -1015,7 +1008,7 @@
             "digest": "sha256:7264e721263a683313271d874fe80984fdbeb5b60af5e0a6c9ab2f4e8bf802c5",
             "pullPolicy": "IfNotPresent"
         },
-        "imagePullSecrets": ["ecr-token"],
+        "imagePullSecrets": [],
         "kubeTargetVersionOverride": "",
         "nameOverride": "",
         "nodeSelector": {},

--- a/projects/kubernetes/autoscaler/1-24/helm/schema.json
+++ b/projects/kubernetes/autoscaler/1-24/helm/schema.json
@@ -486,16 +486,9 @@
             "type": "array",
             "default": [],
             "title": "The imagePullSecrets Schema",
-            "items": {
-                "type": "string",
-                "default": "",
-                "title": "A Schema",
-                "examples": [
-                    "ecr-token"
-                ]
-            },
+            "items": {},
             "examples": [
-                ["ecr-token"]
+                []
             ]
         },
         "kubeTargetVersionOverride": {
@@ -1015,7 +1008,7 @@
             "digest": "sha256:7264e721263a683313271d874fe80984fdbeb5b60af5e0a6c9ab2f4e8bf802c5",
             "pullPolicy": "IfNotPresent"
         },
-        "imagePullSecrets": ["ecr-token"],
+        "imagePullSecrets": [],
         "kubeTargetVersionOverride": "",
         "nameOverride": "",
         "nodeSelector": {},


### PR DESCRIPTION
*Issue #, if available:*
Epic: https://github.com/aws/eks-anywhere/issues/3186

*Description of changes:*
The imagePullSecrets schema field was wrong before. It accepted an array of strings when it should have accepted an array of objects.

This PR resolves the issue.

There was another issue in the metrics-server helm chart where the imagePullSecrets key was under `image` instead of being a top-level key.

None of these things caused actual bugs because the controller overrides imagePullSecrets and injects it as a value to the helm chart. All the same, I'd like to make these changes to keep things tight.

I've manually verified the changes by generating a bundle locally and applying it to a cluster. With the dev bundle I've successfully applied package configs that specify `imagePullSecrets` keys with object lists.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.