### PR TITLE
Remove hardcoded VSphere library name

### DIFF
--- a/projects/kubernetes-sigs/image-builder/packer/ova/vsphere-library.json
+++ b/projects/kubernetes-sigs/image-builder/packer/ova/vsphere-library.json
@@ -1,4 +1,3 @@
 {
-	"vsphere_library_name": "CodeBuild",
 	"output_dir": "./output"
 }


### PR DESCRIPTION
If the VSphere content library name is hardcoded here, then users of the `image-builder` tool will not be able to override the variable for their OVA builds.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
