### PR TITLE
Set default input values for AMI build configuration

### DIFF
--- a/projects/aws/image-builder/CHECKSUMS
+++ b/projects/aws/image-builder/CHECKSUMS
@@ -1,2 +1,2 @@
-df008c9ee65eb7f8d6cae97e27ddf006cd59f66e169787e2dfe9162f8c4a26ae  _output/bin/image-builder/linux-amd64/image-builder
-742f2a4bcf5fafe4ea296e840df465b629c827be46f66e0eaaaa72765e94568c  _output/bin/image-builder/linux-arm64/image-builder
+d4ceb19125a032e1473430273b5299e295d227d0aaa9c643c579eb4cce82222f  _output/bin/image-builder/linux-amd64/image-builder
+886c63c91f5b35f4ab9a464f096b5302e85532c1365f94af8815d31dc7448706  _output/bin/image-builder/linux-arm64/image-builder

--- a/projects/aws/image-builder/builder/constants.go
+++ b/projects/aws/image-builder/builder/constants.go
@@ -1,6 +1,14 @@
 package builder
 
 const (
-	DefaultUbuntuAMIFilterName   string = "ubuntu/images/*ubuntu-focal-20.04-amd64-server-*"
-	DefaultUbuntuAMIFilterOwners string = "679593333241"
+	DefaultUbuntuAMIFilterName    string = "ubuntu/images/*ubuntu-focal-20.04-amd64-server-*"
+	DefaultUbuntuAMIFilterOwners  string = "679593333241"
+	DefaultAMIBuildRegion         string = "us-west-2"
+	DefaultAMIBuilderInstanceType string = "t3.small"
+	DefaultAMIRootDeviceName      string = "/dev/sda1"
+	DefaultAMIVolumeSize          string = "25"
+	DefaultAMIVolumeType          string = "gp3"
+	DefaultAMICustomRoleNames     string = "/home/image-builder/eks-anywhere-build-tooling/projects/kubernetes-sigs/image-builder/ansible/roles/load_additional_files"
+	DefaultAMIAnsibleExtraVars    string = "@/home/image-builder/eks-anywhere-build-tooling/projects/kubernetes-sigs/image-builder/packer/ami/ansible_extra_vars.yaml"
+	DefaultAMIManifestOutput      string = "/home/image-builder/manifest.json"
 )

--- a/projects/aws/image-builder/cmd/build.go
+++ b/projects/aws/image-builder/cmd/build.go
@@ -157,7 +157,22 @@ func ValidateInputs(bo *builder.BuildOptions) error {
 				}
 			}
 		case builder.AMI:
-			if err = json.Unmarshal(config, &bo.AMIConfig); err != nil {
+			// Default configuration for AMI builds
+			defaultAMIConfig := &builder.AMIConfig{
+				AMIFilterName:       builder.DefaultUbuntuAMIFilterName,
+				AMIFilterOwners:     builder.DefaultUbuntuAMIFilterOwners,
+				AMIRegions:          builder.DefaultAMIBuildRegion,
+				AWSRegion:           builder.DefaultAMIBuildRegion,
+				BuilderInstanceType: builder.DefaultAMIBuilderInstanceType,
+				CustomRole:          "true",
+				CustomRoleNames:     builder.DefaultAMICustomRoleNames,
+				AnsibleExtraVars:    builder.DefaultAMIAnsibleExtraVars,
+				ManifestOutput:      builder.DefaultAMIManifestOutput,
+				RootDeviceName:      builder.DefaultAMIRootDeviceName,
+				VolumeSize:          builder.DefaultAMIVolumeSize,
+				VolumeType:          builder.DefaultAMIVolumeType,
+			}
+			if err = json.Unmarshal(config, defaultAMIConfig); err != nil {
 				return err
 			}
 			if bo.AMIConfig.CustomRole == "true" {
@@ -170,12 +185,6 @@ func ValidateInputs(bo *builder.BuildOptions) error {
 					bo.AMIConfig.CustomRoleNames = strings.Join(bo.AMIConfig.CustomRoleNameList, " ")
 					bo.AMIConfig.CustomRoleNameList = nil
 				}
-			}
-			if bo.AMIConfig.AMIFilterOwners == "" {
-				bo.AMIConfig.AMIFilterOwners = builder.DefaultUbuntuAMIFilterOwners
-			}
-			if bo.AMIConfig.AMIFilterName == "" {
-				bo.AMIConfig.AMIFilterName = builder.DefaultUbuntuAMIFilterName
 			}
 		}
 	}

--- a/projects/aws/image-builder/cmd/build_test.go
+++ b/projects/aws/image-builder/cmd/build_test.go
@@ -12,7 +12,7 @@ func TestValidateSupportedHypervisor(t *testing.T) {
 	testCases := []struct {
 		testName     string
 		buildOptions builder.BuildOptions
-		wantErr string
+		wantErr      string
 	}{
 		{
 			testName: "vSphere hypervisor",

--- a/projects/kubernetes-sigs/image-builder/build/build_image.sh
+++ b/projects/kubernetes-sigs/image-builder/build/build_image.sh
@@ -83,16 +83,9 @@ elif [[ $image_format == "ami" ]]; then
   echo "Creating AMI config"
   jq --null-input \
     --arg ami_filter_owners "099720109477" \
-    --arg ami_regions "us-west-2" \
-    --arg aws_region "us-west-2" \
-    --arg builder_instance_type "t3.small" \
-    --arg custom_role "true" \
     --arg custom_role_names "$MAKE_ROOT/ansible/roles/load_additional_files" \
     --arg ansible_extra_vars "@$MAKE_ROOT/packer/ami/ansible_extra_vars.yaml" \
     --arg manifest_output "$MANIFEST_OUTPUT" \
-    --arg root_device_name "/dev/sda1" \
-    --arg volume_size "25" \
-    --arg volume_type "gp3" \
-    '{"ami_filter_owners": $ami_filter_owners, "ami_regions": $ami_regions, "aws_region": $aws_region, "builder_instance_type": $builder_instance_type, "custom_role": $custom_role, "custom_role_names": $custom_role_names, "ansible_extra_vars": $ansible_extra_vars, "root_device_name": $root_device_name, "volume_size": $volume_size, "volume_type": $volume_type, "manifest_output": $manifest_output}' > $image_builder_config_file
+    '{"ami_filter_owners": $ami_filter_owners, "custom_role_names": $custom_role_names, "ansible_extra_vars": $ansible_extra_vars, "manifest_output": $manifest_output}' > $image_builder_config_file
   "${HOME}"/image-builder build --hypervisor ami --os $image_os --release-channel $release_channel --ami-config $image_builder_config_file
 fi


### PR DESCRIPTION
Setting default opinionated values for AMI build configuration so customers can set only values for parameters they really want to control while letting the tool default to these values for other fields.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
