### PR TITLE
Cleans go-cache in presubmit for harbor/emissary

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -341,6 +341,7 @@ needs-cgo-builder=$(and $(if $(filter true,$(CGO_CREATE_BINARIES)),true,),$(if $
 USE_DOCKER_FOR_CGO_BUILD?=false
 DOCKER_USE_ID_FOR_LINUX=$(shell if [ "$$(uname -s)" = "Linux" ] && [ -n "$${USER:-}" ]; then echo "-u $$(id -u $${USER}):$$(id -g $${USER})"; fi)
 GO_MOD_CACHE=$(shell source $(BUILD_LIB)/common.sh && build::common::use_go_version $(GOLANG_VERSION) > /dev/null 2>&1 && go env GOMODCACHE)
+GO_BUILD_CACHE=$(shell source $(BUILD_LIB)/common.sh && build::common::use_go_version $(GOLANG_VERSION) > /dev/null 2>&1 && go env GOCACHE)
 CGO_TARGET?=
 ######################
 

--- a/Common.mk
+++ b/Common.mk
@@ -729,13 +729,32 @@ release: $(RELEASE_TARGETS)
 
 ###  Clean Targets
 
+.PHONY: clean-go-cache
+clean-go-cache:
+# When go downloads pkg to the module cache, GOPATH/pkg/mod, it removes the write permissions
+# prevent accident modifications since files/checksums are tightly controlled
+# adding the perms neccessary to perform the delete
+	@chmod -fR 777 $(GO_MOD_CACHE) &> /dev/null || :
+	$(foreach folder,$(GO_MOD_CACHE) $(GO_BUILD_CACHE),$(if $(wildcard $(folder)),du -hs $(folder) && rm -rf $(folder);,))
+# When building go bins using mods which have been downloaded by go mod download/vendor which will exist in the go_mod_cache
+# there is additional checksum (?) information that is not preserved in the vendor directory within the project folder
+# This additional information gets written out into the resulting binary. If we did not run go mod vendor, which we do 
+# for all project builds, we could get checksum mismatches on the final binaries due to sometimes having the mod previously
+# downloaded in the go_mod_cahe.  Running go mod vendor always ensures that the go mod has always been downloaded
+# to the go_mod_cache directory. If we clear the go_mod_cache we need to delete the go_mod_download sentinel file
+# so the next time we run build go mods will be redownloaded
+	$(foreach file,$(GO_MOD_DOWNLOAD_TARGETS),$(if $(wildcard $(file)),rm -f $(file);,))
+
 .PHONY: clean-repo
 clean-repo:
 	@rm -rf $(REPO)	$(HELM_SOURCE_REPOSITORY)
 
+.PHONY: clean-output
+clean-output:
+	$(if $(wildcard _output),du -hs _output && rm -rf _output,)
+
 .PHONY: clean
-clean: $(if $(filter true,$(REPO_NO_CLONE)),,clean-repo)
-	@rm -rf _output	
+clean: $(if $(filter true,$(REPO_NO_CLONE)),,clean-repo) clean-output
 
 ## --------------------------------------
 ## Help

--- a/projects/emissary-ingress/emissary/Makefile
+++ b/projects/emissary-ingress/emissary/Makefile
@@ -30,6 +30,12 @@ include $(BASE_DIRECTORY)/Common.mk
 
 $(GO_MOD_DOWNLOAD_TARGETS): $(AMBASSADOR_VERSION_TARGET)
 
+ifeq ($(JOB_TYPE),presubmit)
+# space is very limited in presubmit jobs, the image builds can push the total used space over the limit
+# after the binaries are built there are ~2GBs of go build/mod cache
+$(call IMAGE_TARGETS_FOR_NAME, emissary): clean-go-cache
+endif
+
 # do not pass our makeflags down to emissary make since there will be unncessary warnings
 $(AMBASSADOR_VERSION_TARGET): MAKEFLAGS=
 $(AMBASSADOR_VERSION_TARGET):

--- a/projects/goharbor/harbor/Makefile
+++ b/projects/goharbor/harbor/Makefile
@@ -122,16 +122,11 @@ $(OUTPUT_DIR)/$(REPO): $(GIT_PATCH_TARGET)
 
 %/harbor-core: EXTRA_GO_LDFLAGS=-X $(PKG_PATH)/version.GitCommit=$(GITCOMMIT) -X $(PKG_PATH)/version.ReleaseVersion=$(RELEASEVERSION)
 
-$(call IMAGE_TARGETS_FOR_NAME, harbor-portal): clean-go-cache
-
+ifeq ($(JOB_TYPE),presubmit)
 # space is very limited in presubmit jobs, the image builds can push the total used space over the limit
 # after the binaries are built there are ~3GBs of go build/mod cache
-.PHONY: clean-go-cache
-clean-go-cache:
-	if [ "$(JOB_TYPE)" == "presubmit" ]; then \
-		source $(BUILD_LIB)/common.sh && build::common::use_go_version $(GOLANG_VERSION) && go clean -modcache -cache; \
-		$(MAKE) clean-repo; \
-	fi
+$(call IMAGE_TARGETS_FOR_NAME, harbor-portal): clean-go-cache clean-repo
+endif
 
 $(GATHER_LICENSES_TARGETS): | $(FIX_LICENSES_XEIPUUV_TARGET)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds clean-go-cache, which was recently added in the eks-distro repo, to be used for cleaning large go build and go mod cache folders. Adding to the emissary build to hopefully avoid the out of space issues that happen from time to time in presubmit. Harbor was already doing a version of this, standardized the two.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
