### PR TITLE
Bump BR release version

### DIFF
--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
@@ -1,14 +1,14 @@
 1-20:
-    ova-release-version: v1.10.0
+    ova-release-version: v1.10.1
 1-21:
-    ova-release-version: v1.10.0
-    raw-release-version: v1.10.0
+    ova-release-version: v1.10.1
+    raw-release-version: v1.10.1
 1-22:
-    ova-release-version: v1.10.0
-    raw-release-version: v1.10.0
+    ova-release-version: v1.10.1
+    raw-release-version: v1.10.1
 1-23:
-    ova-release-version: v1.10.0
-    raw-release-version: v1.10.0
+    ova-release-version: v1.10.1
+    raw-release-version: v1.10.1
 1-24:
-    ova-release-version: v1.10.0
-    raw-release-version: v1.10.0
+    ova-release-version: v1.10.1
+    raw-release-version: v1.10.1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bumping BR version to point to latest release https://github.com/bottlerocket-os/bottlerocket/releases/tag/v1.10.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
