### PR TITLE
Use proper Make target for EKS-A admin image build

### DIFF
--- a/projects/aws/eks-a-admin-image/Makefile
+++ b/projects/aws/eks-a-admin-image/Makefile
@@ -12,7 +12,7 @@ REPO=eks-a-admin-image
 REPO_OWNER=aws
 
 BUILD_TARGETS=validate
-RELEASE_TARGETS=validate-release-manifest-version eksa-latest-snow-raw-image
+RELEASE_TARGETS=validate-release-manifest-version latest-snow-raw-image
 
 PACKER_VERSION=1.8.0
 


### PR DESCRIPTION
PR #1456 referenced a new Make target that is not available in the Makefile.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
