### PR TITLE
Check in share AMI configuration to the repo

### DIFF
--- a/projects/kubernetes-sigs/image-builder/.gitignore
+++ b/projects/kubernetes-sigs/image-builder/.gitignore
@@ -1,4 +1,3 @@
-packer/ami/share-ami.json
 image-builder
 bottlerocket
 _output

--- a/projects/kubernetes-sigs/image-builder/packer/ami/share-ami.json
+++ b/projects/kubernetes-sigs/image-builder/packer/ami/share-ami.json
@@ -1,0 +1,6 @@
+{
+  "ami_users": "",
+  "ami_groups": "",
+  "snapshot_users": "",
+  "snapshot_groups": ""
+}


### PR DESCRIPTION
Fixing image-builder CLI for AMI builds in local environments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
