### PR TITLE
Fixes git fetch rate limit and build multiple binaries

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -339,6 +339,7 @@ needs-cgo-builder=$(and $(if $(filter true,$(CGO_CREATE_BINARIES)),true,),$(if $
 USE_DOCKER_FOR_CGO_BUILD?=false
 DOCKER_USE_ID_FOR_LINUX=$(shell if [ "$$(uname -s)" = "Linux" ]; then echo "-u $$(id -u $${USER}):$$(id -g $${USER})"; fi)
 GO_MOD_CACHE=$(shell source $(BUILD_LIB)/common.sh && build::common::use_go_version $(GOLANG_VERSION) > /dev/null 2>&1 && go env GOMODCACHE)
+CGO_TARGET?=
 ######################
 
 #### BUILD FLAGS ####

--- a/build/lib/simple_create_binaries.sh
+++ b/build/lib/simple_create_binaries.sh
@@ -65,7 +65,8 @@ function build::simple::binaries(){
       index=0
       for source in $SOURCE_PATTERN; do
         if [ "$(basename $source)" != "${TARGET_FILES[$index]}" ]; then
-          mv $TARGET_FILE$(basename $source) $TARGET_FILE${TARGET_FILES[$index]}
+          # in the case of multiple target files but the first is a ., we cant move . but it should already be named correctly
+          [ -f $TARGET_FILE$(basename $source) ] && mv $TARGET_FILE$(basename $source) $TARGET_FILE${TARGET_FILES[$index]}
         fi
         ((index=index+1))
       done

--- a/build/update-attribution-files/create_pr.sh
+++ b/build/update-attribution-files/create_pr.sh
@@ -23,6 +23,8 @@ fi
 
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 
+source $SCRIPT_ROOT/../lib/common.sh
+
 ORIGIN_ORG="eks-distro-pr-bot"
 UPSTREAM_ORG="aws"
 
@@ -37,7 +39,7 @@ git config remote.upstream.url >&- || git remote add upstream https://github.com
 
 # Files have already changed, stash to perform rebase
 git stash
-git fetch upstream
+retry git fetch upstream
 
 git checkout $MAIN_BRANCH
 # there will be conflicts before we are on the bots fork at this point


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- We started seeing git fetch being rate limited in presubmit
- Fix warning due to missing cgo var
- Fix building multiple binaries with one being `.`, this is needed for the snow br bootstrap changes coming

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
