### PR TITLE
Prune all unused images, not just dangling ones

### DIFF
--- a/projects/aws/eks-a-admin-image/provisioners/download_eksa_artifacts.sh
+++ b/projects/aws/eks-a-admin-image/provisioners/download_eksa_artifacts.sh
@@ -19,8 +19,8 @@ sudo chmod -R a+r $ARTIFACTS_NAME_DIR
 
 # The download images command pulls down all the images in the bundle
 # but after the images get saved to a tar archive, the images are still
-# in the local Docker runtime, that bloats the final admin image. This can cause
-# downstream resource heavy operations to fail due to lack of disk space.
-# To mitigate this, we prune all the images and unused volumes to bring down
-# size of the admin image.
-sudo docker system prune --volumes --force
+# in the local Docker runtime, that bloats the final admin image. This can
+# cause downstream resource heavy operations to fail due to lack of disk
+# space. To mitigate this, we prune all the dangling and unused images and
+# volumes to increase the free disk space on the admin image.
+sudo docker system prune --all --volumes --force


### PR DESCRIPTION
Without the --all flag, it just prunes dangling images but there are no such images in the admin image. What we need is to prune all the unused images.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
