### PR TITLE
Small changes to kind to support iptables-nft

### DIFF
--- a/projects/kubernetes-sigs/kind/Makefile
+++ b/projects/kubernetes-sigs/kind/Makefile
@@ -73,6 +73,7 @@ $(GATHER_LICENSES_TARGETS): | $(FIX_LICENSES_KINDNETD_TARGET)
 s3-artifacts: $(ARTIFACTS_PATH)/manifests/kindnetd/$(GIT_TAG)/kindnetd.yaml
 
 images: kind-base-versioned/images/push kind-node/images/push
+create-ecr-repos: kind-node/create-ecr-repo
 
 $(OUTPUT_BIN_DIR)/%/kind: EXTRA_GO_LDFLAGS=-X=sigs.k8s.io/kind/pkg/cmd/kind/version.gitCommit=$(shell git -C $(REPO) rev-list -n 1  "${GIT_TAG}")
 
@@ -118,10 +119,14 @@ kind-node/images/push: IMAGE_TARGET=node
 kind-node/images/push: $(KIND_NODE_BUILD_AMD64_TARGET) $(KIND_NODE_BUILD_ARM64_TARGET) $(ARM_ENV_CONF_TARGET)
 
 $(KIND_BASE_IMAGE_BUILD_ARGS):
+	@echo -e $(call TARGET_START_LOG)
 	build/base-image-build-args.sh $(RELEASE_BRANCH) $(ARTIFACTS_BUCKET) $@ $(LATEST)
+	@echo -e $(call TARGET_END_LOG)
 
 $(KIND_NODE_IMAGE_BUILD_ARGS):
+	@echo -e $(call TARGET_START_LOG)
 	build/node-image-build-args.sh $(RELEASE_BRANCH) $(KINDNETD_IMAGE_COMPONENT) $(IMAGE_REPO) "$(ARTIFACTS_BUCKET)" $(IMAGE_TAG) $(LATEST) $@
+	@echo -e $(call TARGET_END_LOG)
 
 # Tweak the kind/base image to have a hardcode kubeadm config
 # so that during the image pull phase it pulls eks-d images

--- a/projects/kubernetes-sigs/kind/build/create-kind-cluster.sh
+++ b/projects/kubernetes-sigs/kind/build/create-kind-cluster.sh
@@ -51,7 +51,6 @@ apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 kubeadmConfigPatches:
 - |
-    apiVersion: kubeadm.k8s.io/v1beta2
     kind: ClusterConfiguration
     dns:
         type: CoreDNS

--- a/projects/kubernetes-sigs/kind/images/kindnetd/Dockerfile
+++ b/projects/kubernetes-sigs/kind/images/kindnetd/Dockerfile
@@ -8,4 +8,7 @@ COPY --chown=root:root _output/bin/kind/$TARGETOS-$TARGETARCH/kindnetd /bin/kind
 COPY _output/kindnetd/LICENSES /KINDNETD_LICENSES
 COPY KINDNETD_ATTRIBUTION.txt /KINDNETD_ATTRIBUTION.txt
 
+# Opt into using the iptables-wrapper script to determine iptables mode
+RUN ["update-alternatives", "--set", "iptables", "/usr/sbin/iptables-wrapper"]
+
 CMD ["/bin/kindnetd"]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We recently added the iptables-wrapper to the iptables minimal image so we can support iptables-nft as well as iptables-legacy. This changes the kindnetd image to use this new wrapper alternative.

I made a couple small changes to the kind build to facilitate to my testing of this and for next time we need to run similar tests.

I had thought I would need to make changes to the kind image as well to use the wrapper, however turns out we can't use the wrapper for that case. The kind [entrypoint](https://github.com/kubernetes-sigs/kind/blob/main/images/base/files/usr/local/bin/entrypoint#L364) actually uses a version of the old way of detecting iptables mode by counting the number of iptables rules.  I do not think they can use the new style of looking for the hint created by the kubelet, since the kind vm is booting before kubelet has run. Because of this, I have left this entrypoint alone which has actually always properly switched the mode.

I have tested on both a ubuntu 22.04 node which uses nft and a al2 using legacy to ensure that all three of the following properly switch to nft vs legacy:

- kind vm node
- kube-proxy pods
- kindnetd pod

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
