### PR TITLE
Add subnet ID field to AMI build config

### DIFF
--- a/projects/aws/image-builder/CHECKSUMS
+++ b/projects/aws/image-builder/CHECKSUMS
@@ -1,2 +1,2 @@
-776858392b65be847a24318e7801cee2c00ca506dfcab9b1dd34c442c884d0e4  _output/bin/image-builder/linux-amd64/image-builder
-02579698cbdca96a65abc3ebfb3e4be264055cf2e51a2757f85819e93ffc5f88  _output/bin/image-builder/linux-arm64/image-builder
+339badeac0c589c71128da81c24a7cb08b59dd97b92987470c634b115632cfd5  _output/bin/image-builder/linux-amd64/image-builder
+2bea8265951b0654a8121d8b19901eda7d09a67c71167bb21f9571d6eeb6fe1e  _output/bin/image-builder/linux-arm64/image-builder

--- a/projects/aws/image-builder/builder/builder.go
+++ b/projects/aws/image-builder/builder/builder.go
@@ -14,9 +14,7 @@ const (
 	buildToolingRepoUrl = "https://github.com/aws/eks-anywhere-build-tooling.git"
 )
 
-var (
-	codebuild = os.Getenv("CODEBUILD_CI")
-)
+var codebuild = os.Getenv("CODEBUILD_CI")
 
 func (b *BuildOptions) BuildImage() {
 	// Clone build tooling repo
@@ -61,7 +59,7 @@ func (b *BuildOptions) BuildImage() {
 		if err != nil {
 			log.Fatalf("Error marshalling vsphere config data")
 		}
-		err = ioutil.WriteFile(filepath.Join(imageBuilderProjectPath, "packer/ova/vsphere.json"), vsphereConfigData, 0644)
+		err = ioutil.WriteFile(filepath.Join(imageBuilderProjectPath, "packer/ova/vsphere.json"), vsphereConfigData, 0o644)
 		if err != nil {
 			log.Fatalf("Error writing vsphere config file to packer")
 		}
@@ -98,7 +96,7 @@ func (b *BuildOptions) BuildImage() {
 			if err != nil {
 				log.Fatalf("Error marshalling baremetal config data")
 			}
-			err = ioutil.WriteFile(baremetalConfigFile, baremetalConfigData, 0644)
+			err = ioutil.WriteFile(baremetalConfigFile, baremetalConfigData, 0o644)
 			if err != nil {
 				log.Fatalf("Error writing baremetal config file to packer")
 			}
@@ -122,7 +120,7 @@ func (b *BuildOptions) BuildImage() {
 			if err := os.Remove(ubuntuEfiConfigPath); err != nil {
 				log.Fatalf("Error removing the old ubuntu efi config file: %v", err)
 			}
-			if err := os.WriteFile(ubuntuEfiConfigPath, []byte(ubuntuPatchedEfiConfig), 0644); err != nil {
+			if err := os.WriteFile(ubuntuEfiConfigPath, []byte(ubuntuPatchedEfiConfig), 0o644); err != nil {
 				log.Fatalf("Error writing the new ubuntu efi config file: %v", err)
 			}
 			log.Println("Patched upstream firmware config file")
@@ -166,7 +164,7 @@ func (b *BuildOptions) BuildImage() {
 		if err != nil {
 			log.Fatalf("Error marshalling nutanix config data")
 		}
-		err = ioutil.WriteFile(filepath.Join(upstreamImageBuilderProjectPath, "packer/nutanix/nutanix.json"), nutanixConfigData, 0644)
+		err = ioutil.WriteFile(filepath.Join(upstreamImageBuilderProjectPath, "packer/nutanix/nutanix.json"), nutanixConfigData, 0o644)
 		if err != nil {
 			log.Fatalf("Error writing nutanix config file to packer: %v", err)
 		}
@@ -182,14 +180,14 @@ func (b *BuildOptions) BuildImage() {
 		// Create config file
 		cloudstackConfigFile := filepath.Join(imageBuilderProjectPath, "packer/config/cloudstack.json")
 
-		//Assign ansible user var for cloudstack provider
+		// Assign ansible user var for cloudstack provider
 		b.CloudstackConfig.AnsibleUserVars = "provider=cloudstack"
 		if b.CloudstackConfig != nil {
 			cloudstackConfigData, err := json.Marshal(b.CloudstackConfig)
 			if err != nil {
 				log.Fatalf("Error marshalling cloudstack config data")
 			}
-			err = ioutil.WriteFile(cloudstackConfigFile, cloudstackConfigData, 0644)
+			err = ioutil.WriteFile(cloudstackConfigFile, cloudstackConfigData, 0o644)
 			if err != nil {
 				log.Fatalf("Error writing cloudstack config file to packer")
 			}
@@ -235,7 +233,7 @@ func (b *BuildOptions) BuildImage() {
 				log.Fatalf("Error marshalling AMI config data")
 			}
 
-			err = ioutil.WriteFile(amiConfigFile, amiConfigData, 0644)
+			err = ioutil.WriteFile(amiConfigFile, amiConfigData, 0o644)
 			if err != nil {
 				log.Fatalf("Error writing AMI config file to packer")
 			}

--- a/projects/aws/image-builder/builder/constants.go
+++ b/projects/aws/image-builder/builder/constants.go
@@ -8,7 +8,6 @@ const (
 	DefaultAMIRootDeviceName      string = "/dev/sda1"
 	DefaultAMIVolumeSize          string = "25"
 	DefaultAMIVolumeType          string = "gp3"
-	DefaultAMICustomRoleNames     string = "/home/image-builder/eks-anywhere-build-tooling/projects/kubernetes-sigs/image-builder/ansible/roles/load_additional_files"
 	DefaultAMIAnsibleExtraVars    string = "@/home/image-builder/eks-anywhere-build-tooling/projects/kubernetes-sigs/image-builder/packer/ami/ansible_extra_vars.yaml"
 	DefaultAMIManifestOutput      string = "/home/image-builder/manifest.json"
 )

--- a/projects/aws/image-builder/builder/types.go
+++ b/projects/aws/image-builder/builder/types.go
@@ -98,6 +98,7 @@ type AMIConfig struct {
 	CustomRoleNames     string   `json:"custom_role_names"`
 	ManifestOutput      string   `json:"manifest_output"`
 	RootDeviceName      string   `json:"root_device_name"`
+	SubnetID            string   `json:"subnet_id"`
 	VolumeSize          string   `json:"volume_size"`
 	VolumeType          string   `json:"volume_type"`
 }

--- a/projects/aws/image-builder/cmd/build.go
+++ b/projects/aws/image-builder/cmd/build.go
@@ -165,7 +165,6 @@ func ValidateInputs(bo *builder.BuildOptions) error {
 				AWSRegion:           builder.DefaultAMIBuildRegion,
 				BuilderInstanceType: builder.DefaultAMIBuilderInstanceType,
 				CustomRole:          "true",
-				CustomRoleNames:     builder.DefaultAMICustomRoleNames,
 				AnsibleExtraVars:    builder.DefaultAMIAnsibleExtraVars,
 				ManifestOutput:      builder.DefaultAMIManifestOutput,
 				RootDeviceName:      builder.DefaultAMIRootDeviceName,
@@ -209,6 +208,7 @@ func validateOSHypervisorCombinations(os, hypervisor string) error {
 
 	return nil
 }
+
 func validateRedhat(rhelUsername, rhelPassword, isoUrl string) error {
 	if rhelUsername == "" || rhelPassword == "" {
 		return fmt.Errorf("\"rhel_username\" and \"rhel_password\" are required fields in config when os is redhat")


### PR DESCRIPTION
Adding subnet ID field to configure the subnet/VPC in which Packer launches the builder EC2 instance.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
