### PR TITLE
Create CNI temp directory in non-root user's home directory

### DIFF
--- a/projects/kubernetes-sigs/image-builder/build/setup_packer_configs.sh
+++ b/projects/kubernetes-sigs/image-builder/build/setup_packer_configs.sh
@@ -52,13 +52,13 @@ export CNI_VERSION=$(build::eksd_releases::get_eksd_component_version 'cni-plugi
 
 # Get CNI sha256 to validate cni plugins in image are from eks-d
 # Use sha from manfiest to validate tar and then generate sha from specific binary
-TMP_CNI="/tmp/eks-image-builder-cni"
+TMP_CNI="$HOME/tmp/eks-image-builder-cni"
 mkdir -p $TMP_CNI
 curl -o $TMP_CNI/cni-plugins.tar.gz "$PLUGINS_ASSET_BASE_URL/$CNI_VERSION/cni-plugins-linux-amd64-$CNI_VERSION.tar.gz"
 echo "$(echo $CNI_SHA | sed -E 's/.*sha256:(.*)$/\1/') $TMP_CNI/cni-plugins.tar.gz" > $TMP_CNI/cni.sha256
 sha256sum -c $TMP_CNI/cni.sha256
 tar -zxvf $TMP_CNI/cni-plugins.tar.gz -C $TMP_CNI ./host-device 
-export CNI_HOST_DEVICE_SHA256="$(sha256sum /tmp/cni/host-device | awk -F ' ' '{print $1}')"
+export CNI_HOST_DEVICE_SHA256="$(sha256sum $TMP_CNI/host-device | awk -F ' ' '{print $1}')"
 rm -rf $TMP_CNI
 
 envsubst '$CNI_SHA:$PLUGINS_ASSET_BASE_URL:$CNI_VERSION:$CNI_HOST_DEVICE_SHA256' \


### PR DESCRIPTION
On some OS's like Ubuntu, the root `tmp` directory's permissions are scoped down for other users, and we run AMI builds as non-root (`imagebuilder`) so we're creating it in that user's home directory instead.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
