### PR TITLE
Fix cert manager webhook

### DIFF
--- a/projects/cert-manager/cert-manager/helm/patches/0005-Update-cert-manager-namespace-config.patch
+++ b/projects/cert-manager/cert-manager/helm/patches/0005-Update-cert-manager-namespace-config.patch
@@ -1,0 +1,25 @@
+From 36562aee549d79bb77a4091892c37aeb30ac9b42 Mon Sep 17 00:00:00 2001
+From: Abdullahi Abdinur <acool@amazon.com>
+Date: Wed, 19 Oct 2022 08:56:39 -0700
+Subject: [PATCH 5/5] Update cert manager namespace config
+
+---
+ deploy/charts/cert-manager/templates/webhook-deployment.yaml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/deploy/charts/cert-manager/templates/webhook-deployment.yaml b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+index ea4c83dc2..16e66e67a 100644
+--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
++++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+@@ -73,7 +73,7 @@ spec:
+           {{ if or (not $config.tlsConfig) (and (not $tlsConfig.dynamic) (not $tlsConfig.filesystem) ) -}}
+           - --dynamic-serving-ca-secret-namespace=$(POD_NAMESPACE)
+           - --dynamic-serving-ca-secret-name={{ template "webhook.fullname" . }}-ca
+-          - --dynamic-serving-dns-names={{ template "webhook.fullname" . }},{{ template "webhook.fullname" . }}.{{ template "cert-manager.namespace" . }},{{ template "webhook.fullname" . }}.{{ template "cert-manager.namespace" . }}.svc{{ if .Values.webhook.url.host }},{{ .Values.webhook.url.host }}{{ end }}
++          - --dynamic-serving-dns-names={{ template "webhook.fullname" . }},{{ template "webhook.fullname" . }}.{{ include "cert-manager.namespace" . }},{{ template "webhook.fullname" . }}.{{ include "cert-manager.namespace" . }}.svc{{ if .Values.webhook.url.host }},{{ .Values.webhook.url.host }}{{ end }}
+           {{- end }}
+           {{- with .Values.webhook.extraArgs }}
+           {{- toYaml . | nindent 10 }}
+-- 
+2.37.2
+


### PR DESCRIPTION
*Description of changes:*
- cert-manager webhook doesn't currently allow the quotes on the namespace. Fixing that issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
