### PR TITLE
Fix binary format on arm

### DIFF
--- a/projects/kubernetes-sigs/cluster-api-provider-cloudstack/docker/linux/Dockerfile
+++ b/projects/kubernetes-sigs/cluster-api-provider-cloudstack/docker/linux/Dockerfile
@@ -1,9 +1,12 @@
 ARG BASE_IMAGE # https://gallery.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nonroot
 FROM $BASE_IMAGE
 
+ARG TARGETARCH
+ARG TARGETOS
+
 WORKDIR /
 
-COPY _output/bin/cluster-api-provider-cloudstack/linux-amd64/manager /manager
+COPY _output/bin/cluster-api-provider-cloudstack/$TARGETOS-$TARGETARCH/manager /manager
 COPY _output/LICENSES /LICENSES
 COPY ATTRIBUTION.txt /ATTRIBUTION.txt
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* cluster-api-provider-cloudstack cannot run on arm machine because the binary inside the container is wrong


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
