### PR TITLE
Patch locale warning so it only shows when relevant

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -404,10 +404,13 @@ RELEASE_TARGETS?=validate-checksums $(if $(IMAGE_NAMES),images,) $(if $(filter t
 # generate files that are subsequently validated by the CI. If local environments use different 
 # locales to the CI we get unexpected failures that are tricky to debug without knowledge of 
 # locales so we'll explicitly warn here.
-ifneq ($(call TO_LOWER, $(LANG)), c.utf-8)
-ifneq ($(call TO_LOWER, $(LANG)), posix)
-  $(warning WARNING: Environment locale set to $(LANG). This may create non-deterministic behavior when generating files. If the CI fails validation try `LANG=C.UTF-8 make <recipe>` to generate files instead.)
-endif
+ifeq ($(shell uname -s),Linux)
+  LOCALE := $(call TO_LOWER,$(shell locale | grep LANG | cut -d= -f2 | tr -d '"'))
+  ifeq ($(filter c.utf-8 posix,$(LOCALE)),)
+    $(warning WARNING: Environment locale set to $(LANG). On Linux systems this may create \
+	non-deterministic behavior when running generation recipes. If the CI fails validation try \
+	`LANG=C.UTF-8 make <recipe>` to generate files instead.)
+  endif
 endif
 
 define BUILDCTL

--- a/Common.mk
+++ b/Common.mk
@@ -404,8 +404,12 @@ RELEASE_TARGETS?=validate-checksums $(if $(IMAGE_NAMES),images,) $(if $(filter t
 # generate files that are subsequently validated by the CI. If local environments use different 
 # locales to the CI we get unexpected failures that are tricky to debug without knowledge of 
 # locales so we'll explicitly warn here.
+# In a AL2 container image (like builder base), LANG will be empty which is equilvant to posix
+# In a AL2 (or other distro) full instance the LANG will be en-us.UTF-8 which produces different sorts
+# On Mac, LANG will be en-us.UTF-8 but has a fix applied to sort to avoid the difference
 ifeq ($(shell uname -s),Linux)
-  LOCALE := $(call TO_LOWER,$(shell locale | grep LANG | cut -d= -f2 | tr -d '"'))
+  LOCALE:=$(call TO_LOWER,$(shell locale | grep LANG | cut -d= -f2 | tr -d '"'))
+  LOCALE:=$(if $(LOCALE),$(LOCALE),posix)
   ifeq ($(filter c.utf-8 posix,$(LOCALE)),)
     $(warning WARNING: Environment locale set to $(LANG). On Linux systems this may create \
 	non-deterministic behavior when running generation recipes. If the CI fails validation try \

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,13 @@ PROJECT_PATH_MAP=projects/$(patsubst $(firstword $(subst _, ,$(1)))_%,$(firstwor
 # locales to the CI we get unexpected failures that are tricky to debug without knowledge of 
 # locales so we'll explicitly warn here.
 TO_LOWER = $(shell echo $(1) | tr '[:upper:]' '[:lower:]')
-ifneq ($(call TO_LOWER, $(LANG)), c.utf-8)
-ifneq ($(call TO_LOWER, $(LANG)), posix)
-  $(warning WARNING: Environment locale set to $(LANG). This may create non-deterministic behavior when generating files. If the CI fails validation try `LANG=C.UTF-8 make <recipe>` to generate files instead.)
-endif
+ifeq ($(shell uname -s),Linux)
+  LOCALE := $(call TO_LOWER,$(shell locale | grep LANG | cut -d= -f2 | tr -d '"'))
+  ifeq ($(filter c.utf-8 posix,$(LOCALE)),)
+    $(warning WARNING: Environment locale set to $(LANG). On Linux systems this may create \
+	non-deterministic behavior when running generation recipes. If the CI fails validation try \
+	`LANG=C.UTF-8 make <recipe>` to generate files instead.)
+  endif
 endif
 
 .PHONY: clean-project-%


### PR DESCRIPTION
Patch the locale warning so it only shows when its known to cause an issue, namely on Linux. 