### PR TITLE
Updated EKS-D to 1.25-eks-5

### DIFF
--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -21,6 +21,6 @@ releases:
   number: 8
   kubeVersion: v1.24.9
 - branch: 1-25
-  number: 3
-  kubeVersion: v1.25.5
+  number: 5
+  kubeVersion: v1.25.6
 latest: 1-22


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Update to latest release of EKS-D 1.25 (v1.25-eks-5), which upgrades Kubernetes from 1.25.5 to 1.25.6 and includes updates to patches

Side note: release 4 is skipped because it included a minor bug

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
