### PR TITLE
Update staging_buildspec project name handling

### DIFF
--- a/build/lib/generate_staging_buildspec.sh
+++ b/build/lib/generate_staging_buildspec.sh
@@ -45,7 +45,7 @@ yq eval --null-input '.batch={"fast-fail":true,"build-graph":[]}' > $STAGING_BUI
 PROJECTS=(${ALL_PROJECTS// / })
 for project in "${PROJECTS[@]}"; do
     org=$(cut -d_ -f1 <<< $project)
-    repo=$(cut -d_ -f2 <<< $project)
+    repo=$(cut -d_ -f2- <<< $project)
 
     PROJECT_PATH=$MAKE_ROOT/projects/$org/$repo
 


### PR DESCRIPTION
For repo, we will take the entire substring after the first occurrence of underscore. This is to handle a use case of where the repo name itself contains an underscore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
