### PR TITLE
Support non-gp3 volumes in AMI image builds

### DIFF
--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -411,3 +411,10 @@ function build::bottlerocket::check_release_availablilty() {
   fi
   echo $retval
 }
+
+function build::jq::update_in_place() {
+  local json_file=$1
+  local jq_query=$2
+
+  cat $json_file | jq -S ''"$jq_query"'' > $json_file.tmp && mv $json_file.tmp $json_file
+}

--- a/projects/aws/eks-a-admin-image/build/export-ami-to-s3.sh
+++ b/projects/aws/eks-a-admin-image/build/export-ami-to-s3.sh
@@ -61,7 +61,7 @@ if [[ "$STATUS" != "completed" ]]; then
     exit 1
 fi
 
-echo "Image import for ami $AMI_ID succeed"
+echo "Image import for ami $AMI_ID succeeded"
 
 for dst in "${REPLICAS_SPLIT[@]}"
 do


### PR DESCRIPTION
The upstream image-builder AMI packer.json has a throughput field by default in the block device mappings section but this field is valid only for `gp3` volumes type. Hence, when specifying any non-gp3 volume in the AMI config for image-builder, the image build fails throwing an error that throughput is not valid for non-gp3 volume types. This occurs even if we override throughput to `null` or `""` via Packer var-files. The only solution is to remove the throughput field from the Packer config. This PR adds logic to conditionally remove or add back the throughput field depending on the volume type.

This approach is used in upstream image-builder as well and was confirmed by one of their maintainers. Refer to kubernetes-sigs/image-builder#1102 for the original issue I raised regarding this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
