### PR TITLE
Patch locale disparities by explicitly erroring for unexpected locales

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -400,6 +400,16 @@ BUILD_TARGETS?=validate-checksums attribution $(if $(IMAGE_NAMES),local-images,)
 RELEASE_TARGETS?=validate-checksums $(if $(IMAGE_NAMES),images,) $(if $(filter true,$(HAS_HELM_CHART)),helm/push,) $(if $(filter true,$(HAS_S3_ARTIFACTS)),upload-artifacts,)
 ####################################################
 
+# Locale settings impact file ordering in ls or shell file expansion. The file order is used to
+# generate files that are subsequently validated by the CI. If local environments use different 
+# locales to the CI we get unexpected failures that are tricky to debug without knowledge of 
+# locales so we'll explicitly warn here.
+ifneq ($(call TO_LOWER, $(LANG)), c.utf-8)
+ifneq ($(call TO_LOWER, $(LANG)), posix)
+  $(warning WARNING: Environment locale set to $(LANG). This may create non-deterministic behavior when generating files. If the CI fails validation try `LANG=C.UTF-8 make <recipe>` to generate files instead.)
+endif
+endif
+
 define BUILDCTL
 	$(BUILD_LIB)/buildkit.sh \
 		build \

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,17 @@ ALL_PROJECTS=$(shell $(BUILD_LIB)/all_projects.sh $(BASE_DIRECTORY))
 # $1 - project name using _ as seperator, ex: rancher_local-path-provisoner
 PROJECT_PATH_MAP=projects/$(patsubst $(firstword $(subst _, ,$(1)))_%,$(firstword $(subst _, ,$(1)))/%,$(1))
 
+# Locale settings impact file ordering in ls or shell file expansion. The file order is used to
+# generate files that are subsequently validated by the CI. If local environments use different 
+# locales to the CI we get unexpected failures that are tricky to debug without knowledge of 
+# locales so we'll explicitly warn here.
+TO_LOWER = $(shell echo $(1) | tr '[:upper:]' '[:lower:]')
+ifneq ($(call TO_LOWER, $(LANG)), c.utf-8)
+ifneq ($(call TO_LOWER, $(LANG)), posix)
+  $(warning WARNING: Environment locale set to $(LANG). This may create non-deterministic behavior when generating files. If the CI fails validation try `LANG=C.UTF-8 make <recipe>` to generate files instead.)
+endif
+endif
+
 .PHONY: clean-project-%
 clean-project-%:
 	$(eval PROJECT_PATH=$(call PROJECT_PATH_MAP,$*))


### PR DESCRIPTION
Locales impact file ordering among other things for programs that are locale aware (most GNU programs are). Consequently, if 2 environments use different locales its possible generated files are inconsistent. This can cause the CI to fail unexpectedly without the ability to reproduce locally.

This change ensures we error with a clear message indicating how to create determinisim.
