### PR TITLE
Enforce IMDSv2 in EKS-A Admin image builder AMI

### DIFF
--- a/projects/aws/eks-a-admin-image/eks-a-admin-snow.pkr.hcl
+++ b/projects/aws/eks-a-admin-image/eks-a-admin-snow.pkr.hcl
@@ -43,6 +43,12 @@ source "amazon-ebs" "amazonlinux2" {
     delay_seconds = 5
     max_attempts  = 1440
   }
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 2
+  }
 }
 
 build {


### PR DESCRIPTION
Ensuring that [IMDSv2 is enabled](https://developer.hashicorp.com/packer/plugins/builders/amazon/ebs#metadata-settings) in the source AMI that gets launched when building the EKS-A Admin image.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
