### PR TITLE
Patch image-builder to add IMDS configuration support for Packer builds

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0012-Add-instance-metadata-options-to-Packer-config.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0012-Add-instance-metadata-options-to-Packer-config.patch
@@ -1,0 +1,39 @@
+From 6d13b606a4adc23fc36e7f062d4ed6e07facdb3b Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Thu, 2 Feb 2023 01:39:15 -0800
+Subject: [PATCH] Add instance metadata options to Packer config
+
+Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
+---
+ images/capi/packer/ami/packer.json | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/images/capi/packer/ami/packer.json b/images/capi/packer/ami/packer.json
+index d12b863a4..801137786 100644
+--- a/images/capi/packer/ami/packer.json
++++ b/images/capi/packer/ami/packer.json
+@@ -22,6 +22,11 @@
+           "volume_type": "{{ user `volume_type` }}"
+         }
+       ],
++      "metadata_options": {
++        "http_endpoint": "{{ user `http_endpoint` }}",
++        "http_tokens": "{{ user `http_tokens` }}",
++        "http_put_response_hop_limit": "{{ user `http_put_response_hop_limit` }}"
++      },
+       "name": "{{user `build_name`}}",
+       "profile": "{{ user `aws_profile`}}",
+       "region": "{{ user `aws_region` }}",
+@@ -165,6 +170,9 @@
+     "crictl_version": null,
+     "encrypted": "false",
+     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
++    "http_endpoint": "enabled",
++    "http_tokens": "required",
++    "http_put_response_hop_limit": "2",
+     "iam_instance_profile": "",
+     "ib_version": "{{env `IB_VERSION`}}",
+     "iops": "3000",
+-- 
+2.37.0
+


### PR DESCRIPTION
IMDS configuration options are available for the Packer Amazon EBS builder instance but not exposed as part of upstream image-builder's Packer config. So we need to patch it to make it configurable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
