### PR TITLE
Patch image-builder to fix Goss validations for all EKS-A infra provider image builds

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0001-Add-goss-validations-for-EKS-D-artifacts.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0001-Add-goss-validations-for-EKS-D-artifacts.patch
@@ -1,7 +1,7 @@
 From b67da3f6ef97e1f2db22a4b5e7be6382953ec14a Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 18:36:56 -0800
-Subject: [PATCH 1/9] Add goss validations for EKS-D artifacts
+Subject: [PATCH 1/14] Add goss validations for EKS-D artifacts
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0002-Install-containerd-from-apt-for-Ubuntu.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0002-Install-containerd-from-apt-for-Ubuntu.patch
@@ -1,7 +1,7 @@
 From 3588c40c0866c198093f9ab5ae39c688466e2f6f Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 18:37:06 -0800
-Subject: [PATCH 2/9] Install containerd from apt for Ubuntu
+Subject: [PATCH 2/14] Install containerd from apt for Ubuntu
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0003-Output-vsphere-builds-to-content-library-instead-of-.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0003-Output-vsphere-builds-to-content-library-instead-of-.patch
@@ -1,7 +1,7 @@
 From 03eda063b3a45ba6b5fca9262ea8981b7ba8d3c1 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:00:12 -0800
-Subject: [PATCH 3/9] Output vsphere builds to content library instead of
+Subject: [PATCH 3/14] Output vsphere builds to content library instead of
  exports
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0004-Create-etc-pki-tls-certs-dir-as-part-of-image-builds.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0004-Create-etc-pki-tls-certs-dir-as-part-of-image-builds.patch
@@ -1,7 +1,7 @@
 From 5e8dbf2b9e63897d823ae55e6419593be478c315 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:05:13 -0800
-Subject: [PATCH 4/9] Create /etc/pki/tls/certs dir as part of image-builds
+Subject: [PATCH 4/14] Create /etc/pki/tls/certs dir as part of image-builds
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0005-Add-etcdadm-and-etcd.tar.gz-to-image-for-unstacked-e.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0005-Add-etcdadm-and-etcd.tar.gz-to-image-for-unstacked-e.patch
@@ -1,7 +1,7 @@
 From 96612ddda5df25dff2dde850a475dcad86786790 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:12:53 -0800
-Subject: [PATCH 5/9] Add etcdadm and etcd.tar.gz to image for unstacked etcd
+Subject: [PATCH 5/14] Add etcdadm and etcd.tar.gz to image for unstacked etcd
  support
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0006-Additional-EKS-A-specific-goss-validations.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0006-Additional-EKS-A-specific-goss-validations.patch
@@ -1,7 +1,7 @@
 From 2ffe0c89f5f7a01187ab8bdc3dbad734e834a932 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:26:09 -0800
-Subject: [PATCH 6/9] Additional EKS-A specific goss validations
+Subject: [PATCH 6/14] Additional EKS-A specific goss validations
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0007-Tweak-Product-info-in-OVF.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0007-Tweak-Product-info-in-OVF.patch
@@ -1,7 +1,7 @@
 From d24b5209475a40f7eba76bb36f3d2d1f7ca33892 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:29:16 -0800
-Subject: [PATCH 7/9] Tweak Product info in OVF
+Subject: [PATCH 7/14] Tweak Product info in OVF
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0008-Add-support-for-RHEL-8-RAW-image-builds.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0008-Add-support-for-RHEL-8-RAW-image-builds.patch
@@ -1,7 +1,7 @@
 From b7045aa56a8744c86662fff3c18ca0042789d113 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Fri, 25 Mar 2022 14:17:33 -0700
-Subject: [PATCH 8/9] Add support for RHEL 8 RAW image builds
+Subject: [PATCH 8/14] Add support for RHEL 8 RAW image builds
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0009-Support-crictl-validation-from-input-checksum.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0009-Support-crictl-validation-from-input-checksum.patch
@@ -1,7 +1,7 @@
 From ff8c2434c0ec952bf7a1cdbfe3557a4082efd2f1 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Fri, 2 Sep 2022 14:32:21 -0700
