### PR TITLE
Add metrics-server 1-25

### DIFF
--- a/projects/kubernetes-sigs/metrics-server/1-25/HELM_GIT_TAG
+++ b/projects/kubernetes-sigs/metrics-server/1-25/HELM_GIT_TAG
@@ -1,0 +1,1 @@
+metrics-server-helm-chart-3.8.2

--- a/projects/kubernetes-sigs/metrics-server/1-25/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-25/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
@@ -1,0 +1,182 @@
+From b2ac06da66627f741e0a7a2e8808a739e2a91942 Mon Sep 17 00:00:00 2001
+From: Jonathan Meier <jwmeier@amazon.com>
+Date: Fri, 23 Sep 2022 12:17:23 -0400
+Subject: [PATCH] Conform helm chart to packages standards
+
+---
+ charts/metrics-server/templates/NOTES.txt            |  2 +-
+ charts/metrics-server/templates/_helpers.tpl         |  2 +-
+ charts/metrics-server/templates/apiservice.yaml      |  3 ++-
+ .../templates/clusterrolebinding-auth-delegator.yaml |  2 +-
+ .../metrics-server/templates/clusterrolebinding.yaml |  2 +-
+ charts/metrics-server/templates/deployment.yaml      |  1 +
+ charts/metrics-server/templates/rolebinding.yaml     |  2 +-
+ charts/metrics-server/templates/service.yaml         |  2 ++
+ charts/metrics-server/templates/serviceaccount.yaml  |  1 +
+ charts/metrics-server/templates/servicemonitor.yaml  |  3 ++-
+ charts/metrics-server/values.yaml                    | 12 ++++++------
+ 11 files changed, 19 insertions(+), 13 deletions(-)
+
+diff --git a/charts/metrics-server/templates/NOTES.txt b/charts/metrics-server/templates/NOTES.txt
+index 0ad6bb0..84f5433 100644
+--- a/charts/metrics-server/templates/NOTES.txt
++++ b/charts/metrics-server/templates/NOTES.txt
+@@ -3,5 +3,5 @@
+ ***********************************************************************
+   Chart version: {{ .Chart.Version }}
+   App version:   {{ .Chart.AppVersion }}
+-  Image tag:     {{ include "metrics-server.image" . }}
++  Image ref:     {{ include "metrics-server.image" . }}
+ ***********************************************************************
+diff --git a/charts/metrics-server/templates/_helpers.tpl b/charts/metrics-server/templates/_helpers.tpl
+index f558169..6968513 100644
+--- a/charts/metrics-server/templates/_helpers.tpl
++++ b/charts/metrics-server/templates/_helpers.tpl
+@@ -65,7 +65,7 @@ Create the name of the service account to use
+ The image to use
+ */}}
+ {{- define "metrics-server.image" -}}
+-{{- printf "%s:%s" .Values.image.repository (default (printf "v%s" .Chart.AppVersion) .Values.image.tag) }}
++{{- printf "%s/%s@%s" .Values.image.sourceRegistry .Values.image.repository .Values.image.digest }}
+ {{- end }}
+ 
+ {{/* Get PodDisruptionBudget API Version */}}
+diff --git a/charts/metrics-server/templates/apiservice.yaml b/charts/metrics-server/templates/apiservice.yaml
+index dd37b5d..26026fc 100644
+--- a/charts/metrics-server/templates/apiservice.yaml
++++ b/charts/metrics-server/templates/apiservice.yaml
+@@ -3,6 +3,7 @@ apiVersion: apiregistration.k8s.io/v1
+ kind: APIService
+ metadata:
+   name: v1beta1.metrics.k8s.io
++  namespace: {{ .Release.Namespace | quote }}
+   labels:
+     {{- include "metrics-server.labels" . | nindent 4 }}
+ spec:
+@@ -11,7 +12,7 @@ spec:
+   insecureSkipTLSVerify: true
+   service:
+     name: {{ include "metrics-server.fullname" . }}
+-    namespace: {{ .Release.Namespace }}
++    namespace: {{ .Release.Namespace | quote }}
+   version: v1beta1
+   versionPriority: 100
+ {{- end -}}
+diff --git a/charts/metrics-server/templates/clusterrolebinding-auth-delegator.yaml b/charts/metrics-server/templates/clusterrolebinding-auth-delegator.yaml
+index 826c3b7..c0fb07e 100644
+--- a/charts/metrics-server/templates/clusterrolebinding-auth-delegator.yaml
++++ b/charts/metrics-server/templates/clusterrolebinding-auth-delegator.yaml
+@@ -12,5 +12,5 @@ roleRef:
+ subjects:
+   - kind: ServiceAccount
+     name: {{ include "metrics-server.serviceAccountName" . }}
+-    namespace: {{ .Release.Namespace }}
++    namespace: {{ .Release.Namespace | quote }}
+ {{- end -}}
+diff --git a/charts/metrics-server/templates/clusterrolebinding.yaml b/charts/metrics-server/templates/clusterrolebinding.yaml
+index 512cb65..f02a275 100644
+--- a/charts/metrics-server/templates/clusterrolebinding.yaml
++++ b/charts/metrics-server/templates/clusterrolebinding.yaml
+@@ -12,5 +12,5 @@ roleRef:
+ subjects:
+   - kind: ServiceAccount
+     name: {{ include "metrics-server.serviceAccountName" . }}
+-    namespace: {{ .Release.Namespace }}
++    namespace: {{ .Release.Namespace | quote }}
+ {{- end -}}
+diff --git a/charts/metrics-server/templates/deployment.yaml b/charts/metrics-server/templates/deployment.yaml
+index 90e0588..2c0f320 100644
+--- a/charts/metrics-server/templates/deployment.yaml
++++ b/charts/metrics-server/templates/deployment.yaml
+@@ -2,6 +2,7 @@ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+   name: {{ include "metrics-server.fullname" . }}
++  namespace: {{ .Release.Namespace | quote }}
+   labels:
+     {{- include "metrics-server.labels" . | nindent 4 }}
+ spec:
+diff --git a/charts/metrics-server/templates/rolebinding.yaml b/charts/metrics-server/templates/rolebinding.yaml
+index 3fda743..4dc4e3c 100644
+--- a/charts/metrics-server/templates/rolebinding.yaml
++++ b/charts/metrics-server/templates/rolebinding.yaml
+@@ -13,5 +13,5 @@ roleRef:
+ subjects:
+   - kind: ServiceAccount
+     name: {{ include "metrics-server.serviceAccountName" . }}
+-    namespace: {{ .Release.Namespace }}
++    namespace: {{ .Release.Namespace | quote }}
+ {{- end -}}
+diff --git a/charts/metrics-server/templates/service.yaml b/charts/metrics-server/templates/service.yaml
+index 7470218..3415cc4 100644
+--- a/charts/metrics-server/templates/service.yaml
++++ b/charts/metrics-server/templates/service.yaml
+@@ -2,6 +2,8 @@ apiVersion: v1
+ kind: Service
+ metadata:
+   name: {{ include "metrics-server.fullname" . }}
++  namespace: {{ .Release.Namespace | quote }}
++
+   {{- with .Values.service.annotations }}
+   annotations:
+     {{- toYaml . | nindent 4 }}
+diff --git a/charts/metrics-server/templates/serviceaccount.yaml b/charts/metrics-server/templates/serviceaccount.yaml
+index 12f7724..99e3d32 100644
+--- a/charts/metrics-server/templates/serviceaccount.yaml
++++ b/charts/metrics-server/templates/serviceaccount.yaml
+@@ -3,6 +3,7 @@ apiVersion: v1
+ kind: ServiceAccount
+ metadata:
+   name: {{ template "metrics-server.serviceAccountName" . }}
++  namespace: {{ .Release.Namespace | quote }}
+   {{- with .Values.serviceAccount.annotations }}
+   annotations:
+     {{- toYaml . | nindent 4 }}
+diff --git a/charts/metrics-server/templates/servicemonitor.yaml b/charts/metrics-server/templates/servicemonitor.yaml
+index 52e6491..25b0e74 100644
+--- a/charts/metrics-server/templates/servicemonitor.yaml
++++ b/charts/metrics-server/templates/servicemonitor.yaml
+@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
+ kind: ServiceMonitor
+ metadata:
+   name: {{ include "metrics-server.fullname" . }}
++  namespace: {{ .Release.Namespace | quote }}
+   labels:
+     {{- include "metrics-server.labels" . | nindent 4 }}
+     {{- with .Values.serviceMonitor.additionalLabels }}
+@@ -12,7 +13,7 @@ spec:
+   jobLabel: {{ .Release.Name }}
+   namespaceSelector:
+     matchNames:
+-      - {{ .Release.Namespace }}
++      - {{ .Release.Namespace | quote }}
+   selector:
+     matchLabels:
+       {{- include "metrics-server.selectorLabels" . | nindent 6 }}
+diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
+index 6a97505..7583ac6 100644
+--- a/charts/metrics-server/values.yaml
++++ b/charts/metrics-server/values.yaml
+@@ -3,13 +3,13 @@
+ # Declare variables to be passed into your templates.
+ 
+ image:
+-  repository: k8s.gcr.io/metrics-server/metrics-server
+-  # Overrides the image tag whose default is v{{ .Chart.AppVersion }}
+-  tag: ""
+-  pullPolicy: IfNotPresent
++  sourceRegistry: public.ecr.aws/eks-anywhere
++  repository: metrics-server/eks-distro/kubernetes-sigs/metrics-server
++  digest: {{eks-distro/kubernetes-sigs/metrics-server}}
+ 
+-imagePullSecrets: []
+-# - registrySecretName
++  pullPolicy: IfNotPresent
++  imagePullSecrets:
++    - regcred
+ 
+ nameOverride: ""
+ fullnameOverride: ""
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/kubernetes-sigs/metrics-server/1-25/helm/patches/0002-Make-imagePullSecrets-top-level-value.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-25/helm/patches/0002-Make-imagePullSecrets-top-level-value.patch
@@ -1,0 +1,27 @@
+From ecd33d35d845617423858cfaebed5fda6284f732 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Tue, 18 Oct 2022 18:11:57 -0400
+Subject: [PATCH] Make imagePullSecrets top-level value
+
+---
+ charts/metrics-server/values.yaml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
+index 7583ac6..70b6f7d 100644
+--- a/charts/metrics-server/values.yaml
++++ b/charts/metrics-server/values.yaml
+@@ -8,8 +8,8 @@ image:
+   digest: {{eks-distro/kubernetes-sigs/metrics-server}}
+ 
+   pullPolicy: IfNotPresent
+-  imagePullSecrets:
+-    - regcred
++
++imagePullSecrets: []
+ 
+ nameOverride: ""
+ fullnameOverride: ""
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/kubernetes-sigs/metrics-server/1-25/helm/patches/0003-Make-sourceRegistry-top-level-value.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-25/helm/patches/0003-Make-sourceRegistry-top-level-value.patch
@@ -1,0 +1,41 @@
+From 88f9476520202da61c16a0d5c5701dbe2971b944 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Thu, 20 Oct 2022 07:04:58 -0400
+Subject: [PATCH] Make sourceRegistry top level value
+
+---
+ charts/metrics-server/templates/_helpers.tpl | 2 +-
+ charts/metrics-server/values.yaml            | 3 ++-
+ 2 files changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/charts/metrics-server/templates/_helpers.tpl b/charts/metrics-server/templates/_helpers.tpl
+index 6968513..8494ca4 100644
+--- a/charts/metrics-server/templates/_helpers.tpl
++++ b/charts/metrics-server/templates/_helpers.tpl
+@@ -65,7 +65,7 @@ Create the name of the service account to use
+ The image to use
+ */}}
+ {{- define "metrics-server.image" -}}
+-{{- printf "%s/%s@%s" .Values.image.sourceRegistry .Values.image.repository .Values.image.digest }}
++{{- printf "%s/%s@%s" .Values.sourceRegistry .Values.image.repository .Values.image.digest }}
+ {{- end }}
+ 
+ {{/* Get PodDisruptionBudget API Version */}}
+diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
+index 70b6f7d..7930a5b 100644
+--- a/charts/metrics-server/values.yaml
++++ b/charts/metrics-server/values.yaml
+@@ -2,8 +2,9 @@
+ # This is a YAML-formatted file.
+ # Declare variables to be passed into your templates.
+ 
++sourceRegistry: 783794618700.dkr.ecr.us-west-2.amazonaws.com
++
+ image:
+-  sourceRegistry: public.ecr.aws/eks-anywhere
+   repository: metrics-server/eks-distro/kubernetes-sigs/metrics-server
+   digest: {{eks-distro/kubernetes-sigs/metrics-server}}
+ 
+-- 
+2.30.1 (Apple Git-130)
+

