### PR TITLE
Re-add patch to use tar.gz extension for CNI plugins tarball

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0001-Add-goss-validations-for-EKS-D-artifacts.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0001-Add-goss-validations-for-EKS-D-artifacts.patch
@@ -1,7 +1,7 @@
 From 34d0bfdc0014c0d668d2ae81ac84b16a5cea322e Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 18:36:56 -0800
-Subject: [PATCH 01/13] Add goss validations for EKS-D artifacts
+Subject: [PATCH 01/14] Add goss validations for EKS-D artifacts
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0002-Output-vsphere-builds-to-content-library-instead-of-.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0002-Output-vsphere-builds-to-content-library-instead-of-.patch
@@ -1,7 +1,7 @@
 From 288be8cc85a4edb95ae8701ea2b42e3701671de4 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:00:12 -0800
-Subject: [PATCH 02/13] Output vsphere builds to content library instead of
+Subject: [PATCH 02/14] Output vsphere builds to content library instead of
  exports
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0003-Create-etc-pki-tls-certs-dir-as-part-of-image-builds.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0003-Create-etc-pki-tls-certs-dir-as-part-of-image-builds.patch
@@ -1,7 +1,7 @@
 From 459cb070afd02a41592a832277634a21e54ef785 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:05:13 -0800
-Subject: [PATCH 03/13] Create /etc/pki/tls/certs dir as part of image-builds
+Subject: [PATCH 03/14] Create /etc/pki/tls/certs dir as part of image-builds
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0004-Add-etcdadm-and-etcd.tar.gz-to-image-for-unstacked-e.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0004-Add-etcdadm-and-etcd.tar.gz-to-image-for-unstacked-e.patch
@@ -1,7 +1,7 @@
 From 58cbf77177bc8d809c7f451eba75f369a9e71bbb Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:12:53 -0800
-Subject: [PATCH 04/13] Add etcdadm and etcd.tar.gz to image for unstacked etcd
+Subject: [PATCH 04/14] Add etcdadm and etcd.tar.gz to image for unstacked etcd
  support
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0005-Additional-EKS-A-specific-goss-validations.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0005-Additional-EKS-A-specific-goss-validations.patch
@@ -1,7 +1,7 @@
 From e24c5b5fe0d72b0fa848e4c9cb18451d71439c69 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:26:09 -0800
-Subject: [PATCH 05/13] Additional EKS-A specific goss validations
+Subject: [PATCH 05/14] Additional EKS-A specific goss validations
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0006-Tweak-Product-info-in-OVF.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0006-Tweak-Product-info-in-OVF.patch
@@ -1,7 +1,7 @@
 From 6ce15f944ca5b1044cb6dada22006e6699a37c09 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:29:16 -0800
-Subject: [PATCH 06/13] Tweak Product info in OVF
+Subject: [PATCH 06/14] Tweak Product info in OVF
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0007-Add-support-for-RHEL-8-RAW-image-builds.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0007-Add-support-for-RHEL-8-RAW-image-builds.patch
@@ -1,7 +1,7 @@
 From 02466e5d1b15deb2cac0621c1e9197004477919e Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Fri, 25 Mar 2022 14:17:33 -0700
-Subject: [PATCH 07/13] Add support for RHEL 8 RAW image builds
+Subject: [PATCH 07/14] Add support for RHEL 8 RAW image builds
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0008-Support-crictl-validation-from-input-checksum.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0008-Support-crictl-validation-from-input-checksum.patch
@@ -1,7 +1,7 @@
 From 0f98bad00c51b84102ac1ee028a974e3b860b52e Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Fri, 2 Sep 2022 14:32:21 -0700
-Subject: [PATCH 08/13] Support crictl validation from input checksum
+Subject: [PATCH 08/14] Support crictl validation from input checksum
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0009-Exclude-kernel-and-cloud-init-from-yum-updates.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0009-Exclude-kernel-and-cloud-init-from-yum-updates.patch
@@ -1,7 +1,7 @@
 From 7c6f782664d2683a64e670fd06b556f3c4085bb6 Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
 Date: Tue, 6 Dec 2022 15:42:02 -0600
