### PR TITLE
Use gzip compression when downloading images from bundle

### DIFF
--- a/projects/aws/eks-a-admin-image/provisioners/download_eksa_artifacts.sh
+++ b/projects/aws/eks-a-admin-image/provisioners/download_eksa_artifacts.sh
@@ -6,7 +6,7 @@ set -o nounset
 set -o pipefail
 
 EKSA_MANIFESTS_PATH="${EKSA_MANIFESTS_PATH:-/usr/lib/eks-a/manifests}" # The full path where eks-a manifests will be downloaded
-EKSA_ARTIFACTS_TAR_PATH="${EKSA_ARTIFACTS_TAR_PATH:-/usr/lib/eks-a/artifacts/artifacts.tar}" # The path where the tar containing all eks-a container artifacts will be stored
+EKSA_ARTIFACTS_TAR_PATH="${EKSA_ARTIFACTS_TAR_PATH:-/usr/lib/eks-a/artifacts/artifacts.tar.gz}" # The path where the tar containing all eks-a container artifacts will be stored
 
 sudo mkdir -p $EKSA_MANIFESTS_PATH
 sudo -E env "PATH=$PATH" eksctl anywhere download artifacts --retain-dir --download-dir $EKSA_MANIFESTS_PATH -v4

--- a/projects/aws/eks-a-admin-image/provisioners/test/download_eksa_artifacts.sh
+++ b/projects/aws/eks-a-admin-image/provisioners/test/download_eksa_artifacts.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 EKSA_MANIFESTS_PATH="${EKSA_MANIFESTS_PATH:-/usr/lib/eks-a/manifests}"
-EKSA_ARTIFACTS_TAR_PATH="${EKSA_ARTIFACTS_TAR_PATH:-/usr/lib/eks-a/artifacts/artifacts.tar}"
+EKSA_ARTIFACTS_TAR_PATH="${EKSA_ARTIFACTS_TAR_PATH:-/usr/lib/eks-a/artifacts/artifacts.tar.gz}"
 
 if test -d $EKSA_MANIFESTS_PATH; then
 	echo "Manifests dir exists. Pass."


### PR DESCRIPTION
Changing the path extension to .tar.gz makes the CLI apply gzip compression on the artifacts archive to create a tarball which saves more on disk space. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
