### PR TITLE
Remove quotes from namespace for cert-manager

### DIFF
--- a/projects/cert-manager/cert-manager/helm/patches/0004-Update-cert-manager-namespace-config.patch
+++ b/projects/cert-manager/cert-manager/helm/patches/0004-Update-cert-manager-namespace-config.patch
@@ -1,0 +1,111 @@
+From c80cce2bf365303e3fab8f7acc7404e64ed0a785 Mon Sep 17 00:00:00 2001
+From: Abdullahi Abdinur <acool@amazon.com>
+Date: Wed, 19 Oct 2022 10:58:28 -0700
+Subject: [PATCH 4/4] Update cert manager namespace config
+
+---
+ deploy/charts/cert-manager/templates/_helpers.tpl            | 2 +-
+ .../cert-manager/templates/cainjector-serviceaccount.yaml    | 4 ++--
+ deploy/charts/cert-manager/templates/serviceaccount.yaml     | 4 ++--
+ .../templates/startupapicheck-serviceaccount.yaml            | 4 ++--
+ .../cert-manager/templates/webhook-serviceaccount.yaml       | 4 ++--
+ deploy/charts/cert-manager/values.yaml                       | 5 ++++-
+ 6 files changed, 13 insertions(+), 10 deletions(-)
+
+diff --git a/deploy/charts/cert-manager/templates/_helpers.tpl b/deploy/charts/cert-manager/templates/_helpers.tpl
+index 27db39844..adfe60a05 100644
+--- a/deploy/charts/cert-manager/templates/_helpers.tpl
++++ b/deploy/charts/cert-manager/templates/_helpers.tpl
+@@ -167,5 +167,5 @@ This gets around an problem within helm discussed here
+ https://github.com/helm/helm/issues/5358
+ */}}
+ {{- define "cert-manager.namespace" -}}
+-    {{ .Values.namespace | default .Release.Namespace }}
++    {{ .Release.Namespace | default .Values.defaultNamespace}}
+ {{- end -}}
+diff --git a/deploy/charts/cert-manager/templates/cainjector-serviceaccount.yaml b/deploy/charts/cert-manager/templates/cainjector-serviceaccount.yaml
+index fedc731f8..6f2723a80 100644
+--- a/deploy/charts/cert-manager/templates/cainjector-serviceaccount.yaml
++++ b/deploy/charts/cert-manager/templates/cainjector-serviceaccount.yaml
+@@ -19,9 +19,9 @@ metadata:
+     {{- with .Values.cainjector.serviceAccount.labels }}
+       {{ toYaml . | nindent 4 }}
+     {{- end }}
+-{{- with .Values.global.imagePullSecrets }}
++{{- with .Values.imagePullSecrets }}
+ imagePullSecrets:
+-  {{- toYaml . | nindent 2 }}
++  {{- toYaml . | nindent 8 }}
+ {{- end }}
+ {{- end }}
+ {{- end }}
+diff --git a/deploy/charts/cert-manager/templates/serviceaccount.yaml b/deploy/charts/cert-manager/templates/serviceaccount.yaml
+index 6026842ff..39209cfa5 100644
+--- a/deploy/charts/cert-manager/templates/serviceaccount.yaml
++++ b/deploy/charts/cert-manager/templates/serviceaccount.yaml
+@@ -1,9 +1,9 @@
+ {{- if .Values.serviceAccount.create }}
+ apiVersion: v1
+ kind: ServiceAccount
+-{{- with .Values.global.imagePullSecrets }}
++{{- with .Values.imagePullSecrets }}
+ imagePullSecrets:
+-  {{- toYaml . | nindent 2 }}
++  {{- toYaml . | nindent 8 }}
+ {{- end }}
+ automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+ metadata:
+diff --git a/deploy/charts/cert-manager/templates/startupapicheck-serviceaccount.yaml b/deploy/charts/cert-manager/templates/startupapicheck-serviceaccount.yaml
+index 8c417604a..7d204a838 100644
+--- a/deploy/charts/cert-manager/templates/startupapicheck-serviceaccount.yaml
++++ b/deploy/charts/cert-manager/templates/startupapicheck-serviceaccount.yaml
+@@ -19,9 +19,9 @@ metadata:
+     {{- with .Values.startupapicheck.serviceAccount.labels }}
+       {{ toYaml . | nindent 4 }}
+     {{- end }}
+-{{- with .Values.global.imagePullSecrets }}
++{{- with .Values.imagePullSecrets }}
+ imagePullSecrets:
+-  {{- toYaml . | nindent 2 }}
++  {{- toYaml . | nindent 8 }}
+ {{- end }}
+ {{- end }}
+ {{- end }}
+diff --git a/deploy/charts/cert-manager/templates/webhook-serviceaccount.yaml b/deploy/charts/cert-manager/templates/webhook-serviceaccount.yaml
+index dff5c0672..eec438f38 100644
+--- a/deploy/charts/cert-manager/templates/webhook-serviceaccount.yaml
++++ b/deploy/charts/cert-manager/templates/webhook-serviceaccount.yaml
+@@ -18,8 +18,8 @@ metadata:
+     {{- with .Values.webhook.serviceAccount.labels }}
+       {{ toYaml . | nindent 4 }}
+     {{- end }}
+-{{- with .Values.global.imagePullSecrets }}
++{{- with .Values.imagePullSecrets }}
+ imagePullSecrets:
+-  {{- toYaml . | nindent 2 }}
++  {{- toYaml . | nindent 8 }}
+ {{- end }}
+ {{- end }}
+diff --git a/deploy/charts/cert-manager/values.yaml b/deploy/charts/cert-manager/values.yaml
+index c4a0cb5a2..307a760fc 100644
+--- a/deploy/charts/cert-manager/values.yaml
++++ b/deploy/charts/cert-manager/values.yaml
+@@ -3,11 +3,14 @@
+ # Declare variables to be passed into your templates.
+ namespace: "cert-manager"
+ sourceRegistry: "public.ecr.aws/eks-anywhere"
++imagePullPolicy: "IfNotPresent"
++imagePullSecrets: []
++defaultNamespace: "cert-manager"
+ global:
+   ## Reference to one or more secrets to be used when pulling images
+   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+   ##
+-  imagePullSecrets: []
++  #imagePullSecrets: []
+   # - name: "image-pull-secret"
+ 
+   # Optional priority class to be used for the cert-manager pods
+-- 
+2.37.2
+


### PR DESCRIPTION
*Description of changes:*
- Cert-manager seems to have a problem with quotes on namespace. Fixing that issue in this PR.
- Removes old patches and consolidates to one.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
