### PR TITLE
Sync ipaddresspool caps with upstream

### DIFF
--- a/projects/metallb/metallb/helm/schema.json
+++ b/projects/metallb/metallb/helm/schema.json
@@ -58,11 +58,11 @@
       "description": "L2Advertisement allows to advertise the LoadBalancer IPs provided by the selected pools via L2.",
       "type": "object",
       "required": [
-        "IPAddressPools"
+        "ipAddressPools"
       ],
       "additionalProperties": false,
       "properties": {
-        "IPAddressPools": {
+        "ipAddressPools": {
           "description": "The list of IPAddressPools to advertise via this advertisement, selected by name.",
           "items": {
             "type": "string"
@@ -79,7 +79,7 @@
       "description": "BGPAdvertisement allows to advertise the IPs coming from the selected IPAddressPools via BGP, setting the parameters of the BGP Advertisement.",
       "type": "object",
       "required": [
-        "IPAddressPools"
+        "ipAddressPools"
       ],
       "additionalProperties": false,
       "type": "object",
@@ -91,14 +91,12 @@
         "aggregationLength": {
           "default": 32,
           "description": "The aggregation-length advertisement option lets you “roll up” the /32s into a larger prefix. Defaults to 32. Works for IPv4 addresses.",
-          "format": "int32",
           "minimum": 1,
           "type": "integer"
         },
         "aggregationLengthV6": {
           "default": 128,
           "description": "The aggregation-length advertisement option lets you “roll up” the /128s into a larger prefix. Defaults to 128. Works for IPv6 addresses.",
-          "format": "int32",
           "type": "integer"
         },
         "communities": {
@@ -108,7 +106,7 @@
           },
           "type": "array"
         },
-        "IPAddressPools": {
+        "ipAddressPools": {
           "description": "The list of IPAddressPools to advertise via this advertisement, selected by name.",
           "items": {
             "type": "string"
@@ -117,7 +115,6 @@
         },
         "localPref": {
           "description": "The BGP LOCAL_PREF attribute which is used by BGP best path algorithm, Path with higher localpref is preferred over one with lower localpref.",
-          "format": "int32",
           "type": "integer"
         },
         "peers": {
@@ -139,10 +136,6 @@
       ],
       "type": "object",
       "properties": {
-        "bfdProfile": {
-          "description": "The name of the BFD Profile to be used for the BFD session associated to the BGP session. If not set, the BFD session won't be set up.",
-          "type": "string"
-        },
         "holdTime": {
           "description": "Requested BGP hold time, per RFC4271.",
           "type": "string"
@@ -153,7 +146,6 @@
         },
         "myASN": {
           "description": "AS number to use for the local end of the session.",
-          "format": "int32",
           "maximum": 4294967295,
           "minimum": 0,
           "type": "integer"
@@ -164,7 +156,6 @@
         },
         "peerASN": {
           "description": "AS number to expect from the remote end of the session.",
-          "format": "int32",
           "maximum": 4294967295,
           "minimum": 0,
           "type": "integer"


### PR DESCRIPTION
*Description of changes:*
remove BFD due to no FRR
Remove format int32 for testing with ajv


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
