### PR TITLE
Add library name to VSphere config

### DIFF
--- a/projects/aws/image-builder/CHECKSUMS
+++ b/projects/aws/image-builder/CHECKSUMS
@@ -1,2 +1,2 @@
-e8cd9a8480934ff2b18019627196090b208f137e263c1f87164828d890fa3b3e  _output/bin/image-builder/linux-amd64/image-builder
-8e55817545aa920e6fb390f198892508adb3bfd01a95e3bf611a1a4eb6fb28a8  _output/bin/image-builder/linux-arm64/image-builder
+d3f52d990ad0a3115610d04c4af0084bb68d65ee0b65b286d63f8cf837304f8d  _output/bin/image-builder/linux-amd64/image-builder
+4e25a8329e19ab696dd233bdefa08c7f3d9013e4b7d0eac1714ff47a28e36fcf  _output/bin/image-builder/linux-arm64/image-builder

--- a/projects/aws/image-builder/builder/types.go
+++ b/projects/aws/image-builder/builder/types.go
@@ -44,6 +44,7 @@ type VsphereConfig struct {
 	ResourcePool       string `json:"resource_pool"`
 	Template           string `json:"template"`
 	VcenterServer      string `json:"vcenter_server"`
+	VsphereLibraryName string `json:"vsphere_library_name"`
 	Username           string `json:"username"`
 	Password           string `json:"password"`
 	IsoConfig


### PR DESCRIPTION
Add library name to VSphere config, so that unmarshaling and re-marshaling preserves the field.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
