### PR TITLE
Adds seperate build to checksums batch for pr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ generate-project-list:
 .PHONY: generate-staging-buildspec
 generate-staging-buildspec:
 	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "$(ALL_PROJECTS)" "$(BASE_DIRECTORY)/release/staging-build.yml"
-	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "$(ALL_PROJECTS)" "$(BASE_DIRECTORY)/release/checksums-build.yml" true EXCLUDE_FROM_CHECKSUMS_BUILDSPEC CHECKSUMS_BUILDSPECS false
+	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "$(ALL_PROJECTS)" "$(BASE_DIRECTORY)/release/checksums-build.yml" true EXCLUDE_FROM_CHECKSUMS_BUILDSPEC CHECKSUMS_BUILDSPECS false checksums-pr-buildspec.yml
 	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "aws_bottlerocket-bootstrap" "$(BASE_DIRECTORY)/projects/aws/bottlerocket-bootstrap/buildspecs/batch-build.yml" true
 	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "kubernetes_cloud-provider-vsphere" "$(BASE_DIRECTORY)/projects/kubernetes/cloud-provider-vsphere/buildspecs/batch-build.yml" true
 	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "kubernetes-sigs_kind" "$(BASE_DIRECTORY)/projects/kubernetes-sigs/kind/buildspecs/batch-build.yml" true
@@ -111,9 +111,9 @@ generate: generate-project-list generate-staging-buildspec
 
 .PHONY: validate-generated
 validate-generated: generate
-	@if [ "$$(git status --porcelain -- UPSTREAM_PROJECTS.yaml release/staging-build.yml **/batch-build.yml | wc -l)" -gt 0 ]; then \
-		echo "Error: Generated files, UPSTREAM_PROJECTS.yaml release/staging-build.yml, do not match expected. Please run `make generate` to update"; \
-		git diff -- UPSTREAM_PROJECTS.yaml release/staging-build.yml **/batch-build.yml; \
+	@if [ "$$(git status --porcelain -- UPSTREAM_PROJECTS.yaml release/staging-build.yml release/checksums-build.yml **/batch-build.yml | wc -l)" -gt 0 ]; then \
+		echo "Error: Generated files, UPSTREAM_PROJECTS.yaml release/staging-build.yml release/checksums-build.yml batch-build.yml, do not match expected. Please run `make generate` to update"; \
+		git diff -- UPSTREAM_PROJECTS.yaml release/staging-build.yml release/checksums-build.yml **/batch-build.yml; \
 		exit 1; \
 	fi
 	build/lib/readme_check.sh

--- a/checksums-buildspec.yml
+++ b/checksums-buildspec.yml
@@ -14,4 +14,4 @@ phases:
     - echo "CHECKSUMS -text merge=union" > .gitattributes
     - if $(make check-project-path-exists); then make checksums -C $PROJECT_PATH; fi
     - build/lib/update_go_versions.sh
-    - build/update-attribution-files/create_pr.sh
+    - build/update-attribution-files/create_pr.sh true

--- a/checksums-pr-buildspec.yml
+++ b/checksums-pr-buildspec.yml
@@ -1,0 +1,10 @@
+version: 0.2
+
+env:
+  secrets-manager:
+    GITHUB_TOKEN: "github-eks-distro-pr-bot:github-token"
+
+phases:
+  build:
+    commands:
+    - build/update-attribution-files/create_pr.sh

--- a/release/checksums-build.yml
+++ b/release/checksums-build.yml
@@ -99,6 +99,12 @@ batch:
       env:
         variables:
           PROJECT_PATH: projects/aws/image-builder
+    - identifier: aws_rolesanywhere_credential_helper
+      buildspec: checksums-buildspec.yml
+      env:
+        variables:
+          PROJECT_PATH: projects/aws/rolesanywhere-credential-helper
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.rolesanywhere-credential-helper
     - identifier: aws_containers_hello_eks_anywhere
       buildspec: checksums-buildspec.yml
       env:
@@ -431,3 +437,74 @@ batch:
         variables:
           PROJECT_PATH: projects/vmware/govmomi
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/vmware.govmomi
+    - identifier: final_stage
+      buildspec: checksums-pr-buildspec.yml
+      depend-on:
+        - apache_cloudstack_cloudmonkey
+        - aquasecurity_harbor_scanner_trivy
+        - aquasecurity_trivy
+        - aws_bottlerocket_bootstrap_1_21
+        - aws_bottlerocket_bootstrap_1_22
+        - aws_bottlerocket_bootstrap_1_23
+        - aws_bottlerocket_bootstrap_1_24
+        - aws_bottlerocket_bootstrap_1_25
+        - aws_bottlerocket_bootstrap_1_26
+        - aws_eks_anywhere
+        - aws_eks_anywhere_packages
+        - aws_etcdadm_bootstrap_provider
+        - aws_etcdadm_controller
+        - aws_image_builder
+        - aws_rolesanywhere_credential_helper
+        - aws_containers_hello_eks_anywhere
+        - aws_observability_aws_otel_collector
+        - brancz_kube_rbac_proxy
+        - cert_manager_cert_manager
+        - distribution_distribution
+        - emissary_ingress_emissary
+        - envoyproxy_envoy
+        - fluxcd_flux2
+        - fluxcd_helm_controller
+        - fluxcd_kustomize_controller
+        - fluxcd_notification_controller
+        - fluxcd_source_controller_linux_amd64
+        - fluxcd_source_controller_linux_arm64
+        - goharbor_harbor
+        - helm_helm
+        - kube_vip_kube_vip
+        - kubernetes_autoscaler_1_21
+        - kubernetes_autoscaler_1_22
+        - kubernetes_autoscaler_1_23
+        - kubernetes_autoscaler_1_24
+        - kubernetes_autoscaler_1_25
+        - kubernetes_autoscaler_1_26
+        - kubernetes_cloud_provider_aws
+        - kubernetes_cloud_provider_vsphere_1_21
+        - kubernetes_cloud_provider_vsphere_1_22
+        - kubernetes_cloud_provider_vsphere_1_23
+        - kubernetes_cloud_provider_vsphere_1_24
+        - kubernetes_cloud_provider_vsphere_1_25
+        - kubernetes_cloud_provider_vsphere_1_26
+        - kubernetes_sigs_cluster_api
+        - kubernetes_sigs_cluster_api_provider_cloudstack
+        - kubernetes_sigs_cluster_api_provider_vsphere
+        - kubernetes_sigs_cri_tools
+        - kubernetes_sigs_etcdadm
+        - kubernetes_sigs_kind
+        - kubernetes_sigs_vsphere_csi_driver
+        - metallb_metallb
+        - nutanix_cloud_native_cluster_api_provider_nutanix
+        - prometheus_node_exporter
+        - prometheus_prometheus
+        - rancher_local_path_provisioner
+        - redis_redis
+        - replicatedhq_troubleshoot
+        - tinkerbell_boots
+        - tinkerbell_cluster_api_provider_tinkerbell
+        - tinkerbell_hegel
+        - tinkerbell_hook
+        - tinkerbell_hub
+        - tinkerbell_rufio
+        - tinkerbell_tink
+        - tinkerbell_tinkerbell_chart
+        - torvalds_linux
+        - vmware_govmomi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This moves the pr opening process to a final stage which depends on all other builds in the batch. Creating the PR early technically worked fine, however once the PR is created prow is watching it for new commits and on each commit triggers a dozen api calls to github. We think this was causing us to hit some rate limiting which was have consequences across the prow infra.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
