### PR TITLE
Bump eksd versions

### DIFF
--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -12,12 +12,12 @@ releases:
   number: 21
   kubeVersion: v1.21.14
 - branch: 1-22
-  number: 13
-  kubeVersion: v1.22.15
+  number: 14
+  kubeVersion: v1.22.16
 - branch: 1-23
-  number: 8
+  number: 9
   kubeVersion: v1.23.13
 - branch: 1-24
-  number: 3
-  kubeVersion: v1.24.6
+  number: 4
+  kubeVersion: v1.24.7
 latest: 1-22


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Bump the versions of eksd to match December 01, 2022 release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
