### PR TITLE
Update make add-generated-help-block and attribution-files logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ clean: $(addprefix clean-project-, $(ALL_PROJECTS))
 
 .PHONY: add-generated-help-block-project-%
 add-generated-help-block-project-%:
-	$(eval PROJECT_PATH=projects/$(subst _,/,$*))
+	$(eval PROJECT_PATH=projects/$(patsubst $(firstword $(subst _, ,$*))_%,$(firstword $(subst _, ,$*))/%,$*))
 	$(MAKE) add-generated-help-block -C $(PROJECT_PATH) RELEASE_BRANCH=1-21
 
 .PHONY: add-generated-help-block
@@ -29,7 +29,7 @@ add-generated-help-block: $(addprefix add-generated-help-block-project-, $(ALL_P
 
 .PHONY: attribution-files-project-%
 attribution-files-project-%:
-	$(eval PROJECT_PATH=projects/$(subst _,/,$*))
+	$(eval PROJECT_PATH=projects/$(patsubst $(firstword $(subst _, ,$*))_%,$(firstword $(subst _, ,$*))/%,$*))
 	build/update-attribution-files/make_attribution.sh $(PROJECT_PATH) attribution
 
 .PHONY: attribution-files


### PR DESCRIPTION
While evaluating the PROJECT_PATH, instead of replacing all `_` with `/`, we will only replace the first instance of `_`. This is to help support project that contains `_` in the project name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
