### PR TITLE
Sets compute type for arm code build instances

### DIFF
--- a/UPSTREAM_PROJECTS.yaml
+++ b/UPSTREAM_PROJECTS.yaml
@@ -195,7 +195,7 @@ projects:
           - commit: 7b286fdc8e8fa91a6e9a179a5494b6ee29fce17b
       - name: hook
         versions:
-          - tag: 6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2
+          - commit: 6d43b8b331c7a389f3ffeaa388fa9aa98248d7a2
       - name: hub
         versions:
           - commit: 6c0f0d437bde2c836d90b000312c8b25fa1b65e1

--- a/build/lib/generate_staging_buildspec.sh
+++ b/build/lib/generate_staging_buildspec.sh
@@ -149,7 +149,7 @@ for project in "${PROJECTS[@]}"; do
                         if [ "${val1}" = "linux/amd64" ]; then
                             ARCH_TYPE="\"type\":\"LINUX_CONTAINER\","
                         else
-                            ARCH_TYPE="\"type\":\"ARM_CONTAINER\","
+                            ARCH_TYPE="\"type\":\"ARM_CONTAINER\",\"compute-type\":\"BUILD_GENERAL1_LARGE\","
                         fi
                     fi
 

--- a/projects/fluxcd/source-controller/buildspecs/batch-build.yml
+++ b/projects/fluxcd/source-controller/buildspecs/batch-build.yml
@@ -27,6 +27,7 @@ batch:
       buildspec: projects/fluxcd/source-controller/buildspecs/binaries.yml
       env:
         type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
         variables:
           BINARY_PLATFORMS: linux/arm64
     - identifier: fluxcd_source_controller

--- a/release/staging-build.yml
+++ b/release/staging-build.yml
@@ -175,6 +175,7 @@ batch:
       buildspec: projects/fluxcd/source-controller/buildspecs/binaries.yml
       env:
         type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
         variables:
           PROJECT_PATH: projects/fluxcd/source-controller
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/fluxcd.source-controller


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In the staging build we default to the giant instance type for amd which does not exist for arm. We have to specifically set the arm compute type to the normal large.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
