### PR TITLE
Cleanup repo only in non-Codebuild environments

### DIFF
--- a/projects/aws/image-builder/CHECKSUMS
+++ b/projects/aws/image-builder/CHECKSUMS
@@ -1,2 +1,2 @@
-339badeac0c589c71128da81c24a7cb08b59dd97b92987470c634b115632cfd5  _output/bin/image-builder/linux-amd64/image-builder
-2bea8265951b0654a8121d8b19901eda7d09a67c71167bb21f9571d6eeb6fe1e  _output/bin/image-builder/linux-arm64/image-builder
+3398380c30e009216e0b37373bc610e724a17cf2089898846fbad90ddf146291  _output/bin/image-builder/linux-amd64/image-builder
+59d897125f94ca463e80279352153d40b6eb7fa205c63fdee1ab4e3a98a52365  _output/bin/image-builder/linux-arm64/image-builder

--- a/projects/aws/image-builder/builder/builder.go
+++ b/projects/aws/image-builder/builder/builder.go
@@ -42,7 +42,9 @@ func (b *BuildOptions) BuildImage() {
 
 	supportedReleaseBranches := GetSupportedReleaseBranches()
 	if !SliceContains(supportedReleaseBranches, b.ReleaseChannel) {
-		cleanup(buildToolingRepoPath)
+		if codebuild != "true" {
+			cleanup(buildToolingRepoPath)
+		}
 		log.Fatalf("release-channel should be one of %v", supportedReleaseBranches)
 	}
 


### PR DESCRIPTION
If the build is running in Codebuild, there is no cloned repo so we don't need to run the cleanup.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
