### PR TITLE
Patch image-builder to rename Snow node AMI

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0012-Add-instance-metadata-options-to-Packer-config.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0012-Add-instance-metadata-options-to-Packer-config.patch
@@ -1,5 +1,5 @@
 From 6d13b606a4adc23fc36e7f062d4ed6e07facdb3b Mon Sep 17 00:00:00 2001
-From: Prow Bot <prow@amazonaws.com>
+From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Feb 2023 01:39:15 -0800
 Subject: [PATCH] Add instance metadata options to Packer config
 

--- a/projects/kubernetes-sigs/image-builder/patches/0013-Rename-Snow-node-image-to-reflect-appropriate-CAPI-p.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0013-Rename-Snow-node-image-to-reflect-appropriate-CAPI-p.patch
@@ -1,0 +1,26 @@
+From 5c4cac4d29f5952aeefc5eacb5c8b1dca51c8f8d Mon Sep 17 00:00:00 2001
+From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
+Date: Fri, 10 Feb 2023 16:08:18 -0800
+Subject: [PATCH] Rename Snow node image to reflect appropriate CAPI provider
+
+Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
+---
+ images/capi/packer/ami/packer.json | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/images/capi/packer/ami/packer.json b/images/capi/packer/ami/packer.json
+index 64fb3ce15..6e0b781c9 100644
+--- a/images/capi/packer/ami/packer.json
++++ b/images/capi/packer/ami/packer.json
+@@ -4,7 +4,7 @@
+       "access_key": "{{user `aws_access_key`}}",
+       "ami_description": "{{user `ami_description`}}",
+       "ami_groups": "{{user `ami_groups`}}",
+-      "ami_name": "capa-ami-{{user `build_name`}}-{{user `kubernetes_semver` | clean_resource_name}}-{{user `build_timestamp`}}",
++      "ami_name": "capas-ami-{{user `build_name`}}-{{user `kubernetes_semver` | clean_resource_name}}-{{user `build_timestamp`}}",
+       "ami_product_codes": "",
+       "ami_regions": "{{user `ami_regions`}}",
+       "ami_users": "{{user `ami_users`}}",
+-- 
+2.37.0
+


### PR DESCRIPTION
This PR adds the option to rename the AMI that gets created by image-builder. The default name is `capa-ami-<OS name>-<kubernetes_semver>-<timestamp>`, changing it to reference CAPAS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
