### PR TITLE
Update Prometheus helm charts

### DIFF
--- a/projects/prometheus/prometheus/helm/patches/0005-json-schema-patch.diff
+++ b/projects/prometheus/prometheus/helm/patches/0005-json-schema-patch.diff
@@ -1,4 +1,4 @@
-From 9b9fe932da0a56b4bffef91745f322402d5639bd Mon Sep 17 00:00:00 2001
+From 4a6c41829c56c0b2d474921ff4b40daed032d70d Mon Sep 17 00:00:00 2001
 From: "Ostosh, Ivy" <ivyjin215@gmail.com>
 Date: Mon, 28 Nov 2022 10:52:31 -0600
 Subject: [PATCH] Add values.schema.json
@@ -11,7 +11,7 @@ Subject: [PATCH] Add values.schema.json
 
 diff --git a/charts/prometheus/values.schema.json b/charts/prometheus/values.schema.json
 new file mode 100644
-index 00000000..55bb6c32
+index 00000000..fed82b4a
 --- /dev/null
 +++ b/charts/prometheus/values.schema.json
 @@ -0,0 +1,736 @@
@@ -29,7 +29,7 @@ index 00000000..55bb6c32
 +            "type": "array"
 +        },
 +        "extraScrapeConfigs": {
-+            "type": "array"
++            "type": "string"
 +        },
 +        "forceNamespace": {
 +            "type": "string"
@@ -752,7 +752,7 @@ index 00000000..55bb6c32
 +    }
 +}
 diff --git a/charts/prometheus/values.yaml b/charts/prometheus/values.yaml
-index 9b5fd518..fb931b1d 100644
+index 9b5fd518..3172a421 100644
 --- a/charts/prometheus/values.yaml
 +++ b/charts/prometheus/values.yaml
 @@ -7,7 +7,7 @@ podSecurityPolicy:
@@ -783,7 +783,7 @@ index 9b5fd518..fb931b1d 100644
  # must be a string so you have to add a | after extraScrapeConfigs:
  # example adds prometheus-blackbox-exporter scrape config
 -extraScrapeConfigs:
-+extraScrapeConfigs: []
++extraScrapeConfigs: ""
    # - job_name: 'prometheus-blackbox-exporter'
    #   metrics_path: /probe
    #   params:

--- a/projects/prometheus/prometheus/helm/patches/0006-configmap-reload-patch.diff
+++ b/projects/prometheus/prometheus/helm/patches/0006-configmap-reload-patch.diff
@@ -1,0 +1,49 @@
+From 82e733168d41e0c2fdb58816b51f29b46c6e9dd0 Mon Sep 17 00:00:00 2001
+From: "Ostosh, Ivy" <ivyjin215@gmail.com>
+Date: Tue, 29 Nov 2022 17:33:59 -0600
+Subject: [PATCH] Update pod update strategy due to configmap changes
+
+---
+ charts/prometheus/templates/server/deploy.yaml | 5 +++--
+ charts/prometheus/templates/server/sts.yaml    | 5 +++--
+ 2 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/charts/prometheus/templates/server/deploy.yaml b/charts/prometheus/templates/server/deploy.yaml
+index bbf8ce29..9d6aaa81 100644
+--- a/charts/prometheus/templates/server/deploy.yaml
++++ b/charts/prometheus/templates/server/deploy.yaml
+@@ -23,10 +23,11 @@ spec:
+ {{- end }}
+   template:
+     metadata:
+-    {{- if .Values.server.podAnnotations }}
+       annotations:
++        checksum/config: {{ include (print $.Template.BasePath "/server/cm.yaml") . | sha256sum }}
++      {{- if .Values.server.podAnnotations }}
+         {{ toYaml .Values.server.podAnnotations | nindent 8 }}
+-    {{- end }}
++      {{- end }}
+       labels:
+         {{- include "prometheus.server.labels" . | nindent 8 }}
+         {{- if .Values.server.podLabels}}
+diff --git a/charts/prometheus/templates/server/sts.yaml b/charts/prometheus/templates/server/sts.yaml
+index a4db912e..7ca07a16 100644
+--- a/charts/prometheus/templates/server/sts.yaml
++++ b/charts/prometheus/templates/server/sts.yaml
+@@ -23,10 +23,11 @@ spec:
+   podManagementPolicy: {{ .Values.server.statefulSet.podManagementPolicy }}
+   template:
+     metadata:
+-    {{- if .Values.server.podAnnotations }}
+       annotations:
++        checksum/config: {{ include (print $.Template.BasePath "/server/cm.yaml") . | sha256sum }}
++      {{- if .Values.server.podAnnotations }}
+         {{ toYaml .Values.server.podAnnotations | nindent 8 }}
+-    {{- end }}
++      {{- end }}
+       labels:
+         {{- include "prometheus.server.labels" . | nindent 8 }}
+         {{- if .Values.server.podLabels}}
+-- 
+2.31.0
+

--- a/projects/prometheus/prometheus/helm/patches/0007-values-patch.diff
+++ b/projects/prometheus/prometheus/helm/patches/0007-values-patch.diff
@@ -1,0 +1,37 @@
+From 16cffa8d47724b4b82c994780349b83bfe37deca Mon Sep 17 00:00:00 2001
+From: "Ostosh, Ivy" <ivyjin215@gmail.com>
+Date: Tue, 29 Nov 2022 17:34:12 -0600
+Subject: [PATCH] Update values.yaml
+
+---
+ charts/prometheus/values.yaml | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/charts/prometheus/values.yaml b/charts/prometheus/values.yaml
+index 3172a421..b7304737 100644
+--- a/charts/prometheus/values.yaml
++++ b/charts/prometheus/values.yaml
+@@ -99,11 +99,15 @@ nodeExporter:
+   ## Node tolerations for node-exporter scheduling to nodes with taints
+   ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+   ##
+-  tolerations: []
+-    # - key: "key"
+-    #   operator: "Equal|Exists"
+-    #   value: "value"
+-    #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
++  tolerations:
++    # For K8 version prior to 1.24
++    - key: "node-role.kubernetes.io/master"
++      operator: "Exists"
++      effect: "NoSchedule"
++    # For K8 version 1.24+
++    - key: "node-role.kubernetes.io/control-plane"
++      operator: "Exists"
++      effect: "NoSchedule"
+ 
+   ## Node labels for node-exporter pod assignment
+   ## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+-- 
+2.31.0
+

--- a/projects/prometheus/prometheus/helm/schema.json
+++ b/projects/prometheus/prometheus/helm/schema.json
@@ -12,7 +12,7 @@
             "type": "array"
         },
         "extraScrapeConfigs": {
-            "type": "array"
+            "type": "string"
         },
         "forceNamespace": {
             "type": "string"


### PR DESCRIPTION
Add support for pod update strategy due to configmap changes, and tolerations for node-exporter

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
