### PR TITLE
Pin kustomize version to v4.5.7

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -393,6 +393,7 @@ UPLOAD_DO_NOT_DELETE?=false
 ####################################################
 
 #################### OTHER #########################
+KUSTOMIZE_VERSION=4.5.7
 KUSTOMIZE_TARGET=$(OUTPUT_DIR)/kustomize
 GIT_DEPS_DIR?=$(OUTPUT_DIR)/gitdependencies
 SPECIAL_TARGET_SECONDARY=$(strip $(PROJECT_DEPENDENCIES_TARGETS) $(GO_MOD_DOWNLOAD_TARGETS))
@@ -540,7 +541,7 @@ binaries: $(BINARY_TARGETS)
 
 $(KUSTOMIZE_TARGET):
 	@mkdir -p $(OUTPUT_DIR)
-	curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- $(OUTPUT_DIR)
+	curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s $(KUSTOMIZE_VERSION) $(OUTPUT_DIR)
 
 .PHONY: clone-repo
 clone-repo: $(REPO)


### PR DESCRIPTION
[Kustomize](https://github.com/kubernetes-sigs/kustomize) released a new version v5.0.0 today which caused some issues in generating manifests, specifically setting `creationTimestamp` to `"null"` (with quotes). So pinning to an older version to avoid this. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
