### PR TITLE
Fix CVE-2022-1996 for Cluster Autoscaler 1-23

### DIFF
--- a/projects/kubernetes/autoscaler/1-23/CHECKSUMS
+++ b/projects/kubernetes/autoscaler/1-23/CHECKSUMS
@@ -1,2 +1,2 @@
-d196eb528275682aae8e42e3a3691207d3d880c276c0693895ac53eef8037e0c  _output/1-23/bin/autoscaler/linux-amd64/cluster-autoscaler
-c552816fe821414e8616c8b09f845788a057cb6c627f0668b86ccf79dd1d95c4  _output/1-23/bin/autoscaler/linux-arm64/cluster-autoscaler
+cd94c9c7c322f7189d8b64e614bc75475d548462439f8ce297c331c89eb1abae  _output/1-23/bin/autoscaler/linux-amd64/cluster-autoscaler
+f6a8ca293dd23b712d1bbf628b851c3a490137752edc66250d8dd1e30db65497  _output/1-23/bin/autoscaler/linux-arm64/cluster-autoscaler

--- a/projects/kubernetes/autoscaler/1-23/patches/0002-Fix-CVE-2022-1996-for-1.23.patch
+++ b/projects/kubernetes/autoscaler/1-23/patches/0002-Fix-CVE-2022-1996-for-1.23.patch
@@ -1,0 +1,50 @@
+From 607a0779cd7e78f3dd3c390541ecb90df06212c3 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Wed, 8 Feb 2023 10:18:23 -0500
+Subject: [PATCH] Fix CVE 2022-1996 for 1.23
+
+Requires go-restful>=3.8.0.
+---
+ cluster-autoscaler/go.mod | 3 +++
+ cluster-autoscaler/go.sum | 7 ++++---
+ 2 files changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/cluster-autoscaler/go.mod b/cluster-autoscaler/go.mod
+index 2bed8b24d..6ea67dbf5 100644
+--- a/cluster-autoscaler/go.mod
++++ b/cluster-autoscaler/go.mod
+@@ -12,6 +12,7 @@ require (
+ 	github.com/Azure/go-autorest/autorest/to v0.4.0
+ 	github.com/aws/aws-sdk-go v1.38.49
+ 	github.com/digitalocean/godo v1.27.0
++	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
+ 	github.com/ghodss/yaml v1.0.0
+ 	github.com/gofrs/uuid v4.0.0+incompatible
+ 	github.com/golang/mock v1.6.0
+@@ -101,3 +102,5 @@ replace k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.23.0
+ replace k8s.io/sample-controller => k8s.io/sample-controller v0.23.0
+ 
+ replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.23.0
++
++replace github.com/emicklei/go-restful => github.com/emicklei/go-restful/v3 v3.8.0
+diff --git a/cluster-autoscaler/go.sum b/cluster-autoscaler/go.sum
+index 046b77812..10df340f4 100644
+--- a/cluster-autoscaler/go.sum
++++ b/cluster-autoscaler/go.sum
+@@ -235,9 +235,10 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
+ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+ github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
+ github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
+-github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+-github.com/emicklei/go-restful v2.9.5+incompatible h1:spTtZBk5DYEvbxMVutUuTyh1Ao2r4iyvLdACqsl/Ljk=
+-github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
++github.com/emicklei/go-restful/v3 v3.8.0 h1:eCZ8ulSerjdAiaNpF7GxXIE7ZCMo1moN1qX+S609eVw=
++github.com/emicklei/go-restful/v3 v3.8.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
++github.com/emicklei/go-restful/v3 v3.9.0 h1:XwGDlfxEnQZzuopoqxwSEllNcCOM9DhhFyhFIIGKwxE=
++github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
+ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
+ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
+-- 
+2.37.1 (Apple Git-137.1)
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes https://nvd.nist.gov/vuln/detail/CVE-2022-1996, present in Cluster Autoscaler v1.23.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->