--- a/projects/kubernetes-sigs/metrics-server/1-25/helm/schema.json
+++ b/projects/kubernetes-sigs/metrics-server/1-25/helm/schema.json
@@ -1,0 +1,772 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "http://example.com/example.json",
+    "type": "object",
+    "default": {},
+    "title": "Metrics Server",
+    "properties": {
+        "sourceRegistry": {
+            "description": "Override source registry of the helm chart.",
+            "type": "string"
+        },
+        "image": {
+            "type": "object",
+            "default": {},
+            "title": "The image Schema",
+            "required": [],
+            "properties": {
+                "repository": {
+                    "type": "string",
+                    "default": "metrics-server/eks-distro/kubernetes-sigs/metrics-server",
+                    "title": "The repository Schema",
+                    "examples": [
+                        "metrics-server/eks-distro/kubernetes-sigs/metrics-server"
+                    ]
+                },
+                "digest": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The digest Schema",
+                    "examples": [
+                        "sha256:21c7e2aea0555a9889021a50637c113bb7988922649bbed5634d4e95b5aa8b5d"
+                    ]
+                },
+                "pullPolicy": {
+                    "type": "string",
+                    "default": "IfNotPresent",
+                    "title": "The pullPolicy Schema",
+                    "examples": [
+                        "IfNotPresent"
+                    ]
+                }
+            },
+            "examples": [{
+                "repository": "metrics-server/eks-distro/kubernetes-sigs/metrics-server",
+                "digest": "sha256:46a80fd791bb08dfaa68728f50d086b09bd7a355cd0a16a075fd11eb876c2b80",
+                "pullPolicy": "IfNotPresent"
+            }]
+        },
+        "imagePullSecrets": {
+            "type": "array",
+            "default": [],
+            "title": "The imagePullSecrets Schema",
+            "items": {},
+            "examples": [
+                []
+            ]
+        },
+        "nameOverride": {
+            "type": "string",
+            "default": "",
+            "title": "The nameOverride Schema",
+            "examples": [
+                ""
+            ]
+        },
+        "fullnameOverride": {
+            "type": "string",
+            "default": "",
+            "title": "The fullnameOverride Schema",
+            "examples": [
+                ""
+            ]
+        },
+        "serviceAccount": {
+            "type": "object",
+            "default": {},
+            "title": "The serviceAccount Schema",
+            "required": [],
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "default": true,
+                    "title": "The create Schema",
+                    "examples": [
+                        true
+                    ]
+                },
+                "annotations": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The annotations Schema",
+                    "required": [],
+                    "properties": {},
+                    "examples": [{}]
+                },
+                "name": {
+                    "type": "string",
+                    "default": "",
+                    "title": "The name Schema",
+                    "examples": [
+                        ""
+                    ]
+                }
+            },
+            "examples": [{
+                "create": true,
+                "annotations": {},
+                "name": ""
+            }]
+        },
+        "rbac": {
+            "type": "object",
+            "default": {},
+            "title": "The rbac Schema",
+            "required": [],
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "default": true,
+                    "title": "The create Schema",
+                    "examples": [
+                        true
+                    ]
+                },
+                "pspEnabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "title": "The pspEnabled Schema",
+                    "examples": [
+                        false
+                    ]
+                }
+            },
+            "examples": [{
+                "create": true,
+                "pspEnabled": false
+            }]
+        },
+        "apiService": {
+            "type": "object",
+            "default": {},
+            "title": "The apiService Schema",
+            "required": [
+                "create"
+            ],
+            "properties": {
+                "create": {
+                    "type": "boolean",
+                    "default": true,
+                    "title": "The create Schema",
+                    "examples": [
+                        true
+                    ]
+                }
+            },
+            "examples": [{
+                "create": true
+            }]
+        },
+        "podLabels": {
+            "type": "object",
+            "default": {},
+            "title": "The podLabels Schema",
+            "required": [],
+            "properties": {},
+            "examples": [{}]
+        },
+        "podAnnotations": {
+            "type": "object",
+            "default": {},
+            "title": "The podAnnotations Schema",
+            "required": [],
+            "properties": {},
+            "examples": [{}]
+        },
+        "podSecurityContext": {
+            "type": "object",
+            "default": {},
+            "title": "The podSecurityContext Schema",
+            "required": [],
+            "properties": {},
+            "examples": [{}]
+        },
+        "securityContext": {
+            "type": "object",
+            "default": {},
+            "title": "The securityContext Schema",
+            "required": [],
+            "properties": {
+                "allowPrivilegeEscalation": {
+                    "type": "boolean",
+                    "default": false,
+                    "title": "The allowPrivilegeEscalation Schema",
+                    "examples": [
+                        false
+                    ]
+                },
+                "readOnlyRootFilesystem": {
+                    "type": "boolean",
+                    "default": true,
+                    "title": "The readOnlyRootFilesystem Schema",
+                    "examples": [
+                        true
+                    ]
+                },
+                "runAsNonRoot": {
+                    "type": "boolean",
+                    "default": true,
+                    "title": "The runAsNonRoot Schema",
+                    "examples": [
+                        true
+                    ]
+                },
+                "runAsUser": {
+                    "type": "integer",
+                    "default": 1000,
+                    "title": "The runAsUser Schema",
+                    "examples": [
+                        1000
+                    ]
+                }
+            },
+            "examples": [{
+                "allowPrivilegeEscalation": false,
+                "readOnlyRootFilesystem": true,
+                "runAsNonRoot": true,
+                "runAsUser": 1000
+            }]
+        },
+        "priorityClassName": {
+            "type": "string",
+            "default": "system-cluster-critical",
+            "title": "The priorityClassName Schema",
+            "examples": [
+                "system-cluster-critical"
+            ]
+        },
+        "containerPort": {
+            "type": "integer",
+            "default": 4443,
+            "title": "The containerPort Schema",
+            "examples": [
+                4443
+            ]
+        },
+        "hostNetwork": {
+            "type": "object",
+            "default": {},
+            "title": "The hostNetwork Schema",
+            "required": [],
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "title": "The enabled Schema",
+                    "examples": [
+                        false
+                    ]
+                }
+            },
+            "examples": [{
+                "enabled": false
+            }]
+        },
+        "replicas": {
+            "type": "integer",
+            "default": 1,
+            "title": "The replicas Schema",
+            "examples": [
+                1
+            ]
+        },
+        "updateStrategy": {
+            "type": "object",
+            "default": {},
+            "title": "The updateStrategy Schema",
+            "required": [],
+            "properties": {},
+            "examples": [{}]
+        },
+        "podDisruptionBudget": {
+            "type": "object",
+            "default": {},
+            "title": "The podDisruptionBudget Schema",
+            "required": [],
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "title": "The enabled Schema",
+                    "examples": [
+                        false
+                    ]
+                },
+                "minAvailable": {
+                    "type": "integer",
+                    "default": 3,
+                    "title": "The minAvailable Schema",
+                    "examples": [
+                        null
+                    ]
+                },
+                "maxUnavailable": {
+                    "type": "integer",
+                    "default": 1,
+                    "title": "The maxUnavailable Schema",
+                    "examples": [
+                        null
+                    ]
+                }
+            },
+            "examples": [{
+                "enabled": false,
+                "minAvailable": null,
+                "maxUnavailable": null
+            }]
+        },
+        "defaultArgs": {
+            "type": "array",
+            "default": ["--cert-dir=/tmp", "--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname", "--kubelet-use-node-status-port", "--metric-resolution=15s"],
+            "title": "The defaultArgs Schema",
+            "items": {
+                "type": "string",
+                "title": "A Schema",
+                "examples": [
+                    "--cert-dir=/tmp",
+                    "--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname",
+                    "--kubelet-use-node-status-port",
+                    "--metric-resolution=15s"
+                ]
+            },
+            "examples": [
+                ["--cert-dir=/tmp",
+                    "--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname",
+                    "--kubelet-use-node-status-port",
+                    "--metric-resolution=15s"
+                ]
+            ]
+        },
+        "args": {
+            "type": "array",
+            "default": [],
+            "title": "The args Schema",
+            "items": {},
+            "examples": [
+                []
+            ]
+        },
+        "livenessProbe": {
+            "type": "object",
+            "default": {},
+            "title": "The livenessProbe Schema",
+            "required": [],
+            "properties": {
+                "httpGet": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The httpGet Schema",
+                    "required": [
+                        "path",
+                        "port",
+                        "scheme"
+                    ],
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "default": "/livez",
+                            "title": "The path Schema",
+                            "examples": [
+                                "/livez"
+                            ]
+                        },
+                        "port": {
+                            "type": "string",
+                            "default": "https",
+                            "title": "The port Schema",
+                            "examples": [
+                                "https"
+                            ]
+                        },
+                        "scheme": {
+                            "type": "string",
+                            "default": "HTTPS",
+                            "title": "The scheme Schema",
+                            "examples": [
+                                "HTTPS"
+                            ]
+                        }
+                    },
+                    "examples": [{
+                        "path": "/livez",
+                        "port": "https",
+                        "scheme": "HTTPS"
+                    }]
+                },
+                "initialDelaySeconds": {
+                    "type": "integer",
+                    "default": 0,
+                    "title": "The initialDelaySeconds Schema",
+                    "examples": [
+                        0
+                    ]
+                },
+                "periodSeconds": {
+                    "type": "integer",
+                    "default": 10,
+                    "title": "The periodSeconds Schema",
+                    "examples": [
+                        10
+                    ]
+                },
+                "failureThreshold": {
+                    "type": "integer",
+                    "default": 3,
+                    "title": "The failureThreshold Schema",
+                    "examples": [
+                        3
+                    ]
+                }
+            },
+            "examples": [{
+                "httpGet": {
+                    "path": "/livez",
+                    "port": "https",
+                    "scheme": "HTTPS"
+                },
+                "initialDelaySeconds": 0,
+                "periodSeconds": 10,
+                "failureThreshold": 3
+            }]
+        },
+        "readinessProbe": {
+            "type": "object",
+            "default": {},
+            "title": "The readinessProbe Schema",
+            "required": [],
+            "properties": {
+                "httpGet": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The httpGet Schema",
+                    "required": [
+                        "path",
+                        "port",
+                        "scheme"
+                    ],
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "default": "/readyz",
+                            "title": "The path Schema",
+                            "examples": [
+                                "/readyz"
+                            ]
+                        },
+                        "port": {
+                            "type": "string",
+                            "default": "https",
+                            "title": "The port Schema",
+                            "examples": [
+                                "https"
+                            ]
+                        },
+                        "scheme": {
+                            "type": "string",
+                            "default": "HTTPS",
+                            "title": "The scheme Schema",
+                            "examples": [
+                                "HTTPS"
+                            ]
+                        }
+                    },
+                    "examples": [{
+                        "path": "/readyz",
+                        "port": "https",
+                        "scheme": "HTTPS"
+                    }]
+                },
+                "initialDelaySeconds": {
+                    "type": "integer",
+                    "default": 20,
+                    "title": "The initialDelaySeconds Schema",
+                    "examples": [
+                        20
+                    ]
+                },
+                "periodSeconds": {
+                    "type": "integer",
+                    "default": 10,
+                    "title": "The periodSeconds Schema",
+                    "examples": [
+                        10
+                    ]
+                },
+                "failureThreshold": {
+                    "type": "integer",
+                    "default": 3,
+                    "title": "The failureThreshold Schema",
+                    "examples": [
+                        3
+                    ]
+                }
+            },
+            "examples": [{
+                "httpGet": {
+                    "path": "/readyz",
+                    "port": "https",
+                    "scheme": "HTTPS"
+                },
+                "initialDelaySeconds": 20,
+                "periodSeconds": 10,
+                "failureThreshold": 3
+            }]
+        },
+        "service": {
+            "type": "object",
+            "default": {},
+            "title": "The service Schema",
+            "required": [],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "default": "ClusterIP",
+                    "title": "The type Schema",
+                    "examples": [
+                        "ClusterIP"
+                    ]
+                },
+                "port": {
+                    "type": "integer",
+                    "default": 443,
+                    "title": "The port Schema",
+                    "examples": [
+                        443
+                    ]
+                },
+                "annotations": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The annotations Schema",
+                    "required": [],
+                    "properties": {},
+                    "examples": [{}]
+                },
+                "labels": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The labels Schema",
+                    "required": [],
+                    "properties": {},
+                    "examples": [{}]
+                }
+            },
+            "examples": [{
+                "type": "ClusterIP",
+                "port": 443,
+                "annotations": {},
+                "labels": {}
+            }]
+        },
+        "metrics": {
+            "type": "object",
+            "default": {},
+            "title": "The metrics Schema",
+            "required": [
+                "enabled"
+            ],
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "title": "The enabled Schema",
+                    "examples": [
+                        false
+                    ]
+                }
+            },
+            "examples": [{
+                "enabled": false
+            }]
+        },
+        "serviceMonitor": {
+            "type": "object",
+            "default": {},
+            "title": "The serviceMonitor Schema",
+            "required": ["enabled"],
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "default": false,
+                    "title": "The enabled Schema",
+                    "examples": [
+                        false
+                    ]
+                },
+                "additionalLabels": {
+                    "type": "object",
+                    "default": {},
+                    "title": "The additionalLabels Schema",
+                    "required": [],
+                    "properties": {},
+                    "examples": [{}]
+                },
+                "interval": {
+                    "type": "string",
+                    "default": "1m",
+                    "title": "The interval Schema",
+                    "examples": [
+                        "1m"
+                    ]
+                },
+                "scrapeTimeout": {
+                    "type": "string",
+                    "default": "10s",
+                    "title": "The scrapeTimeout Schema",
+                    "examples": [
+                        "10s"
+                    ]
+                }
+            },
+            "examples": [{
+                "enabled": false,
+                "additionalLabels": {},
+                "interval": "1m",
+                "scrapeTimeout": "10s"
+            }]
+        },
+        "resources": {
+            "type": "object",
+            "default": {},
+            "title": "The resources Schema",
+            "required": [],
+            "properties": {},
+            "examples": [{}]
+        },
+        "extraVolumeMounts": {
+            "type": "array",
+            "default": [],
+            "title": "The extraVolumeMounts Schema",
+            "items": {},
+            "examples": [
+                []
+            ]
+        },
+        "extraVolumes": {
+            "type": "array",
+            "default": [],
+            "title": "The extraVolumes Schema",
+            "items": {},
+            "examples": [
+                []
+            ]
+        },
+        "nodeSelector": {
+            "type": "object",
+            "default": {},
+            "title": "The nodeSelector Schema",
+            "required": [],
+            "properties": {},
+            "examples": [{}]
+        },
+        "tolerations": {
+            "type": "array",
+            "default": [],
+            "title": "The tolerations Schema",
+            "items": {},
+            "examples": [
+                []
+            ]
+        },
+        "affinity": {
+            "type": "object",
+            "default": {},
+            "title": "The affinity Schema",
+            "required": [],
+            "properties": {},
+            "examples": [{}]
+        }
+    },
+    "examples": [{
+        "sourceRegistry": "public.ecr.aws/eks-anywhere",
+        "image": {
+            "repository": "metrics-server/eks-distro/kubernetes-sigs/metrics-server",
+            "digest": "sha256:46a80fd791bb08dfaa68728f50d086b09bd7a355cd0a16a075fd11eb876c2b80",
+            "pullPolicy": "IfNotPresent"
+        },
+        "imagePullSecrets": [],
+        "nameOverride": "",
+        "fullnameOverride": "",
+        "serviceAccount": {
+            "create": true,
+            "annotations": {},
+            "name": ""
+        },
+        "rbac": {
+            "create": true,
+            "pspEnabled": false
+        },
+        "apiService": {
+            "create": true
+        },
+        "podLabels": {},
+        "podAnnotations": {},
+        "podSecurityContext": {},
+        "securityContext": {
+            "allowPrivilegeEscalation": false,
+            "readOnlyRootFilesystem": true,
+            "runAsNonRoot": true,
+            "runAsUser": 1000
+        },
+        "priorityClassName": "system-cluster-critical",
+        "containerPort": 4443,
+        "hostNetwork": {
+            "enabled": false
+        },
+        "replicas": 1,
+        "updateStrategy": {},
+        "podDisruptionBudget": {
+            "enabled": false,
+            "minAvailable": null,
+            "maxUnavailable": null
+        },
+        "defaultArgs": [
+            "--cert-dir=/tmp",
+            "--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname",
+            "--kubelet-use-node-status-port",
+            "--metric-resolution=15s"
+        ],
+        "args": [],
+        "livenessProbe": {
+            "httpGet": {
+                "path": "/livez",
+                "port": "https",
+                "scheme": "HTTPS"
+            },
+            "initialDelaySeconds": 0,
+            "periodSeconds": 10,
+            "failureThreshold": 3
+        },
+        "readinessProbe": {
+            "httpGet": {
+                "path": "/readyz",
+                "port": "https",
+                "scheme": "HTTPS"
+            },
+            "initialDelaySeconds": 20,
+            "periodSeconds": 10,
+            "failureThreshold": 3
+        },
+        "service": {
+            "type": "ClusterIP",
+            "port": 443,
+            "annotations": {},
+            "labels": {}
+        },
+        "metrics": {
+            "enabled": false
+        },
+        "serviceMonitor": {
+            "enabled": false,
+            "additionalLabels": {},
+            "interval": "1m",
+            "scrapeTimeout": "10s"
+        },
+        "resources": {},
+        "extraVolumeMounts": [],
+        "extraVolumes": [],
+        "nodeSelector": {},
+        "tolerations": [],
+        "affinity": {}
+    }]
+}

--- a/projects/kubernetes-sigs/metrics-server/1-25/helm/sedfile.template
+++ b/projects/kubernetes-sigs/metrics-server/1-25/helm/sedfile.template
@@ -1,0 +1,1 @@
+s/version: .*$/version: ${HELM_TAG}/


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a 1-25 metrics-server helm chart build.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->