### PR TITLE
Fix for setup-packer-configs-ova error

### DIFF
--- a/build/lib/eksa_releases.sh
+++ b/build/lib/eksa_releases.sh
@@ -32,7 +32,7 @@ function build::eksa_releases::load_bundle_manifest() {
 
     local -r latest_version=$(echo "$release_manifest" | yq e ".spec.latestVersion" -)
     local -r bundle_manifest_url=$(echo "$release_manifest" | yq e ".spec.releases[] | select(.version == \"$latest_version\") .bundleManifestUrl" -)
-    BUNDLE_MANIFEST[$bundle_manifest_key]=$(yq | curl -s --retry 5 "$bundle_manifest_url")
+    BUNDLE_MANIFEST[$bundle_manifest_key]=$(curl -s --retry 5 "$bundle_manifest_url" | yq)
   fi
   if $echo; then
     echo "${BUNDLE_MANIFEST[$bundle_manifest_key]}"


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere/issues/4724

*Description of changes:*
The curl output should be piped into yq, not the other way around.

Paired with @vignesh-goutham on this fix.

This simply pipes the curl output into yq as intended. At this time, it is unclear why the script just stops at this location, but this fixes it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
