### PR TITLE
Make sourceRegistry Top Level Value

### DIFF
--- a/projects/kubernetes-sigs/metrics-server/1-21/helm/patches/0003-Make-sourceRegistry-top-level-value.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-21/helm/patches/0003-Make-sourceRegistry-top-level-value.patch
@@ -1,0 +1,41 @@
+From 88f9476520202da61c16a0d5c5701dbe2971b944 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Thu, 20 Oct 2022 07:04:58 -0400
+Subject: [PATCH] Make sourceRegistry top level value
+
+---
+ charts/metrics-server/templates/_helpers.tpl | 2 +-
+ charts/metrics-server/values.yaml            | 3 ++-
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/charts/metrics-server/templates/_helpers.tpl b/charts/metrics-server/templates/_helpers.tpl
+index 6968513..8494ca4 100644
+--- a/charts/metrics-server/templates/_helpers.tpl
++++ b/charts/metrics-server/templates/_helpers.tpl
+@@ -65,7 +65,7 @@ Create the name of the service account to use
+ The image to use
+ */}}
+ {{- define "metrics-server.image" -}}
+-{{- printf "%s/%s@%s" .Values.image.sourceRegistry .Values.image.repository .Values.image.digest }}
++{{- printf "%s/%s@%s" .Values.sourceRegistry .Values.image.repository .Values.image.digest }}
+ {{- end }}
+ 
+ {{/* Get PodDisruptionBudget API Version */}}
+diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
+index 70b6f7d..7930a5b 100644
+--- a/charts/metrics-server/values.yaml
++++ b/charts/metrics-server/values.yaml
+@@ -2,8 +2,9 @@
+ # This is a YAML-formatted file.
+ # Declare variables to be passed into your templates.
+ 
++sourceRegistry: 783794618700.dkr.ecr.us-west-2.amazonaws.com
++
+ image:
+-  sourceRegistry: public.ecr.aws/eks-anywhere
+   repository: metrics-server/eks-distro/kubernetes-sigs/metrics-server
+   digest: {{eks-distro/kubernetes-sigs/metrics-server}}
+ 
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/kubernetes-sigs/metrics-server/1-21/helm/schema.json
+++ b/projects/kubernetes-sigs/metrics-server/1-21/helm/schema.json
@@ -5,20 +5,16 @@
     "default": {},
     "title": "Metrics Server",
     "properties": {
+        "sourceRegistry": {
+            "description": "Override source registry of the helm chart.",
+            "type": "string"
+        },
         "image": {
             "type": "object",
             "default": {},
             "title": "The image Schema",
             "required": [],
             "properties": {
-                "sourceRegistry": {
-                    "type": "string",
-                    "default": "public.ecr.aws/eks-anywhere",
-                    "title": "The sourceRegistry Schema",
-                    "examples": [
-                        "public.ecr.aws/eks-anywhere"
-                    ]
-                },
                 "repository": {
                     "type": "string",
                     "default": "metrics-server/eks-distro/kubernetes-sigs/metrics-server",
@@ -45,7 +41,6 @@
                 }
             },
             "examples": [{
-                "sourceRegistry": "public.ecr.aws/eks-anywhere",
                 "repository": "metrics-server/eks-distro/kubernetes-sigs/metrics-server",
                 "digest": "sha256:46a80fd791bb08dfaa68728f50d086b09bd7a355cd0a16a075fd11eb876c2b80",
                 "pullPolicy": "IfNotPresent"
@@ -683,8 +678,8 @@
         }
     },
     "examples": [{
+        "sourceRegistry": "public.ecr.aws/eks-anywhere",
         "image": {
-            "sourceRegistry": "public.ecr.aws/eks-anywhere",
             "repository": "metrics-server/eks-distro/kubernetes-sigs/metrics-server",
             "digest": "sha256:46a80fd791bb08dfaa68728f50d086b09bd7a355cd0a16a075fd11eb876c2b80",
             "pullPolicy": "IfNotPresent"

--- a/projects/kubernetes-sigs/metrics-server/1-22/helm/patches/0003-Make-sourceRegistry-top-level-value.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-22/helm/patches/0003-Make-sourceRegistry-top-level-value.patch
@@ -1,0 +1,41 @@
+From 88f9476520202da61c16a0d5c5701dbe2971b944 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Thu, 20 Oct 2022 07:04:58 -0400
+Subject: [PATCH] Make sourceRegistry top level value
+
+---
+ charts/metrics-server/templates/_helpers.tpl | 2 +-
+ charts/metrics-server/values.yaml            | 3 ++-
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/charts/metrics-server/templates/_helpers.tpl b/charts/metrics-server/templates/_helpers.tpl
+index 6968513..8494ca4 100644
+--- a/charts/metrics-server/templates/_helpers.tpl
++++ b/charts/metrics-server/templates/_helpers.tpl
+@@ -65,7 +65,7 @@ Create the name of the service account to use
+ The image to use
+ */}}
+ {{- define "metrics-server.image" -}}
+-{{- printf "%s/%s@%s" .Values.image.sourceRegistry .Values.image.repository .Values.image.digest }}
++{{- printf "%s/%s@%s" .Values.sourceRegistry .Values.image.repository .Values.image.digest }}
+ {{- end }}
+ 
+ {{/* Get PodDisruptionBudget API Version */}}
+diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
+index 70b6f7d..7930a5b 100644
+--- a/charts/metrics-server/values.yaml
++++ b/charts/metrics-server/values.yaml
+@@ -2,8 +2,9 @@
+ # This is a YAML-formatted file.
+ # Declare variables to be passed into your templates.
+ 
++sourceRegistry: 783794618700.dkr.ecr.us-west-2.amazonaws.com
++
+ image:
+-  sourceRegistry: public.ecr.aws/eks-anywhere
+   repository: metrics-server/eks-distro/kubernetes-sigs/metrics-server
+   digest: {{eks-distro/kubernetes-sigs/metrics-server}}
+ 
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/kubernetes-sigs/metrics-server/1-22/helm/schema.json
+++ b/projects/kubernetes-sigs/metrics-server/1-22/helm/schema.json
@@ -5,20 +5,16 @@
     "default": {},
     "title": "Metrics Server",
     "properties": {
+        "sourceRegistry": {
+            "description": "Override source registry of the helm chart.",
+            "type": "string"
+        },
         "image": {
             "type": "object",
             "default": {},
             "title": "The image Schema",
             "required": [],
             "properties": {
-                "sourceRegistry": {
-                    "type": "string",
-                    "default": "public.ecr.aws/eks-anywhere",
-                    "title": "The sourceRegistry Schema",
-                    "examples": [
-                        "public.ecr.aws/eks-anywhere"
-                    ]
-                },
                 "repository": {
                     "type": "string",
                     "default": "metrics-server/eks-distro/kubernetes-sigs/metrics-server",
@@ -45,7 +41,6 @@
                 }
             },
             "examples": [{
-                "sourceRegistry": "public.ecr.aws/eks-anywhere",
                 "repository": "metrics-server/eks-distro/kubernetes-sigs/metrics-server",
                 "digest": "sha256:46a80fd791bb08dfaa68728f50d086b09bd7a355cd0a16a075fd11eb876c2b80",
                 "pullPolicy": "IfNotPresent"
@@ -683,8 +678,8 @@
         }
     },
     "examples": [{
+        "sourceRegistry": "public.ecr.aws/eks-anywhere",
         "image": {
-            "sourceRegistry": "public.ecr.aws/eks-anywhere",
             "repository": "metrics-server/eks-distro/kubernetes-sigs/metrics-server",
             "digest": "sha256:46a80fd791bb08dfaa68728f50d086b09bd7a355cd0a16a075fd11eb876c2b80",
             "pullPolicy": "IfNotPresent"

--- a/projects/kubernetes-sigs/metrics-server/1-23/helm/patches/0003-Make-sourceRegistry-top-level-value.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-23/helm/patches/0003-Make-sourceRegistry-top-level-value.patch
@@ -1,0 +1,41 @@
+From 88f9476520202da61c16a0d5c5701dbe2971b944 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Thu, 20 Oct 2022 07:04:58 -0400
+Subject: [PATCH] Make sourceRegistry top level value
+
+---
+ charts/metrics-server/templates/_helpers.tpl | 2 +-
+ charts/metrics-server/values.yaml            | 3 ++-
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/charts/metrics-server/templates/_helpers.tpl b/charts/metrics-server/templates/_helpers.tpl
+index 6968513..8494ca4 100644
+--- a/charts/metrics-server/templates/_helpers.tpl
++++ b/charts/metrics-server/templates/_helpers.tpl
+@@ -65,7 +65,7 @@ Create the name of the service account to use
+ The image to use
+ */}}
+ {{- define "metrics-server.image" -}}
+-{{- printf "%s/%s@%s" .Values.image.sourceRegistry .Values.image.repository .Values.image.digest }}
++{{- printf "%s/%s@%s" .Values.sourceRegistry .Values.image.repository .Values.image.digest }}
+ {{- end }}
+ 
+ {{/* Get PodDisruptionBudget API Version */}}
+diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
+index 70b6f7d..7930a5b 100644
+--- a/charts/metrics-server/values.yaml
++++ b/charts/metrics-server/values.yaml
+@@ -2,8 +2,9 @@
+ # This is a YAML-formatted file.
+ # Declare variables to be passed into your templates.
+ 
++sourceRegistry: 783794618700.dkr.ecr.us-west-2.amazonaws.com
++
+ image:
+-  sourceRegistry: public.ecr.aws/eks-anywhere
+   repository: metrics-server/eks-distro/kubernetes-sigs/metrics-server
+   digest: {{eks-distro/kubernetes-sigs/metrics-server}}
+ 
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/kubernetes-sigs/metrics-server/1-23/helm/schema.json
+++ b/projects/kubernetes-sigs/metrics-server/1-23/helm/schema.json
@@ -5,20 +5,16 @@
     "default": {},
     "title": "Metrics Server",
     "properties": {
+        "sourceRegistry": {
+            "description": "Override source registry of the helm chart.",
+            "type": "string"
+        },
         "image": {
             "type": "object",
             "default": {},
             "title": "The image Schema",
             "required": [],
             "properties": {
-                "sourceRegistry": {
-                    "type": "string",
-                    "default": "public.ecr.aws/eks-anywhere",
-                    "title": "The sourceRegistry Schema",
-                    "examples": [
-                        "public.ecr.aws/eks-anywhere"
-                    ]
-                },
                 "repository": {
                     "type": "string",
                     "default": "metrics-server/eks-distro/kubernetes-sigs/metrics-server",
@@ -45,7 +41,6 @@
                 }
             },
             "examples": [{
-                "sourceRegistry": "public.ecr.aws/eks-anywhere",
                 "repository": "metrics-server/eks-distro/kubernetes-sigs/metrics-server",
                 "digest": "sha256:46a80fd791bb08dfaa68728f50d086b09bd7a355cd0a16a075fd11eb876c2b80",
                 "pullPolicy": "IfNotPresent"
@@ -683,8 +678,8 @@
         }
     },
     "examples": [{
+        "sourceRegistry": "public.ecr.aws/eks-anywhere",
         "image": {
-            "sourceRegistry": "public.ecr.aws/eks-anywhere",
             "repository": "metrics-server/eks-distro/kubernetes-sigs/metrics-server",
             "digest": "sha256:46a80fd791bb08dfaa68728f50d086b09bd7a355cd0a16a075fd11eb876c2b80",
             "pullPolicy": "IfNotPresent"

--- a/projects/kubernetes-sigs/metrics-server/1-24/helm/patches/0003-Make-sourceRegistry-top-level-value.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-24/helm/patches/0003-Make-sourceRegistry-top-level-value.patch
@@ -1,0 +1,41 @@
+From 88f9476520202da61c16a0d5c5701dbe2971b944 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Thu, 20 Oct 2022 07:04:58 -0400
+Subject: [PATCH] Make sourceRegistry top level value
+
+---
+ charts/metrics-server/templates/_helpers.tpl | 2 +-
+ charts/metrics-server/values.yaml            | 3 ++-
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/charts/metrics-server/templates/_helpers.tpl b/charts/metrics-server/templates/_helpers.tpl
+index 6968513..8494ca4 100644
+--- a/charts/metrics-server/templates/_helpers.tpl
++++ b/charts/metrics-server/templates/_helpers.tpl
+@@ -65,7 +65,7 @@ Create the name of the service account to use
+ The image to use
+ */}}
+ {{- define "metrics-server.image" -}}
+-{{- printf "%s/%s@%s" .Values.image.sourceRegistry .Values.image.repository .Values.image.digest }}
++{{- printf "%s/%s@%s" .Values.sourceRegistry .Values.image.repository .Values.image.digest }}
+ {{- end }}
+ 
+ {{/* Get PodDisruptionBudget API Version */}}
+diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
+index 70b6f7d..7930a5b 100644
+--- a/charts/metrics-server/values.yaml
++++ b/charts/metrics-server/values.yaml
+@@ -2,8 +2,9 @@
+ # This is a YAML-formatted file.
+ # Declare variables to be passed into your templates.
+ 
++sourceRegistry: 783794618700.dkr.ecr.us-west-2.amazonaws.com
++
+ image:
+-  sourceRegistry: public.ecr.aws/eks-anywhere
+   repository: metrics-server/eks-distro/kubernetes-sigs/metrics-server
+   digest: {{eks-distro/kubernetes-sigs/metrics-server}}
+ 
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/kubernetes-sigs/metrics-server/1-24/helm/schema.json
+++ b/projects/kubernetes-sigs/metrics-server/1-24/helm/schema.json
@@ -5,20 +5,16 @@
     "default": {},
     "title": "Metrics Server",
     "properties": {
+        "sourceRegistry": {
+            "description": "Override source registry of the helm chart.",
+            "type": "string"
+        },
         "image": {
             "type": "object",
             "default": {},
             "title": "The image Schema",
             "required": [],
             "properties": {
-                "sourceRegistry": {
-                    "type": "string",
-                    "default": "public.ecr.aws/eks-anywhere",
-                    "title": "The sourceRegistry Schema",
-                    "examples": [
-                        "public.ecr.aws/eks-anywhere"
-                    ]
-                },
                 "repository": {
                     "type": "string",
                     "default": "metrics-server/eks-distro/kubernetes-sigs/metrics-server",
@@ -45,7 +41,6 @@
                 }
             },
             "examples": [{
-                "sourceRegistry": "public.ecr.aws/eks-anywhere",
                 "repository": "metrics-server/eks-distro/kubernetes-sigs/metrics-server",
                 "digest": "sha256:46a80fd791bb08dfaa68728f50d086b09bd7a355cd0a16a075fd11eb876c2b80",
                 "pullPolicy": "IfNotPresent"
@@ -683,8 +678,8 @@
         }
     },
     "examples": [{
+        "sourceRegistry": "public.ecr.aws/eks-anywhere",
         "image": {
-            "sourceRegistry": "public.ecr.aws/eks-anywhere",
             "repository": "metrics-server/eks-distro/kubernetes-sigs/metrics-server",
             "digest": "sha256:46a80fd791bb08dfaa68728f50d086b09bd7a355cd0a16a075fd11eb876c2b80",
             "pullPolicy": "IfNotPresent"

--- a/projects/kubernetes/autoscaler/1-21/helm/patches/0006-Make-sourceRegistry-top-level-value.patch
+++ b/projects/kubernetes/autoscaler/1-21/helm/patches/0006-Make-sourceRegistry-top-level-value.patch
@@ -1,0 +1,43 @@
+From 0f2973cbefb62ccd02b86ffd291a3601eece8757 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Thu, 20 Oct 2022 07:19:14 -0400
+Subject: [PATCH] Make sourceRegistry top level value
+
+---
+ charts/cluster-autoscaler/templates/deployment.yaml | 2 +-
+ charts/cluster-autoscaler/values.yaml               | 5 +++--
+ 2 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/charts/cluster-autoscaler/templates/deployment.yaml b/charts/cluster-autoscaler/templates/deployment.yaml
+index 5cfca0daf..8f743f4f6 100644
+--- a/charts/cluster-autoscaler/templates/deployment.yaml
++++ b/charts/cluster-autoscaler/templates/deployment.yaml
+@@ -48,7 +48,7 @@ spec:
+       {{- end }}
+       containers:
+         - name: {{ template "cluster-autoscaler.name" . }}
+-          image: "{{ .Values.image.sourceRegistry }}/{{ .Values.image.repository }}@{{ .Values.image.digest }}"
++          image: "{{ .Values.sourceRegistry }}/{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+           command:
+             - ./cluster-autoscaler
+diff --git a/charts/cluster-autoscaler/values.yaml b/charts/cluster-autoscaler/values.yaml
+index f88d5e60d..08ad944ab 100644
+--- a/charts/cluster-autoscaler/values.yaml
++++ b/charts/cluster-autoscaler/values.yaml
+@@ -229,9 +229,10 @@ extraVolumeMounts: []
+ # fullnameOverride -- String to fully override `cluster-autoscaler.fullname` template.
+ fullnameOverride: ""
+ 
++# sourceRegistry -- Image registry
++sourceRegistry: 783794618700.dkr.ecr.us-west-2.amazonaws.com
++
+ image:
+-  # image.sourceRegistry -- Image registry
+-  sourceRegistry: public.ecr.aws/eks-anywhere
+   # image.repository -- Image repository
+   repository: kubernetes/autoscaler
+   # image.digest -- Image digest
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/kubernetes/autoscaler/1-21/helm/schema.json
+++ b/projects/kubernetes/autoscaler/1-21/helm/schema.json
@@ -436,20 +436,16 @@
                 ""
             ]
         },
+        "sourceRegistry": {
+            "description": "Override source registry of the helm chart.",
+            "type": "string"
+        },
         "image": {
             "type": "object",
             "default": {},
             "title": "The image Schema",
             "required": [],
             "properties": {
-                "sourceRegistry": {
-                    "type": "string",
-                    "default": "public.ecr.aws",
-                    "title": "The sourceRegistry Schema",
-                    "examples": [
-                        "public.ecr.aws"
-                    ]
-                },
                 "repository": {
                     "type": "string",
                     "default": "kubernetes/autoscaler",
@@ -476,7 +472,6 @@
                 }
             },
             "examples": [{
-                "sourceRegistry": "public.ecr.aws",
                 "repository": "kubernetes/autoscaler",
                 "digest": "sha256:7264e721263a683313271d874fe80984fdbeb5b60af5e0a6c9ab2f4e8bf802c5",
                 "pullPolicy": "IfNotPresent"
@@ -1002,8 +997,8 @@
         "extraVolumes": [],
         "extraVolumeMounts": [],
         "fullnameOverride": "",
+        "sourceRegistry": "public.ecr.aws",
         "image": {
-            "sourceRegistry": "public.ecr.aws",
             "repository": "kubernetes/autoscaler",
             "digest": "sha256:7264e721263a683313271d874fe80984fdbeb5b60af5e0a6c9ab2f4e8bf802c5",
             "pullPolicy": "IfNotPresent"

--- a/projects/kubernetes/autoscaler/1-22/helm/patches/0006-Make-sourceRegistry-top-level-value.patch
+++ b/projects/kubernetes/autoscaler/1-22/helm/patches/0006-Make-sourceRegistry-top-level-value.patch
@@ -1,0 +1,43 @@
+From 0f2973cbefb62ccd02b86ffd291a3601eece8757 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Thu, 20 Oct 2022 07:19:14 -0400
+Subject: [PATCH] Make sourceRegistry top level value
+
+---
+ charts/cluster-autoscaler/templates/deployment.yaml | 2 +-
+ charts/cluster-autoscaler/values.yaml               | 5 +++--
+ 2 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/charts/cluster-autoscaler/templates/deployment.yaml b/charts/cluster-autoscaler/templates/deployment.yaml
+index 5cfca0daf..8f743f4f6 100644
+--- a/charts/cluster-autoscaler/templates/deployment.yaml
++++ b/charts/cluster-autoscaler/templates/deployment.yaml
+@@ -48,7 +48,7 @@ spec:
+       {{- end }}
+       containers:
+         - name: {{ template "cluster-autoscaler.name" . }}
+-          image: "{{ .Values.image.sourceRegistry }}/{{ .Values.image.repository }}@{{ .Values.image.digest }}"
++          image: "{{ .Values.sourceRegistry }}/{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+           command:
+             - ./cluster-autoscaler
+diff --git a/charts/cluster-autoscaler/values.yaml b/charts/cluster-autoscaler/values.yaml
+index f88d5e60d..08ad944ab 100644
+--- a/charts/cluster-autoscaler/values.yaml
++++ b/charts/cluster-autoscaler/values.yaml
+@@ -229,9 +229,10 @@ extraVolumeMounts: []
+ # fullnameOverride -- String to fully override `cluster-autoscaler.fullname` template.
+ fullnameOverride: ""
+ 
++# sourceRegistry -- Image registry
++sourceRegistry: 783794618700.dkr.ecr.us-west-2.amazonaws.com
++
+ image:
+-  # image.sourceRegistry -- Image registry
+-  sourceRegistry: public.ecr.aws/eks-anywhere
+   # image.repository -- Image repository
+   repository: kubernetes/autoscaler
+   # image.digest -- Image digest
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/kubernetes/autoscaler/1-22/helm/schema.json
+++ b/projects/kubernetes/autoscaler/1-22/helm/schema.json
@@ -436,20 +436,16 @@
                 ""
             ]
         },
+        "sourceRegistry": {
+            "description": "Override source registry of the helm chart.",
+            "type": "string"
+        },
         "image": {
             "type": "object",
             "default": {},
             "title": "The image Schema",
             "required": [],
             "properties": {
-                "sourceRegistry": {
-                    "type": "string",
-                    "default": "public.ecr.aws",
-                    "title": "The sourceRegistry Schema",
-                    "examples": [
-                        "public.ecr.aws"
-                    ]
-                },
                 "repository": {
                     "type": "string",
                     "default": "kubernetes/autoscaler",
@@ -476,7 +472,6 @@
                 }
             },
             "examples": [{
-                "sourceRegistry": "public.ecr.aws",
                 "repository": "kubernetes/autoscaler",
                 "digest": "sha256:7264e721263a683313271d874fe80984fdbeb5b60af5e0a6c9ab2f4e8bf802c5",
                 "pullPolicy": "IfNotPresent"
@@ -1002,8 +997,8 @@
         "extraVolumes": [],
         "extraVolumeMounts": [],
         "fullnameOverride": "",
+        "sourceRegistry": "public.ecr.aws",
         "image": {
-            "sourceRegistry": "public.ecr.aws",
             "repository": "kubernetes/autoscaler",
             "digest": "sha256:7264e721263a683313271d874fe80984fdbeb5b60af5e0a6c9ab2f4e8bf802c5",
             "pullPolicy": "IfNotPresent"

--- a/projects/kubernetes/autoscaler/1-23/helm/patches/0006-Make-sourceRegistry-top-level-value.patch
+++ b/projects/kubernetes/autoscaler/1-23/helm/patches/0006-Make-sourceRegistry-top-level-value.patch
@@ -1,0 +1,43 @@
+From 0f2973cbefb62ccd02b86ffd291a3601eece8757 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Thu, 20 Oct 2022 07:19:14 -0400
+Subject: [PATCH] Make sourceRegistry top level value
+
+---
+ charts/cluster-autoscaler/templates/deployment.yaml | 2 +-
+ charts/cluster-autoscaler/values.yaml               | 5 +++--
+ 2 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/charts/cluster-autoscaler/templates/deployment.yaml b/charts/cluster-autoscaler/templates/deployment.yaml
+index 5cfca0daf..8f743f4f6 100644
+--- a/charts/cluster-autoscaler/templates/deployment.yaml
++++ b/charts/cluster-autoscaler/templates/deployment.yaml
+@@ -48,7 +48,7 @@ spec:
+       {{- end }}
+       containers:
+         - name: {{ template "cluster-autoscaler.name" . }}
+-          image: "{{ .Values.image.sourceRegistry }}/{{ .Values.image.repository }}@{{ .Values.image.digest }}"
++          image: "{{ .Values.sourceRegistry }}/{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+           command:
+             - ./cluster-autoscaler
+diff --git a/charts/cluster-autoscaler/values.yaml b/charts/cluster-autoscaler/values.yaml
+index f88d5e60d..08ad944ab 100644
+--- a/charts/cluster-autoscaler/values.yaml
++++ b/charts/cluster-autoscaler/values.yaml
+@@ -229,9 +229,10 @@ extraVolumeMounts: []
+ # fullnameOverride -- String to fully override `cluster-autoscaler.fullname` template.
+ fullnameOverride: ""
+ 
++# sourceRegistry -- Image registry
++sourceRegistry: 783794618700.dkr.ecr.us-west-2.amazonaws.com
++
+ image:
+-  # image.sourceRegistry -- Image registry
+-  sourceRegistry: public.ecr.aws/eks-anywhere
+   # image.repository -- Image repository
+   repository: kubernetes/autoscaler
+   # image.digest -- Image digest
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/kubernetes/autoscaler/1-23/helm/schema.json
+++ b/projects/kubernetes/autoscaler/1-23/helm/schema.json
@@ -436,20 +436,16 @@
                 ""
             ]
         },
+        "sourceRegistry": {
+            "description": "Override source registry of the helm chart.",
+            "type": "string"
+        },
         "image": {
             "type": "object",
             "default": {},
             "title": "The image Schema",
             "required": [],
             "properties": {
-                "sourceRegistry": {
-                    "type": "string",
-                    "default": "public.ecr.aws",
-                    "title": "The sourceRegistry Schema",
-                    "examples": [
-                        "public.ecr.aws"
-                    ]
-                },
                 "repository": {
                     "type": "string",
                     "default": "kubernetes/autoscaler",
@@ -476,7 +472,6 @@
                 }
             },
             "examples": [{
-                "sourceRegistry": "public.ecr.aws",
                 "repository": "kubernetes/autoscaler",
                 "digest": "sha256:7264e721263a683313271d874fe80984fdbeb5b60af5e0a6c9ab2f4e8bf802c5",
                 "pullPolicy": "IfNotPresent"
@@ -1002,8 +997,8 @@
         "extraVolumes": [],
         "extraVolumeMounts": [],
         "fullnameOverride": "",
+        "sourceRegistry": "public.ecr.aws",
         "image": {
-            "sourceRegistry": "public.ecr.aws",
             "repository": "kubernetes/autoscaler",
             "digest": "sha256:7264e721263a683313271d874fe80984fdbeb5b60af5e0a6c9ab2f4e8bf802c5",
             "pullPolicy": "IfNotPresent"

--- a/projects/kubernetes/autoscaler/1-24/helm/patches/0006-Make-sourceRegistry-top-level-value.patch
+++ b/projects/kubernetes/autoscaler/1-24/helm/patches/0006-Make-sourceRegistry-top-level-value.patch
@@ -1,0 +1,43 @@
+From 0f2973cbefb62ccd02b86ffd291a3601eece8757 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Thu, 20 Oct 2022 07:19:14 -0400
+Subject: [PATCH] Make sourceRegistry top level value
+
+---
+ charts/cluster-autoscaler/templates/deployment.yaml | 2 +-
+ charts/cluster-autoscaler/values.yaml               | 5 +++--
+ 2 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/charts/cluster-autoscaler/templates/deployment.yaml b/charts/cluster-autoscaler/templates/deployment.yaml
+index 5cfca0daf..8f743f4f6 100644
+--- a/charts/cluster-autoscaler/templates/deployment.yaml
++++ b/charts/cluster-autoscaler/templates/deployment.yaml
+@@ -48,7 +48,7 @@ spec:
+       {{- end }}
+       containers:
+         - name: {{ template "cluster-autoscaler.name" . }}
+-          image: "{{ .Values.image.sourceRegistry }}/{{ .Values.image.repository }}@{{ .Values.image.digest }}"
++          image: "{{ .Values.sourceRegistry }}/{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
+           command:
+             - ./cluster-autoscaler
+diff --git a/charts/cluster-autoscaler/values.yaml b/charts/cluster-autoscaler/values.yaml
+index f88d5e60d..08ad944ab 100644
+--- a/charts/cluster-autoscaler/values.yaml
++++ b/charts/cluster-autoscaler/values.yaml
+@@ -229,9 +229,10 @@ extraVolumeMounts: []
+ # fullnameOverride -- String to fully override `cluster-autoscaler.fullname` template.
+ fullnameOverride: ""
+ 
++# sourceRegistry -- Image registry
++sourceRegistry: 783794618700.dkr.ecr.us-west-2.amazonaws.com
++
+ image:
+-  # image.sourceRegistry -- Image registry
+-  sourceRegistry: public.ecr.aws/eks-anywhere
+   # image.repository -- Image repository
+   repository: kubernetes/autoscaler
+   # image.digest -- Image digest
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/kubernetes/autoscaler/1-24/helm/schema.json
+++ b/projects/kubernetes/autoscaler/1-24/helm/schema.json
@@ -436,20 +436,16 @@
                 ""
             ]
         },
+        "sourceRegistry": {
+            "description": "Override source registry of the helm chart.",
+            "type": "string"
+        },
         "image": {
             "type": "object",
             "default": {},
             "title": "The image Schema",
             "required": [],
             "properties": {
-                "sourceRegistry": {
-                    "type": "string",
-                    "default": "public.ecr.aws",
-                    "title": "The sourceRegistry Schema",
-                    "examples": [
-                        "public.ecr.aws"
-                    ]
-                },
                 "repository": {
                     "type": "string",
                     "default": "kubernetes/autoscaler",
@@ -476,7 +472,6 @@
                 }
             },
             "examples": [{
-                "sourceRegistry": "public.ecr.aws",
                 "repository": "kubernetes/autoscaler",
                 "digest": "sha256:7264e721263a683313271d874fe80984fdbeb5b60af5e0a6c9ab2f4e8bf802c5",
                 "pullPolicy": "IfNotPresent"
@@ -1002,8 +997,8 @@
         "extraVolumes": [],
         "extraVolumeMounts": [],
         "fullnameOverride": "",
+        "sourceRegistry": "public.ecr.aws",
         "image": {
-            "sourceRegistry": "public.ecr.aws",
             "repository": "kubernetes/autoscaler",
             "digest": "sha256:7264e721263a683313271d874fe80984fdbeb5b60af5e0a6c9ab2f4e8bf802c5",
             "pullPolicy": "IfNotPresent"


### PR DESCRIPTION
*Description of changes:*
Fixes a bug in cluster-autoscaler and metrics-server packages.

The previous registry key was image.sourceRegistry when it should have been sourceRegistry.

Additionally, the default image registry was set to a public AWS registry when it should have pointed to 7837 account.

Because of these two things together, the controller did not override the registry with the prod account and instead tried to pull images from the public eks-anywhere account, which did not contain the images.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Manually tested by building both packages locally and creating bundle locally. Successfully installed both packages on a dev cluster pointing to prod account with the chart image sha's overwritten to point at image shas in the production account.

Additionally verified that the new schema.json sourceRegistry field works correctly.
<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->