-Subject: [PATCH 9/9] Support crictl validation from input checksum
+Subject: [PATCH 9/14] Support crictl validation from input checksum
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0010-Exclude-kernel-and-cloud-init-from-yum-updates.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0010-Exclude-kernel-and-cloud-init-from-yum-updates.patch
@@ -1,7 +1,7 @@
 From ce8ff287cf476896a48092f75dffe325c087504c Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
 Date: Tue, 6 Dec 2022 15:42:02 -0600
-Subject: [PATCH] Exclude kernel and cloud-init from yum updates
+Subject: [PATCH 10/14] Exclude kernel and cloud-init from yum updates
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0011-Patch-cloud-init-systemd-unit-to-wait-for-network-ma.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0011-Patch-cloud-init-systemd-unit-to-wait-for-network-ma.patch
@@ -1,7 +1,7 @@
 From 6eb44207c6cd9206e1db927318fe26a704294100 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Mon, 9 Jan 2023 14:11:18 -0600
-Subject: [PATCH] Patch cloud-init systemd unit to wait for network manager
+Subject: [PATCH 11/14] Patch cloud-init systemd unit to wait for network manager
  online
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0012-Add-instance-metadata-options-to-Packer-config.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0012-Add-instance-metadata-options-to-Packer-config.patch
@@ -1,7 +1,7 @@
 From 6d13b606a4adc23fc36e7f062d4ed6e07facdb3b Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Feb 2023 01:39:15 -0800
-Subject: [PATCH] Add instance metadata options to Packer config
+Subject: [PATCH 12/14] Add instance metadata options to Packer config
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0013-Rename-Snow-node-image-to-reflect-appropriate-CAPI-p.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0013-Rename-Snow-node-image-to-reflect-appropriate-CAPI-p.patch
@@ -1,7 +1,7 @@
 From 5c4cac4d29f5952aeefc5eacb5c8b1dca51c8f8d Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Fri, 10 Feb 2023 16:08:18 -0800
