### PR TITLE
Pin RHEL version to 8.6

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0010-Pin-RHEL-to-8.6-version-to-avoid-cloud-init-bug.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0010-Pin-RHEL-to-8.6-version-to-avoid-cloud-init-bug.patch
@@ -1,0 +1,25 @@
+From 6b33fb57ae56ab020e056517bd882f0d998dee75 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Mon, 5 Dec 2022 15:36:26 -0600
+Subject: [PATCH] Pin RHEL to 8.6 version to avoid cloud-init bug
+
+Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
+---
+ images/capi/ansible/roles/setup/tasks/redhat.yml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/images/capi/ansible/roles/setup/tasks/redhat.yml b/images/capi/ansible/roles/setup/tasks/redhat.yml
+index 70721c6cb..7ca3c7eac 100644
+--- a/images/capi/ansible/roles/setup/tasks/redhat.yml
++++ b/images/capi/ansible/roles/setup/tasks/redhat.yml
+@@ -39,6 +39,7 @@
+   yum:
+     name: '*'
+     state: latest
++    releasever: '8.6'
+     lock_timeout: 60
+     exclude: 'kernel*'
+ 
+-- 
+2.24.3 (Apple Git-128)
+


### PR DESCRIPTION
*Description of changes:*
RHEL 8.7 shipped with a cloud-init bug, where cloud-init tried to pull user-data from its data source before networking setup completes. Cloud-init fails to retry once networking is up, and defaults to nil user-data. This causes bootstrapping process to fail completely. This change pins image-building to 8.6 version till upstream fixes cloud-init issues.

https://bugs.launchpad.net/cloud-init/+bug/1998655
https://github.com/aws/eks-anywhere/issues/4282

/hold 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