-Subject: [PATCH 09/13] Exclude kernel and cloud-init from yum updates
+Subject: [PATCH 09/14] Exclude kernel and cloud-init from yum updates
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0010-Patch-cloud-init-systemd-unit-to-wait-for-network-ma.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0010-Patch-cloud-init-systemd-unit-to-wait-for-network-ma.patch
@@ -1,7 +1,7 @@
 From b09e2bf3d33970f204f9a30e1a6515810cd3f666 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Mon, 9 Jan 2023 14:11:18 -0600
-Subject: [PATCH 10/13] Patch cloud-init systemd unit to wait for network
+Subject: [PATCH 10/14] Patch cloud-init systemd unit to wait for network
  manager online
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0011-Add-instance-metadata-options-to-Packer-config.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0011-Add-instance-metadata-options-to-Packer-config.patch
@@ -1,7 +1,7 @@
 From 2e8c25de607b30673eece004019943b8dbb6dfdb Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Feb 2023 01:39:15 -0800
-Subject: [PATCH 11/13] Add instance metadata options to Packer config
+Subject: [PATCH 11/14] Add instance metadata options to Packer config
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0012-Rename-Snow-node-image-to-reflect-appropriate-CAPI-p.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0012-Rename-Snow-node-image-to-reflect-appropriate-CAPI-p.patch
@@ -1,7 +1,7 @@
 From 6ca9ba74bdadeefba85c49078df09e8fb8e2e7ff Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Fri, 10 Feb 2023 16:08:18 -0800
-Subject: [PATCH 12/13] Rename Snow node image to reflect appropriate CAPI
+Subject: [PATCH 12/14] Rename Snow node image to reflect appropriate CAPI
  provider
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0013-Add-EKS-A-specific-inline-Goss-vars-to-all-supported.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0013-Add-EKS-A-specific-inline-Goss-vars-to-all-supported.patch
@@ -1,7 +1,7 @@
 From 8289c8a7a3a7ad668e25507ee8eae404a27fe4e5 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Mar 2023 19:27:50 -0800
-Subject: [PATCH 13/13] Add EKS-A specific inline Goss vars to all supported
+Subject: [PATCH 13/14] Add EKS-A specific inline Goss vars to all supported
  providers
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0014-Use-tar.gz-extension-for-CNI-plugins-tarball.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0014-Use-tar.gz-extension-for-CNI-plugins-tarball.patch
@@ -1,0 +1,26 @@
+From 376d269984a104e6ccfac18e91cf3281625aa7a0 Mon Sep 17 00:00:00 2001
+From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
+Date: Thu, 9 Mar 2023 16:05:22 -0800
+Subject: [PATCH 14/14] Use tar.gz extension for CNI plugins tarball
+
+Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
+---
+ images/capi/ansible/roles/kubernetes/tasks/url.yml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/images/capi/ansible/roles/kubernetes/tasks/url.yml b/images/capi/ansible/roles/kubernetes/tasks/url.yml
+index d2fd4fb0b..1bf7f61e6 100644
+--- a/images/capi/ansible/roles/kubernetes/tasks/url.yml
++++ b/images/capi/ansible/roles/kubernetes/tasks/url.yml
+@@ -57,7 +57,7 @@
+ 
+ - name: Download CNI tarball
+   get_url:
+-    url: "{{ kubernetes_cni_http_source }}/{{ kubernetes_cni_semver }}/cni-plugins-linux-{{ kubernetes_goarch }}-{{ kubernetes_cni_semver }}.tgz"
++    url: "{{ kubernetes_cni_http_source }}/{{ kubernetes_cni_semver }}/cni-plugins-linux-{{ kubernetes_goarch }}-{{ kubernetes_cni_semver }}.tar.gz"
+     checksum: "{{ kubernetes_cni_http_checksum }}"
+     dest: /tmp/cni.tar.gz
+     mode: 0755
+-- 
+2.39.2
+


### PR DESCRIPTION
Adding back part of a patch removed in #1958.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
