### PR TITLE
Add kubectl to packages image for helm hooks

### DIFF
--- a/projects/aws/eks-anywhere-packages/Makefile
+++ b/projects/aws/eks-anywhere-packages/Makefile
@@ -9,6 +9,7 @@ GO_MOD_NAME="github.com/aws/eks-anywhere-packages/"
 GO_VAR_PREFIX="pkg/config."
 GO_VARS=version=${GIT_TAG} gitHash=${PROJECT_COMMIT_HASH} buildTime=${TIME}
 EXTRA_GO_LDFLAGS=$(foreach v,$(GO_VARS),-X ${GO_MOD_NAME}${GO_VAR_PREFIX}${v})
+PROJECT_DEPENDENCIES=eksd/kubernetes/client
 
 
 DOCKERFILE_FOLDER=./docker/linux/$(IMAGE_NAME)

--- a/projects/aws/eks-anywhere-packages/docker/linux/eks-anywhere-packages/Dockerfile
+++ b/projects/aws/eks-anywhere-packages/docker/linux/eks-anywhere-packages/Dockerfile
@@ -5,6 +5,7 @@ ARG TARGETARCH
 ARG TARGETOS
 
 COPY _output/bin/eks-anywhere-packages/$TARGETOS-$TARGETARCH/package-manager /package-manager
+COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksd/kubernetes/client/bin/kubectl /usr/local/bin/kubectl
 COPY _output/LICENSES /LICENSES
 COPY ATTRIBUTION.txt /ATTRIBUTION.txt
 


### PR DESCRIPTION
*Description of changes:* Adds kubectl for use within helm hooks to migrate resources.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