-Subject: [PATCH] Rename Snow node image to reflect appropriate CAPI provider
+Subject: [PATCH 12/14] Rename Snow node image to reflect appropriate CAPI provider
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0014-Add-EKS-A-specific-inline-Goss-vars-to-all-supported.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0014-Add-EKS-A-specific-inline-Goss-vars-to-all-supported.patch
@@ -1,0 +1,89 @@
+From 5cd28db729dba2b8734816044a64ef5461ca3472 Mon Sep 17 00:00:00 2001
+From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
+Date: Thu, 2 Mar 2023 19:27:50 -0800
+Subject: [PATCH 14/14] Add EKS-A specific inline Goss vars to all supported
+ providers
+
+Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
+---
+ images/capi/packer/ami/packer.json     | 7 ++++++-
+ images/capi/packer/nutanix/packer.json | 7 ++++++-
+ images/capi/packer/qemu/packer.json    | 7 ++++++-
+ images/capi/packer/raw/packer.json     | 7 ++++++-
+ 4 files changed, 24 insertions(+), 4 deletions(-)
+
+diff --git a/images/capi/packer/ami/packer.json b/images/capi/packer/ami/packer.json
+index 6e0b781c9..b3147acea 100644
+--- a/images/capi/packer/ami/packer.json
++++ b/images/capi/packer/ami/packer.json
+@@ -142,7 +142,12 @@
+         "kubernetes_deb_version": "{{ user `kubernetes_deb_version` }}",
+         "kubernetes_rpm_version": "{{ split (user `kubernetes_rpm_version`) \"-\" 0 }}",
+         "kubernetes_source_type": "{{user `kubernetes_source_type`}}",
+-        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}"
++        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}",
++        "etcdadm_version": "{{ user `etcdadm_version` }}",
++        "etcd_version": "{{ user `etcd_version` }}",
++        "etcd_sha256": "{{ user `etcd_sha256` }}",
++        "pause_image": "{{ user `pause_image` }}",
++        "kubernetes_cni_host_device_sha256": "{{ user `kubernetes_cni_host_device_sha256` }}"
+       },
+       "version": "{{user `goss_version`}}"
+     }
+diff --git a/images/capi/packer/nutanix/packer.json b/images/capi/packer/nutanix/packer.json
+index f623d9236..0f078c894 100644
+--- a/images/capi/packer/nutanix/packer.json
++++ b/images/capi/packer/nutanix/packer.json
+@@ -81,7 +81,12 @@
+         "kubernetes_deb_version": "{{ user `kubernetes_deb_version` }}",
+         "kubernetes_rpm_version": "{{ split (user `kubernetes_rpm_version`) \"-\" 0  }}",
+         "kubernetes_source_type": "{{user `kubernetes_source_type`}}",
+-        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}"
++        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}",
++        "etcdadm_version": "{{ user `etcdadm_version` }}",
++        "etcd_version": "{{ user `etcd_version` }}",
++        "etcd_sha256": "{{ user `etcd_sha256` }}",
++        "pause_image": "{{ user `pause_image` }}",
++        "kubernetes_cni_host_device_sha256": "{{ user `kubernetes_cni_host_device_sha256` }}"
+       },
+       "version": "{{user `goss_version`}}"
+     }
+diff --git a/images/capi/packer/qemu/packer.json b/images/capi/packer/qemu/packer.json
+index d7e13400e..b35d60062 100644
+--- a/images/capi/packer/qemu/packer.json
++++ b/images/capi/packer/qemu/packer.json
+@@ -115,7 +115,12 @@
+         "kubernetes_deb_version": "{{ user `kubernetes_deb_version` }}",
+         "kubernetes_rpm_version": "{{ split (user `kubernetes_rpm_version`) \"-\" 0  }}",
+         "kubernetes_source_type": "{{user `kubernetes_source_type`}}",
+-        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}"
++        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}",
++        "etcdadm_version": "{{ user `etcdadm_version` }}",
++        "etcd_version": "{{ user `etcd_version` }}",
++        "etcd_sha256": "{{ user `etcd_sha256` }}",
++        "pause_image": "{{ user `pause_image` }}",
++        "kubernetes_cni_host_device_sha256": "{{ user `kubernetes_cni_host_device_sha256` }}"
+       },
+       "version": "{{user `goss_version`}}"
+     }
+diff --git a/images/capi/packer/raw/packer.json b/images/capi/packer/raw/packer.json
+index 935912d1b..cea216116 100644
+--- a/images/capi/packer/raw/packer.json
++++ b/images/capi/packer/raw/packer.json
+@@ -119,7 +119,12 @@
+         "kubernetes_deb_version": "{{ user `kubernetes_deb_version` }}",
+         "kubernetes_rpm_version": "{{ split (user `kubernetes_rpm_version`) \"-\" 0  }}",
+         "kubernetes_source_type": "{{user `kubernetes_source_type`}}",
+-        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}"
++        "kubernetes_version": "{{user `kubernetes_semver` | replace \"v\" \"\" 1}}",
++        "etcdadm_version": "{{ user `etcdadm_version` }}",
++        "etcd_version": "{{ user `etcd_version` }}",
++        "etcd_sha256": "{{ user `etcd_sha256` }}",
++        "pause_image": "{{ user `pause_image` }}",
++        "kubernetes_cni_host_device_sha256": "{{ user `kubernetes_cni_host_device_sha256` }}"
+       },
+       "version": "{{user `goss_version`}}"
+     }
+-- 
+2.37.0
+


### PR DESCRIPTION
Along with the Goss post-build validations included in upstream image-builder, we also have our own validations which verify some EKS-A specific build changes and configurations.  The inline variables for these Goss validations are passed in only for OVA builds (since they were the only images we were building when the patch was added) but they are being set to empty for other providers which caused incorrect var resolutions and false positive errors such as
```
File: /var/cache/etcdadm/etcd//etcd--linux-amd64.tar.gz: exists:Expected <bool>: false to equal <bool>: true
```
This happened because the `etcd` tarball template is `/var/cache/etcdadm/etcd/{{ etcd_version }}/etcd-{{ etcd_version }}-linux-amd64.tar.gz` but `etcd_version` is not passed to the Goss vars list.
This PR fixes this by adding the vars in the AMI, Raw, Cloudstack and Nutanix Packer configs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
