### PR TITLE
Adds guard around image builds for newer kube versions

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -959,6 +959,19 @@ create-ecr-repos: $(foreach image,$(IMAGE_NAMES),$(image)/create-ecr-repo) $(if 
 var-value-%:
 	@echo $($*)
 
+.PHONY: check-for-supported-release-branch
+check-for-supported-release-branch:
+	@if [ -d $(MAKE_ROOT)/$(RELEASE_BRANCH) ]; then \
+		echo "Supported version to build"; \
+		exit 0; \
+	elif { [ "false" == "$(BINARIES_ARE_RELEASE_BRANCHED)" ] || [ -z "$(BINARY_TARGET_FILES)" ]; } && [ "true" == "$$(yq e ".releases[] | select(.branch==\"$(RELEASE_BRANCH)\") | has(\"branch\")" $(BASE_DIRECTORY)/EKSD_LATEST_RELEASES)" ]; then \
+		echo "Supported version to build"; \
+		exit 0; \
+	else \
+		echo "Not a supported version to build"; \
+		exit 1; \
+	fi	
+
 .PHONY: github-rate-limit-%
 github-rate-limit-%:
 	@if [[ -n "$(GITHUB_TOKEN)" ]] && [[  "presubmit" == "$(JOB_TYPE)" ]]; then \

--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -85,18 +85,18 @@ function build::common::upload_artifacts() {
   local -r do_not_delete=$8
   
   if [ "$dry_run" = "true" ]; then
-    aws s3 cp "$artifactspath" "$artifactsbucket"/"$projectpath"/"$buildidentifier"-"$githash"/artifacts --recursive --dryrun
-    aws s3 cp "$artifactspath" "$artifactsbucket"/"$projectpath"/"$latesttag" --recursive --dryrun
+    build::common::echo_and_run aws s3 cp "$artifactspath" "$artifactsbucket"/"$projectpath"/"$buildidentifier"-"$githash"/artifacts --recursive --dryrun
+    build::common::echo_and_run aws s3 cp "$artifactspath" "$artifactsbucket"/"$projectpath"/"$latesttag" --recursive --dryrun
   else
     # Upload artifacts to s3 
     # 1. To proper path on s3 with buildId-githash
     # 2. Latest path to indicate the latest build, with --delete option to delete stale files in the dest path
-    aws s3 sync "$artifactspath" "$artifactsbucket"/"$projectpath"/"$buildidentifier"-"$githash"/artifacts --acl public-read
+    build::common::echo_and_run aws s3 sync "$artifactspath" "$artifactsbucket"/"$projectpath"/"$buildidentifier"-"$githash"/artifacts --acl public-read
 
     if [ "$do_not_delete" = "true" ]; then
-      aws s3 sync "$artifactspath" "$artifactsbucket"/"$projectpath"/"$latesttag" --acl public-read
+      build::common::echo_and_run aws s3 sync "$artifactspath" "$artifactsbucket"/"$projectpath"/"$latesttag" --acl public-read
     else
-      aws s3 sync "$artifactspath" "$artifactsbucket"/"$projectpath"/"$latesttag" --delete --acl public-read
+      build::common::echo_and_run aws s3 sync "$artifactspath" "$artifactsbucket"/"$projectpath"/"$latesttag" --delete --acl public-read
     fi
   fi
 }

--- a/build/lib/create_release_checksums.sh
+++ b/build/lib/create_release_checksums.sh
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -x
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/build/lib/upload_artifacts.sh
+++ b/build/lib/upload_artifacts.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -x
+
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/projects/kubernetes-sigs/image-builder/.gitignore
+++ b/projects/kubernetes-sigs/image-builder/.gitignore
@@ -2,3 +2,5 @@ image-builder
 bottlerocket
 _output
 *.pem
+fake-ubuntu.gz
+fake-ubuntu.ova

--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -160,45 +160,60 @@ export GOVC_INSECURE?=true
 
 # Since we do not build the ova in presubmit but want to validate upload-artifacts behavior
 $(FAKE_UBUNTU_OVA_PATH):
+	@echo -e $(call TARGET_START_LOG)
 	touch $@
 	touch $(ARTIFACTS_PATH)/ova/ubuntu/packer.log
+	@echo -e $(call TARGET_END_LOG)
 
 $(FAKE_UBUNTU_RAW_PATH):
+	@echo -e $(call TARGET_START_LOG)
 	@mkdir -p $(@D)
 	touch $@
+	@echo -e $(call TARGET_END_LOG)
 
 # in the case of BR ova these targets are the same, guard against this to avoid the overwriting target warning
 ifneq ($(FINAL_BOTTLEROCKET_OVA_PATH),$(FINAL_OVA_PATH))
 $(FINAL_OVA_PATH):
+	@echo -e $(call TARGET_START_LOG)
 	@mkdir -p $(@D)
 	mv *.ova $@
+	@echo -e $(call TARGET_END_LOG)
 endif
 
 $(FINAL_RAW_IMAGE_PATH):
+	@echo -e $(call TARGET_START_LOG)
 	@mkdir -p $(@D)
 	mv *.gz $@
 
 $(FINAL_CLOUDSTACK_IMAGE_PATH):
+	@echo -e $(call TARGET_START_LOG)
 	@mkdir -p $(@D)
 	mv *.qcow2 $@
+	@echo -e $(call TARGET_END_LOG)
 
 $(FINAL_BOTTLEROCKET_AMI_PATH): FULL_OUTPUT_DIR=$(MAKE_ROOT)/$(OUTPUT_DIR)/bottlerocket
 $(FINAL_BOTTLEROCKET_AMI_PATH): BOTTLEROCKET_DOWNLOAD_PATH=$(FULL_OUTPUT_DIR)/bottlerocket/downloads
 $(FINAL_BOTTLEROCKET_AMI_PATH):
+	@echo -e $(call TARGET_START_LOG)
 	@mkdir -p $(@D)
 	mv $(BOTTLEROCKET_DOWNLOAD_PATH)/ami/*.gz $@
+	@echo -e $(call TARGET_END_LOG)
 
 $(FINAL_BOTTLEROCKET_OVA_PATH): FULL_OUTPUT_DIR=$(MAKE_ROOT)/$(OUTPUT_DIR)/bottlerocket
 $(FINAL_BOTTLEROCKET_OVA_PATH): BOTTLEROCKET_DOWNLOAD_PATH=$(FULL_OUTPUT_DIR)/bottlerocket/downloads
 $(FINAL_BOTTLEROCKET_OVA_PATH):
+	@echo -e $(call TARGET_START_LOG)
 	@mkdir -p $(@D)
 	mv $(BOTTLEROCKET_DOWNLOAD_PATH)/ova/*.ova $@
+	@echo -e $(call TARGET_END_LOG)
 
 $(FINAL_BOTTLEROCKET_RAW_PATH): FULL_OUTPUT_DIR=$(MAKE_ROOT)/$(OUTPUT_DIR)/bottlerocket
 $(FINAL_BOTTLEROCKET_RAW_PATH): BOTTLEROCKET_DOWNLOAD_PATH=$(FULL_OUTPUT_DIR)/bottlerocket/downloads
 $(FINAL_BOTTLEROCKET_RAW_PATH):
+	@echo -e $(call TARGET_START_LOG)
 	@mkdir -p $(@D)
 	mv $(BOTTLEROCKET_DOWNLOAD_PATH)/raw/*.gz $@
+	@echo -e $(call TARGET_END_LOG)
 
 .PHONY: setup-ami-share
 setup-ami-share:
@@ -207,6 +222,7 @@ setup-ami-share:
 $(BOTTLEROCKET_SETUP_TARGET): FULL_OUTPUT_DIR=$(MAKE_ROOT)/$(OUTPUT_DIR)/bottlerocket
 $(BOTTLEROCKET_SETUP_TARGET): export BOTTLEROCKET_ROOT_JSON_PATH=$(BOTTLEROCKET_DOWNLOAD_PATH)/root.json
 $(BOTTLEROCKET_SETUP_TARGET):
+	@echo -e $(call TARGET_START_LOG)
 	@mkdir -p $(BOTTLEROCKET_DOWNLOAD_PATH)
 	# This configuration supports local installations and checksum validations
 	# of root.json file
@@ -215,22 +231,29 @@ $(BOTTLEROCKET_SETUP_TARGET):
 		> $(BOTTLEROCKET_SETUP_TARGET)
 	curl https://cache.bottlerocket.aws/root.json -o $$BOTTLEROCKET_ROOT_JSON_PATH
 	sha512sum -c $(BOTTLEROCKET_SETUP_TARGET)
+	@echo -e $(call TARGET_END_LOG)
 
 .PHONY: deps-%
 deps-%: MAKEFLAGS=
 deps-%: $(GIT_PATCH_TARGET)
+	@echo -e $(call TARGET_START_LOG)
 	$(MAKE) -C $(IMAGE_BUILDER_DIR) deps-$*
+	@echo -e $(call TARGET_END_LOG)
 
 .PHONY: setup-packer-configs-%
 setup-packer-configs-%:
+	@echo -e $(call TARGET_START_LOG)
 	build/setup_packer_configs.sh $(RELEASE_BRANCH) $* $(IMAGE_OS) $(ARTIFACTS_BUCKET) $(ARTIFACTS_PATH)/$*/$(IMAGE_OS) $(ADDITIONAL_PAUSE_$(RELEASE_BRANCH)_FROM) $(LATEST) $(IMAGE_BUILDER_DIR)
+	@echo -e $(call TARGET_END_LOG)
 
 .PHONY: build-ami-ubuntu-2004
 build-ami-ubuntu-2004: MAKEFLAGS=
 build-ami-ubuntu-2004: FULL_OUTPUT_DIR=$(MAKE_ROOT)/$(OUTPUT_DIR)/ami/$(IMAGE_OS)
 build-ami-ubuntu-2004: PACKER_TYPE_VAR_FILES=$(PACKER_AMI_VAR_FILES)
 build-ami-ubuntu-2004: setup-ami-share deps-ami setup-packer-configs-ami
+	@echo -e $(call TARGET_START_LOG)
 	PACKER_VAR_FILES="$(PACKER_VAR_FILES)" $(MAKE) -C $(IMAGE_BUILDER_DIR) validate-ami-ubuntu-2004
+	@echo -e $(call TARGET_END_LOG)
 
 .PHONY: release-ami-%
 release-ami-%: FULL_OUTPUT_DIR=$(MAKE_ROOT)/$(OUTPUT_DIR)/ami/$(IMAGE_OS)
@@ -240,70 +263,92 @@ release-ami-%: AMI_S3_DST=$(EXPORT_AMI_BUCKET)/$(ARTIFACTS_UPLOAD_PATH)/ami/$(IM
 release-ami-%: EXPORT_AMI_DST=$(AMI_S3_DST)/$(GIT_HASH)
 release-ami-%: LATEST_AMI_S3_URL=$(AMI_S3_DST)/$(LATEST)/ubuntu.raw
 release-ami-%: setup-ami-share
+	@echo -e $(call TARGET_START_LOG)
 	build/build_image.sh $* $(RELEASE_BRANCH) $(IMAGE_FORMAT) $(ARTIFACTS_BUCKET) $(LATEST)
 	build/export-ami-to-s3.sh $(RELEASE_BRANCH) $(MANIFEST_OUTPUT) raw $(EXPORT_AMI_DST) $(LATEST_AMI_S3_URL)
+	@echo -e $(call TARGET_END_LOG)
 
 .PHONY: release-ova-%
 release-ova-%:
+	@echo -e $(call TARGET_START_LOG)
 	build/build_image.sh $* $(RELEASE_BRANCH) $(IMAGE_FORMAT) $(ARTIFACTS_BUCKET) $(LATEST)
+	@echo -e $(call TARGET_END_LOG)
 
 .PHONY: local-build-ova-%
 local-build-ova-%: MAKEFLAGS=
 local-build-ova-%: FULL_OUTPUT_DIR=$(MAKE_ROOT)/$(OUTPUT_DIR)/ova/$(IMAGE_OS)
 local-build-ova-%: PACKER_TYPE_VAR_FILES=$(PACKER_OVA_VAR_FILES)
 local-build-ova-%: deps-ova setup-packer-configs-ova
+	@echo -e $(call TARGET_START_LOG)
 	PACKER_FLAGS="-force" PACKER_LOG=1 PACKER_LOG_PATH=$(ARTIFACTS_PATH)/ova/$(IMAGE_OS)/packer.log PACKER_VAR_FILES="$(PACKER_VAR_FILES)" \
 		OVF_CUSTOM_PROPERTIES="$(FULL_OUTPUT_DIR)/config/ovf_custom_properties.json" \
 		$(MAKE) -C $(IMAGE_BUILDER_DIR) build-node-ova-vsphere-$*
+	@echo -e $(call TARGET_END_LOG)
 
 .PHONY: download-bottlerocket-%
 download-bottlerocket-%: IMAGE_OS=bottlerocket
 download-bottlerocket-%: FULL_OUTPUT_DIR=$(MAKE_ROOT)/$(OUTPUT_DIR)/bottlerocket
 download-bottlerocket-%: BOTTLEROCKET_DOWNLOAD_PATH=$(FULL_OUTPUT_DIR)/bottlerocket/downloads
 download-bottlerocket-%: $(BOTTLEROCKET_SETUP_TARGET)
+	@echo -e $(call TARGET_START_LOG)
 	build/get_bottlerocket_artifacts.sh $(RELEASE_BRANCH) $* $(BOTTLEROCKET_DOWNLOAD_PATH) $(PROJECT_PATH)/$(RELEASE_BRANCH) $(LATEST_TAG)
+	@echo -e $(call TARGET_END_LOG)
 
 .PHONY: upload-bottlerocket-%
 upload-bottlerocket-%: IMAGE_OS=bottlerocket
 upload-bottlerocket-%: ARTIFACTS_PATH_IMAGE_FORMAT=$(ARTIFACTS_PATH)/$*/bottlerocket
 upload-bottlerocket-%: ARTIFACTS_UPLOAD_PATH_IMAGE_FORMAT=$(ARTIFACTS_UPLOAD_PATH)/$*/bottlerocket
 upload-bottlerocket-%:
+	@echo -e $(call TARGET_START_LOG)
 	build/upload_bottlerocket_artifacts.sh $(RELEASE_BRANCH) $* $(ARTIFACTS_PATH_IMAGE_FORMAT) $(ARTIFACTS_UPLOAD_PATH_IMAGE_FORMAT)
+	@echo -e $(call TARGET_END_LOG)
 
 .PHONY: release-image-build-on-metal-%
 release-image-build-on-metal-%: $(GIT_PATCH_TARGET)
+	@echo -e $(call TARGET_START_LOG)
 	build/build_image_on_metal.sh $(BASE_DIRECTORY) $(PROJECT_PATH) $(RELEASE_BRANCH) $(RAW_IMAGE_BUILD_AMI) $(RAW_IMAGE_BUILD_INSTANCE_TYPE) $(RAW_IMAGE_BUILD_KEY_NAME) $* $(IMAGE_FORMAT) $(LATEST)
+	@echo -e $(call TARGET_END_LOG)
 
 .PHONY: build-qemu-rhel-local
 build-qemu-rhel-local: FULL_OUTPUT_DIR=$(MAKE_ROOT)/$(OUTPUT_DIR)/qemu/$(IMAGE_OS)
 build-qemu-rhel-local: deps-qemu setup-packer-configs-qemu
+	@echo -e $(call TARGET_START_LOG)
 	build/build_qemu_rhel_local.sh $(MAKE_ROOT) $(BASE_IMAGE) $(IMAGE_BUILDER_DIR) "$(PACKER_VAR_FILES)"
+	@echo -e $(call TARGET_END_LOG)
 
 .PHONY: local-build-ami-%
 local-build-ami-%: MAKEFLAGS=
 local-build-ami-%: FULL_OUTPUT_DIR=$(MAKE_ROOT)/$(OUTPUT_DIR)/ami/$(IMAGE_OS)
 local-build-ami-%: PACKER_TYPE_VAR_FILES=$(PACKER_AMI_VAR_FILES)
 local-build-ami-%: deps-ami setup-packer-configs-ami
+	@echo -e $(call TARGET_START_LOG)
 	PACKER_FLAGS="-force" PACKER_LOG=1 PACKER_LOG_PATH=$(ARTIFACTS_PATH)/ami/$(IMAGE_OS)/packer.log PACKER_VAR_FILES="$(PACKER_VAR_FILES)" \
 		$(MAKE) -C $(IMAGE_BUILDER_DIR) build-ami-$*
+	@echo -e $(call TARGET_END_LOG)
 
 .PHONY: local-build-raw-%
 local-build-raw-%: FULL_OUTPUT_DIR=$(MAKE_ROOT)/$(OUTPUT_DIR)/raw/$(IMAGE_OS)
 local-build-raw-%: deps-raw setup-packer-configs-raw
+	@echo -e $(call TARGET_START_LOG)
 	PACKER_FLAGS="-force" PACKER_LOG=1 PACKER_LOG_PATH=$(ARTIFACTS_PATH)/raw/$(IMAGE_OS)/packer.log PACKER_VAR_FILES="$(PACKER_VAR_FILES)" \
 		$(MAKE) -C $(IMAGE_BUILDER_DIR) build-raw-$*
+	@echo -e $(call TARGET_END_LOG)
 
 .PHONY: local-build-qemu-%
 local-build-qemu-%: FULL_OUTPUT_DIR=$(MAKE_ROOT)/$(OUTPUT_DIR)/qemu/$(IMAGE_OS)
 local-build-qemu-%: deps-qemu setup-packer-configs-qemu
+	@echo -e $(call TARGET_START_LOG)
 	PACKER_FLAGS="-force" PACKER_LOG=1 PACKER_LOG_PATH=$(ARTIFACTS_PATH)/qemu/$(IMAGE_OS)/packer.log PACKER_VAR_FILES="$(PACKER_VAR_FILES)" \
 		$(MAKE) -C $(IMAGE_BUILDER_DIR) build-qemu-$*
+	@echo -e $(call TARGET_END_LOG)
 
 .PHONY: local-build-nutanix-ubuntu-2004
 local-build-nutanix-ubuntu-2004: FULL_OUTPUT_DIR=$(MAKE_ROOT)/$(OUTPUT_DIR)/nutanix/$(IMAGE_OS)
 local-build-nutanix-ubuntu-2004: deps-nutanix setup-packer-configs-nutanix
+	@echo -e $(call TARGET_START_LOG)
 	PACKER_FLAGS="-force" PACKER_LOG=1 PACKER_LOG_PATH=$(ARTIFACTS_PATH)/nutanix/$(IMAGE_OS)/packer.log PACKER_VAR_FILES="$(PACKER_VAR_FILES)" \
 		$(MAKE) -C $(IMAGE_BUILDER_DIR) build-nutanix-ubuntu-2004
+	@echo -e $(call TARGET_END_LOG)
 
 .PHONY: validate-ubuntu-2004
 validate-ubuntu-2004: check-env-validation $(GIT_PATCH_TARGET) setup-packer-configs-ova
@@ -315,21 +360,18 @@ check-env-validation:
 		$(error Environment var TEMPLATE not set. Example: TEMPLATE=<ubuntu.livecd> make ...)
 	endif
 
-.PHONY: s3-artifacts-%
-s3-artifacts-%: ARTIFACTS_PATH_IMAGE_FORMAT=$(ARTIFACTS_PATH)/$*/$(IMAGE_OS)
-s3-artifacts-%: $(S3_TARGET_PREREQUISITES)
-	$(MAKE) -C $(MAKE_ROOT) s3-artifacts ARTIFACTS_PATH=$(ARTIFACTS_PATH_IMAGE_FORMAT) IMAGE_FORMAT=$* IMAGE_OS=$(IMAGE_OS)
-
 .PHONY: upload-artifacts-%
 upload-artifacts-%: ARTIFACTS_PATH_IMAGE_FORMAT=$(ARTIFACTS_PATH)/$*/$(IMAGE_OS)
 upload-artifacts-%: ARTIFACTS_UPLOAD_PATH_IMAGE_FORMAT=$(ARTIFACTS_UPLOAD_PATH)/$*/$(IMAGE_OS)
-upload-artifacts-%: s3-artifacts-%
-	$(MAKE) -C $(MAKE_ROOT) upload-artifacts ARTIFACTS_PATH=$(ARTIFACTS_PATH_IMAGE_FORMAT) ARTIFACTS_UPLOAD_PATH=$(ARTIFACTS_UPLOAD_PATH_IMAGE_FORMAT) IMAGE_FORMAT=$*
-
+upload-artifacts-%: $(S3_TARGET_PREREQUISITES)
+	@echo -e $(call TARGET_START_LOG)
+	$(MAKE) -C $(MAKE_ROOT) upload-artifacts ARTIFACTS_PATH=$(ARTIFACTS_PATH_IMAGE_FORMAT) ARTIFACTS_UPLOAD_PATH=$(ARTIFACTS_UPLOAD_PATH_IMAGE_FORMAT) IMAGE_FORMAT=$* IMAGE_OS=$(IMAGE_OS)
+	@echo -e $(call TARGET_END_LOG)
 
 .PHONY: unsupported-release-target
 unsupported-release-target:
 	@echo "Unsupported combination of image format and image os chosen. Build will quit now..."
+
 
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block

--- a/projects/kubernetes-sigs/image-builder/build/build_image_on_metal.sh
+++ b/projects/kubernetes-sigs/image-builder/build/build_image_on_metal.sh
@@ -114,7 +114,7 @@ for i in $(seq 1 $MAX_RETRIES); do
     echo "Attempt $(($i))"
 
     # Transfer the repo contents from the CI environment to the EC2 instance
-    rsync -avzh --progress -e "ssh $SSH_OPTS" $REPO_ROOT $REMOTE_HOST:~/ && echo "Files transferred!" && break
+    rsync -azh -e "ssh $SSH_OPTS" $REPO_ROOT $REMOTE_HOST:~/ && echo "Files transferred!" && break
 
     if [ "$i" = "$MAX_RETRIES" ]; then
         exit 1

--- a/projects/kubernetes-sigs/image-builder/build/get_bottlerocket_artifacts.sh
+++ b/projects/kubernetes-sigs/image-builder/build/get_bottlerocket_artifacts.sh
@@ -13,11 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -x
 set -o errexit
 set -o nounset
 set -o pipefail
 
+MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+source "${MAKE_ROOT}/../../../build/lib/common.sh"
 
 RELEASE_CHANNEL="${1?Specify first argument - EKS-D release channel}"
 FORMAT="${2?Specify second argument - Image format}"
@@ -61,7 +62,7 @@ OS_DOWNLOAD_PATH=${BOTTLEROCKET_DOWNLOAD_PATH}/${FORMAT}
 rm -rf $OS_DOWNLOAD_PATH
 
 # Downloading the TARGET from the Bottlerocket target location using Tuftool
-tuftool download "${OS_DOWNLOAD_PATH}" \
+build::common::echo_and_run tuftool download "${OS_DOWNLOAD_PATH}" \
     --target-name "${TARGET}" \
     --root "${BOTTLEROCKET_DOWNLOAD_PATH}/root.json" \
     --metadata-url "${BOTTLEROCKET_METADATA_URL}" \
@@ -70,7 +71,7 @@ tuftool download "${OS_DOWNLOAD_PATH}" \
 # Post processing for aws and metal variants
 if [[ $VARIANT == "aws" ]] || [[ $VARIANT == "metal" ]]; then
   BOTTLEROCKET_IMG="${TARGET%.lz4}"
-  lz4 --decompress ${OS_DOWNLOAD_PATH}/${TARGET} ${OS_DOWNLOAD_PATH}/${BOTTLEROCKET_IMG}
-  gzip ${OS_DOWNLOAD_PATH}/${BOTTLEROCKET_IMG}
+  build::common::echo_and_run lz4 --decompress ${OS_DOWNLOAD_PATH}/${TARGET} ${OS_DOWNLOAD_PATH}/${BOTTLEROCKET_IMG}
+  build::common::echo_and_run gzip ${OS_DOWNLOAD_PATH}/${BOTTLEROCKET_IMG}
   rm -f ${OS_DOWNLOAD_PATH}/${TARGET}
 fi

--- a/projects/kubernetes-sigs/image-builder/build/setup_packer_configs.sh
+++ b/projects/kubernetes-sigs/image-builder/build/setup_packer_configs.sh
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-set -x
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -39,9 +37,23 @@ MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 source "${MAKE_ROOT}/../../../build/lib/common.sh"
 source "${MAKE_ROOT}/../../../build/lib/eksa_releases.sh"
 
+function env_and_envsubst()
+{
+    echo -e "\nRunning envsubst with input file $2 saving to $3 with ENV: "
+    local -r env_vars=(${1//:/ })
+    for var in "${env_vars[@]}"; do
+        local var_name=${var:1}
+        echo "$var_name: ${!var_name:-}"
+    done
+    envsubst "$1" < "$2" > "$3"
+}
+
 # Preload release yaml
-build::eksd_releases::load_release_yaml $RELEASE_BRANCH
-build::eksa_releases::load_bundle_manifest $DEV_RELEASE $LATEST_TAG
+echo "Loading EKSD manifest from: $(build::eksd_releases::get_release_yaml_url $RELEASE_BRANCH)"
+build::eksd_releases::load_release_yaml $RELEASE_BRANCH > /dev/null
+
+echo "Loading EKSA manifest from: $(build::eksa_releases::get_eksa_release_manifest_url)"
+build::eksa_releases::load_bundle_manifest $DEV_RELEASE $LATEST_TAG > /dev/null
 
 OUTPUT_CONFIGS="$MAKE_ROOT/_output/$RELEASE_BRANCH/$IMAGE_FORMAT/$IMAGE_OS/config"
 mkdir -p $OUTPUT_CONFIGS
@@ -52,6 +64,7 @@ export CNI_VERSION=$(build::eksd_releases::get_eksd_component_version 'cni-plugi
 
 # Get CNI sha256 to validate cni plugins in image are from eks-d
 # Use sha from manfiest to validate tar and then generate sha from specific binary
+echo "Downloading cni plugins to get shasum of host-device plugin for validation during image building"
 TMP_CNI="$HOME/tmp/eks-image-builder-cni"
 mkdir -p $TMP_CNI
 curl -o $TMP_CNI/cni-plugins.tar.gz "$PLUGINS_ASSET_BASE_URL/$CNI_VERSION/cni-plugins-linux-amd64-$CNI_VERSION.tar.gz"
@@ -61,14 +74,14 @@ tar -zxvf $TMP_CNI/cni-plugins.tar.gz -C $TMP_CNI ./host-device
 export CNI_HOST_DEVICE_SHA256="$(sha256sum $TMP_CNI/host-device | awk -F ' ' '{print $1}')"
 rm -rf $TMP_CNI
 
-envsubst '$CNI_SHA:$PLUGINS_ASSET_BASE_URL:$CNI_VERSION:$CNI_HOST_DEVICE_SHA256' \
-    < "$MAKE_ROOT/packer/config/cni.json.tmpl" \
-    > "$OUTPUT_CONFIGS/cni.json"
+env_and_envsubst '$CNI_SHA:$PLUGINS_ASSET_BASE_URL:$CNI_VERSION:$CNI_HOST_DEVICE_SHA256' \
+    "$MAKE_ROOT/packer/config/cni.json.tmpl" \
+    "$OUTPUT_CONFIGS/cni.json"
 
 export PAUSE_IMAGE=$(build::eksd_releases::get_eksd_kubernetes_image_url 'pause-image' $RELEASE_BRANCH)
-envsubst '$PAUSE_IMAGE:$HTTP_PROXY:$HTTPS_PROXY:$NO_PROXY' \
-    < "$MAKE_ROOT/packer/config/common.json.tmpl" \
-    > "$OUTPUT_CONFIGS/common.json"
+env_and_envsubst '$PAUSE_IMAGE:$HTTP_PROXY:$HTTPS_PROXY:$NO_PROXY' \
+    "$MAKE_ROOT/packer/config/common.json.tmpl" \
+    "$OUTPUT_CONFIGS/common.json"
 
 
 export IMAGE_REPO=$(build::eksd_releases::get_eksd_image_repo $RELEASE_BRANCH)
@@ -86,16 +99,16 @@ export ETCDADM_VERSION='v0.1.5'
 export CRICTL_URL=${CRICTL_URL:-$(build::eksa_releases::get_eksa_component_asset_url 'eksD' 'crictl' $RELEASE_BRANCH $DEV_RELEASE $LATEST_TAG)}
 export CRICTL_SHA256="${CRICTL_SHA256:-$(build::eksa_releases::get_eksa_component_asset_artifact_checksum 'eksD' 'crictl' 'sha256' $RELEASE_BRANCH $DEV_RELEASE $LATEST_TAG)}"
 
-envsubst '$IMAGE_REPO:$KUBERNETES_ASSET_BASE_URL:$KUBERNETES_VERSION:$KUBERNETES_SERIES:$CRICTL_URL:$CRICTL_SHA256:$ETCD_HTTP_SOURCE:$ETCD_VERSION:$ETCDADM_HTTP_SOURCE:$ETCD_SHA256:$ETCDADM_VERSION:$KUBERNETES_FULL_VERSION' \
-    < "$MAKE_ROOT/packer/config/kubernetes.json.tmpl" \
-    > "$OUTPUT_CONFIGS/kubernetes.json"
+env_and_envsubst '$IMAGE_REPO:$KUBERNETES_ASSET_BASE_URL:$KUBERNETES_VERSION:$KUBERNETES_SERIES:$CRICTL_URL:$CRICTL_SHA256:$ETCD_HTTP_SOURCE:$ETCD_VERSION:$ETCDADM_HTTP_SOURCE:$ETCD_SHA256:$ETCDADM_VERSION:$KUBERNETES_FULL_VERSION' \
+    "$MAKE_ROOT/packer/config/kubernetes.json.tmpl" \
+    "$OUTPUT_CONFIGS/kubernetes.json"
 
 ADDITIONAL_PAUSE_IMAGE_VERSION_BASE_URL=$(build::eksd_releases::get_eksd_kubernetes_asset_base_url $ADDITIONAL_PAUSE_IMAGE_FROM)
 ADDITIONAL_PAUSE_KUBERNETES_VERSION=$(build::eksd_releases::get_eksd_component_version "kubernetes" $ADDITIONAL_PAUSE_IMAGE_FROM)
 export ADDITIONAL_PAUSE_IMAGE=$ADDITIONAL_PAUSE_IMAGE_VERSION_BASE_URL/$ADDITIONAL_PAUSE_KUBERNETES_VERSION/bin/linux/amd64/pause.tar
-envsubst '$ADDITIONAL_PAUSE_IMAGE' \
-    < "$MAKE_ROOT/packer/config/additional_components.json.tmpl" \
-    > "$OUTPUT_CONFIGS/additional_components.json"
+env_and_envsubst '$ADDITIONAL_PAUSE_IMAGE' \
+    "$MAKE_ROOT/packer/config/additional_components.json.tmpl" \
+    "$OUTPUT_CONFIGS/additional_components.json"
 
 # Write kubernetes version and the eksd manifest url consumed to output directory
 mkdir -p $OVA_PATH
@@ -103,13 +116,13 @@ echo "$KUBERNETES_VERSION" > "$OVA_PATH"/KUBERNETES_VERSION
 export EKSD_MANIFEST_URL=$(build::eksd_releases::get_release_yaml_url $RELEASE_BRANCH)
 echo "$EKSD_MANIFEST_URL" > "$OVA_PATH"/EKSD_MANIFEST_URL
 
-envsubst '$CNI_VERSION:$ETCD_VERSION:$ETCD_SHA256:$ETCDADM_VERSION:$PAUSE_IMAGE:$CNI_HOST_DEVICE_SHA256' \
-    < "$MAKE_ROOT/packer/config/validate_goss_inline_vars.json.tmpl" \
-    > "$OUTPUT_CONFIGS/validate_goss_inline_vars.json"
+env_and_envsubst '$CNI_VERSION:$ETCD_VERSION:$ETCD_SHA256:$ETCDADM_VERSION:$PAUSE_IMAGE:$CNI_HOST_DEVICE_SHA256' \
+    "$MAKE_ROOT/packer/config/validate_goss_inline_vars.json.tmpl" \
+    "$OUTPUT_CONFIGS/validate_goss_inline_vars.json"
 
-envsubst '$EKSD_NAME' \
-    < "$MAKE_ROOT/packer/config/ovf_custom_properties.json.tmpl" \
-    > "$OUTPUT_CONFIGS/ovf_custom_properties.json"
+env_and_envsubst '$EKSD_NAME' \
+    "$MAKE_ROOT/packer/config/ovf_custom_properties.json.tmpl" \
+    "$OUTPUT_CONFIGS/ovf_custom_properties.json"
 
 # This is the IP address that Packer will create the server on to host the local
 # directory containing the kickstart config
@@ -133,6 +146,7 @@ if [ "$IMAGE_FORMAT" = "ova" ] && [ "$IMAGE_OS" = "redhat" ]; then
     fi
     export PACKER_HTTP_SERVER_IP=$(ip a l $ACTIVE_INTERFACE | awk '/inet / {print $2}' | cut -d/ -f1)
     rhel_ova_config_file="${MAKE_ROOT}/${IMAGE_BUILDER_DIR}/packer/ova/rhel-8.json"
+    echo "Setting boot_media_path for rhel config to $PACKER_HTTP_SERVER_IP"
     cat <<< $(jq --arg httpendpoint "http://$PACKER_HTTP_SERVER_IP:{{ .HTTPPort }}" \
              '.boot_media_path=$httpendpoint' $rhel_ova_config_file) > $rhel_ova_config_file
 fi

--- a/projects/kubernetes-sigs/image-builder/build/upload_bottlerocket_artifacts.sh
+++ b/projects/kubernetes-sigs/image-builder/build/upload_bottlerocket_artifacts.sh
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -x
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -32,5 +31,5 @@ if [ $release_availability -ne 0 ]; then
   echo "No Bottlerocket release found for release branch. Terminating silently..."
   exit 0
 fi
-make -C $MAKE_ROOT s3-artifacts-${FORMAT} IMAGE_OS=bottlerocket
-make -C $MAKE_ROOT upload-artifacts ARTIFACTS_PATH=$ARTIFACTS_PATH ARTIFACTS_UPLOAD_PATH=$ARTIFACTS_UPLOAD_PATH IMAGE_FORMAT=$FORMAT IMAGE_OS=bottlerocket
+
+build::common::echo_and_run make -C $MAKE_ROOT upload-artifacts ARTIFACTS_PATH=$ARTIFACTS_PATH ARTIFACTS_UPLOAD_PATH=$ARTIFACTS_UPLOAD_PATH IMAGE_FORMAT=$FORMAT IMAGE_OS=bottlerocket

--- a/projects/kubernetes-sigs/image-builder/buildspecs/ami.yml
+++ b/projects/kubernetes-sigs/image-builder/buildspecs/ami.yml
@@ -14,4 +14,4 @@ phases:
 
   build:
     commands:
-      - make release IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=ami RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH
+      - if make check-for-supported-release-branch -C $PROJECT_PATH; then make release IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=ami RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH; fi

--- a/projects/kubernetes-sigs/image-builder/buildspecs/cloudstack.yml
+++ b/projects/kubernetes-sigs/image-builder/buildspecs/cloudstack.yml
@@ -8,4 +8,4 @@ phases:
 
   build:
     commands:
-      - make release IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=cloudstack RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH
+      - if make check-for-supported-release-branch -C $PROJECT_PATH; then make release IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=cloudstack RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH; fi

--- a/projects/kubernetes-sigs/image-builder/buildspecs/ova.yml
+++ b/projects/kubernetes-sigs/image-builder/buildspecs/ova.yml
@@ -20,4 +20,4 @@ phases:
 
   build:
     commands:
-      - make release IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=ova RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH
+      - if make check-for-supported-release-branch -C $PROJECT_PATH; then make release IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=ova RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH; fi

--- a/projects/kubernetes-sigs/image-builder/buildspecs/raw.yml
+++ b/projects/kubernetes-sigs/image-builder/buildspecs/raw.yml
@@ -8,4 +8,4 @@ phases:
 
   build:
     commands:
-      - make release IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=raw RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH
+      - if make check-for-supported-release-branch -C $PROJECT_PATH; then make release IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=raw RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH; fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We issues in codebuild when building release branches which do not have the newer versions of kube. This is an attempt to check for that, like we do for project_path for new projects, so we can bail out early

~https://github.com/aws/eks-distro-prow-jobs/pull/491~
https://github.com/aws/eks-anywhere-prow-jobs/pull/273

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
