### PR TITLE
Add patch to ensure correct Packer binary is used for image builds

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0001-Add-goss-validations-for-EKS-D-artifacts.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0001-Add-goss-validations-for-EKS-D-artifacts.patch
@@ -1,7 +1,7 @@
 From 34d0bfdc0014c0d668d2ae81ac84b16a5cea322e Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 18:36:56 -0800
-Subject: [PATCH 01/14] Add goss validations for EKS-D artifacts
+Subject: [PATCH 01/15] Add goss validations for EKS-D artifacts
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0002-Output-vsphere-builds-to-content-library-instead-of-.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0002-Output-vsphere-builds-to-content-library-instead-of-.patch
@@ -1,7 +1,7 @@
 From 288be8cc85a4edb95ae8701ea2b42e3701671de4 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:00:12 -0800
-Subject: [PATCH 02/14] Output vsphere builds to content library instead of
+Subject: [PATCH 02/15] Output vsphere builds to content library instead of
  exports
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0003-Create-etc-pki-tls-certs-dir-as-part-of-image-builds.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0003-Create-etc-pki-tls-certs-dir-as-part-of-image-builds.patch
@@ -1,7 +1,7 @@
 From 459cb070afd02a41592a832277634a21e54ef785 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:05:13 -0800
-Subject: [PATCH 03/14] Create /etc/pki/tls/certs dir as part of image-builds
+Subject: [PATCH 03/15] Create /etc/pki/tls/certs dir as part of image-builds
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0004-Add-etcdadm-and-etcd.tar.gz-to-image-for-unstacked-e.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0004-Add-etcdadm-and-etcd.tar.gz-to-image-for-unstacked-e.patch
@@ -1,7 +1,7 @@
 From 58cbf77177bc8d809c7f451eba75f369a9e71bbb Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:12:53 -0800
-Subject: [PATCH 04/14] Add etcdadm and etcd.tar.gz to image for unstacked etcd
+Subject: [PATCH 04/15] Add etcdadm and etcd.tar.gz to image for unstacked etcd
  support
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0005-Additional-EKS-A-specific-goss-validations.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0005-Additional-EKS-A-specific-goss-validations.patch
@@ -1,7 +1,7 @@
 From e24c5b5fe0d72b0fa848e4c9cb18451d71439c69 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:26:09 -0800
-Subject: [PATCH 05/14] Additional EKS-A specific goss validations
+Subject: [PATCH 05/15] Additional EKS-A specific goss validations
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0006-Tweak-Product-info-in-OVF.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0006-Tweak-Product-info-in-OVF.patch
@@ -1,7 +1,7 @@
 From 6ce15f944ca5b1044cb6dada22006e6699a37c09 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:29:16 -0800
-Subject: [PATCH 06/14] Tweak Product info in OVF
+Subject: [PATCH 06/15] Tweak Product info in OVF
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0007-Add-support-for-RHEL-8-RAW-image-builds.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0007-Add-support-for-RHEL-8-RAW-image-builds.patch
@@ -1,7 +1,7 @@
 From 02466e5d1b15deb2cac0621c1e9197004477919e Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Fri, 25 Mar 2022 14:17:33 -0700
-Subject: [PATCH 07/14] Add support for RHEL 8 RAW image builds
+Subject: [PATCH 07/15] Add support for RHEL 8 RAW image builds
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0008-Support-crictl-validation-from-input-checksum.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0008-Support-crictl-validation-from-input-checksum.patch
@@ -1,7 +1,7 @@
 From 0f98bad00c51b84102ac1ee028a974e3b860b52e Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Fri, 2 Sep 2022 14:32:21 -0700
-Subject: [PATCH 08/14] Support crictl validation from input checksum
+Subject: [PATCH 08/15] Support crictl validation from input checksum
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0009-Exclude-kernel-and-cloud-init-from-yum-updates.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0009-Exclude-kernel-and-cloud-init-from-yum-updates.patch
@@ -1,7 +1,7 @@
 From 7c6f782664d2683a64e670fd06b556f3c4085bb6 Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
 Date: Tue, 6 Dec 2022 15:42:02 -0600
-Subject: [PATCH 09/14] Exclude kernel and cloud-init from yum updates
+Subject: [PATCH 09/15] Exclude kernel and cloud-init from yum updates
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0010-Patch-cloud-init-systemd-unit-to-wait-for-network-ma.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0010-Patch-cloud-init-systemd-unit-to-wait-for-network-ma.patch
@@ -1,7 +1,7 @@
 From b09e2bf3d33970f204f9a30e1a6515810cd3f666 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Mon, 9 Jan 2023 14:11:18 -0600
-Subject: [PATCH 10/14] Patch cloud-init systemd unit to wait for network
+Subject: [PATCH 10/15] Patch cloud-init systemd unit to wait for network
  manager online
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0011-Add-instance-metadata-options-to-Packer-config.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0011-Add-instance-metadata-options-to-Packer-config.patch
@@ -1,7 +1,7 @@
 From 2e8c25de607b30673eece004019943b8dbb6dfdb Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Feb 2023 01:39:15 -0800
-Subject: [PATCH 11/14] Add instance metadata options to Packer config
+Subject: [PATCH 11/15] Add instance metadata options to Packer config
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0012-Rename-Snow-node-image-to-reflect-appropriate-CAPI-p.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0012-Rename-Snow-node-image-to-reflect-appropriate-CAPI-p.patch
@@ -1,7 +1,7 @@
 From 6ca9ba74bdadeefba85c49078df09e8fb8e2e7ff Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Fri, 10 Feb 2023 16:08:18 -0800
-Subject: [PATCH 12/14] Rename Snow node image to reflect appropriate CAPI
+Subject: [PATCH 12/15] Rename Snow node image to reflect appropriate CAPI
  provider
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0013-Add-EKS-A-specific-inline-Goss-vars-to-all-supported.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0013-Add-EKS-A-specific-inline-Goss-vars-to-all-supported.patch
@@ -1,7 +1,7 @@
 From 8289c8a7a3a7ad668e25507ee8eae404a27fe4e5 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Mar 2023 19:27:50 -0800
-Subject: [PATCH 13/14] Add EKS-A specific inline Goss vars to all supported
+Subject: [PATCH 13/15] Add EKS-A specific inline Goss vars to all supported
  providers
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0014-Use-tar.gz-extension-for-CNI-plugins-tarball.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0014-Use-tar.gz-extension-for-CNI-plugins-tarball.patch
@@ -1,7 +1,7 @@
 From 376d269984a104e6ccfac18e91cf3281625aa7a0 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 9 Mar 2023 16:05:22 -0800
-Subject: [PATCH 14/14] Use tar.gz extension for CNI plugins tarball
+Subject: [PATCH 14/15] Use tar.gz extension for CNI plugins tarball
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0015-Ensure-the-correct-Packer-binary-is-used-for-image-b.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0015-Ensure-the-correct-Packer-binary-is-used-for-image-b.patch
@@ -1,0 +1,211 @@
+From 24def7595928ca9de0565cea6fae5795a84201f7 Mon Sep 17 00:00:00 2001
+From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
+Date: Thu, 16 Mar 2023 20:18:56 -0700
+Subject: [PATCH 15/15] Ensure the correct Packer binary is used for image builds
+
+Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
+---
+ images/capi/Makefile              | 73 ++++++++++++++++---------------
+ images/capi/hack/ensure-packer.sh |  2 +-
+ 2 files changed, 39 insertions(+), 36 deletions(-)
+
+diff --git a/images/capi/Makefile b/images/capi/Makefile
+index c90bcc2ac..d19bbe723 100644
+--- a/images/capi/Makefile
++++ b/images/capi/Makefile
+@@ -23,6 +23,9 @@ SHELL := /usr/bin/env bash
+ # This option is for running docker manifest command
+ export DOCKER_CLI_EXPERIMENTAL := enabled
+ export PATH := $(PATH):$(CURDIR)/.local/bin
++# Defining the canonical location of the Packer binary which will be used for
++# `packer init`, `packer build` and `packer validate` commands.
++PACKER=$(shell if [ $$(command -v packer | grep -v sbin) ]; then echo $$(command -v packer); else echo $(CURDIR)/.local/bin/packer; fi)
+ 
+ export IB_VERSION ?= $(shell git describe --dirty)
+ 
+@@ -347,134 +350,134 @@ NUTANIX_VALIDATE_TARGETS	:= $(addprefix validate-,$(NUTANIX_BUILD_NAMES))
+ .PHONY: $(NODE_OVA_LOCAL_BUILD_TARGETS)
+ $(NODE_OVA_LOCAL_BUILD_TARGETS): deps-ova
+     # This uses a packer file builder to input unattend variables into a json file to be consumed by the python script before running the vmware-iso provisioner
+-	$(if $(findstring windows,$@),packer build $(PACKER_WINDOWS_NODE_FLAGS) -var-file="packer/ova/packer-common.json" -var-file="$(abspath packer/ova/$(subst build-node-ova-local-,,$@).json)" -only=file $(ABSOLUTE_PACKER_VAR_FILES) packer/ova/packer-windows.json,)
++	$(if $(findstring windows,$@),$(PACKER) build $(PACKER_WINDOWS_NODE_FLAGS) -var-file="packer/ova/packer-common.json" -var-file="$(abspath packer/ova/$(subst build-node-ova-local-,,$@).json)" -only=file $(ABSOLUTE_PACKER_VAR_FILES) packer/ova/packer-windows.json,)
+ 	$(if $(findstring windows,$@),hack/windows-ova-unattend.py --unattend-file='./packer/ova/windows/$(subst build-node-ova-local-,,$@)/autounattend.xml',)
+-	packer build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="packer/ova/packer-common.json" -var-file="$(abspath packer/ova/$(subst build-node-ova-local-,,$@).json)" -except=vsphere -only=vmware-iso $(ABSOLUTE_PACKER_VAR_FILES) packer/ova/packer-$(if $(findstring windows,$@),windows,node).json
++	$(PACKER) build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="packer/ova/packer-common.json" -var-file="$(abspath packer/ova/$(subst build-node-ova-local-,,$@).json)" -except=vsphere -only=vmware-iso $(ABSOLUTE_PACKER_VAR_FILES) packer/ova/packer-$(if $(findstring windows,$@),windows,node).json
+ 
+ .PHONY: $(NODE_OVA_LOCAL_VALIDATE_TARGETS)
+ $(NODE_OVA_LOCAL_VALIDATE_TARGETS): deps-ova
+-	packer validate $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="packer/ova/packer-common.json" -var-file="$(abspath packer/ova/$(subst validate-node-ova-local-,,$@).json)" -except=vsphere -only=vmware-iso $(ABSOLUTE_PACKER_VAR_FILES) packer/ova/packer-$(if $(findstring windows,$@),windows,node).json
++	$(PACKER) validate $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="packer/ova/packer-common.json" -var-file="$(abspath packer/ova/$(subst validate-node-ova-local-,,$@).json)" -except=vsphere -only=vmware-iso $(ABSOLUTE_PACKER_VAR_FILES) packer/ova/packer-$(if $(findstring windows,$@),windows,node).json
+ 
+ .PHONY: $(NODE_OVA_LOCAL_VMX_BUILD_TARGETS)
+ $(NODE_OVA_LOCAL_VMX_BUILD_TARGETS): deps-ova
+-	packer build $(PACKER_NODE_FLAGS) -var-file="packer/ova/packer-common.json" -var-file="$(abspath packer/ova/$(subst build-node-ova-local-vmx-,,$@).json)" -var-file="packer/ova/vmx.json" -except=vsphere -except=vmware-iso -only=vmware-vmx $(ABSOLUTE_PACKER_VAR_FILES) packer/ova/packer-node.json
++	$(PACKER) build $(PACKER_NODE_FLAGS) -var-file="packer/ova/packer-common.json" -var-file="$(abspath packer/ova/$(subst build-node-ova-local-vmx-,,$@).json)" -var-file="packer/ova/vmx.json" -except=vsphere -except=vmware-iso -only=vmware-vmx $(ABSOLUTE_PACKER_VAR_FILES) packer/ova/packer-node.json
+ 
+ .PHONY: $(NODE_OVA_LOCAL_BASE_BUILD_TARGETS)
+ $(NODE_OVA_LOCAL_BASE_BUILD_TARGETS): deps-ova
+-	packer build $(PACKER_NODE_FLAGS) -var-file="packer/ova/packer-common.json" -var-file="$(abspath packer/ova/$(subst build-node-ova-local-base-,,$@).json)"  -except=vsphere -except=vmware-iso -except=vmware-vmx -only=vmware-iso-base $(ABSOLUTE_PACKER_VAR_FILES) packer/ova/packer-node.json
++	$(PACKER) build $(PACKER_NODE_FLAGS) -var-file="packer/ova/packer-common.json" -var-file="$(abspath packer/ova/$(subst build-node-ova-local-base-,,$@).json)"  -except=vsphere -except=vmware-iso -except=vmware-vmx -only=vmware-iso-base $(ABSOLUTE_PACKER_VAR_FILES) packer/ova/packer-node.json
+ 
+ .PHONY: $(NODE_OVA_VSPHERE_BUILD_TARGETS)
+ $(NODE_OVA_VSPHERE_BUILD_TARGETS): deps-ova
+     # This uses a packer file builder to input unattend variables into a json file to be consumed by the python script before running the vsphere provisioner
+-	$(if $(findstring windows,$@),packer build $(PACKER_WINDOWS_NODE_FLAGS) -var-file="packer/ova/packer-common.json" -var-file="$(abspath packer/ova/$(subst build-node-ova-vsphere-,,$@).json)" -only=file $(ABSOLUTE_PACKER_VAR_FILES) packer/ova/packer-windows.json,)
++	$(if $(findstring windows,$@),$(PACKER) build $(PACKER_WINDOWS_NODE_FLAGS) -var-file="packer/ova/packer-common.json" -var-file="$(abspath packer/ova/$(subst build-node-ova-vsphere-,,$@).json)" -only=file $(ABSOLUTE_PACKER_VAR_FILES) packer/ova/packer-windows.json,)
+ 	$(if $(findstring windows,$@),hack/windows-ova-unattend.py --unattend-file='./packer/ova/windows/$(subst build-node-ova-vsphere-,,$@)/autounattend.xml',)
+-	packer build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS))  -var-file="packer/ova/packer-common.json" -var-file="$(abspath packer/ova/$(subst build-node-ova-vsphere-,,$@).json)" -var-file="packer/ova/vsphere.json"  -except=local -only=vsphere-iso $(ABSOLUTE_PACKER_VAR_FILES) -only=vsphere packer/ova/packer-$(if $(findstring windows,$@),windows,node).json
++	$(PACKER) build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS))  -var-file="packer/ova/packer-common.json" -var-file="$(abspath packer/ova/$(subst build-node-ova-vsphere-,,$@).json)" -var-file="packer/ova/vsphere.json"  -except=local -only=vsphere-iso $(ABSOLUTE_PACKER_VAR_FILES) -only=vsphere packer/ova/packer-$(if $(findstring windows,$@),windows,node).json
+ 
+ .PHONY: $(NODE_OVA_VSPHERE_BASE_BUILD_TARGETS)
+ $(NODE_OVA_VSPHERE_BASE_BUILD_TARGETS): deps-ova
+-	packer build $(PACKER_NODE_FLAGS) -var-file="packer/ova/packer-common.json" -var-file="$(abspath packer/ova/$(subst build-node-ova-vsphere-base-,,$@).json)" -var-file="packer/ova/vsphere.json" -except=local -except=manifest -except=vsphere -only=vsphere-iso-base $(ABSOLUTE_PACKER_VAR_FILES) packer/ova/packer-node.json
++	$(PACKER) build $(PACKER_NODE_FLAGS) -var-file="packer/ova/packer-common.json" -var-file="$(abspath packer/ova/$(subst build-node-ova-vsphere-base-,,$@).json)" -var-file="packer/ova/vsphere.json" -except=local -except=manifest -except=vsphere -only=vsphere-iso-base $(ABSOLUTE_PACKER_VAR_FILES) packer/ova/packer-node.json
+ 
+ .PHONY: $(NODE_OVA_VSPHERE_CLONE_BUILD_TARGETS)
+ $(NODE_OVA_VSPHERE_CLONE_BUILD_TARGETS): deps-ova
+-	packer build $(PACKER_NODE_FLAGS) -var-file="packer/ova/packer-common.json" -var-file="$(abspath packer/ova/$(subst build-node-ova-vsphere-clone-,,$@).json)" -var-file="packer/ova/vsphere.json" -except=local -only=vsphere-clone $(ABSOLUTE_PACKER_VAR_FILES) packer/ova/packer-node.json
++	$(PACKER) build $(PACKER_NODE_FLAGS) -var-file="packer/ova/packer-common.json" -var-file="$(abspath packer/ova/$(subst build-node-ova-vsphere-clone-,,$@).json)" -var-file="packer/ova/vsphere.json" -except=local -only=vsphere-clone $(ABSOLUTE_PACKER_VAR_FILES) packer/ova/packer-node.json
+ 
+ .PHONY: $(AMI_BUILD_TARGETS)
+ $(AMI_BUILD_TARGETS): deps-ami
+-	packer build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/ami/$(subst build-ami-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/ami/packer$(if $(findstring windows,$@),-windows,).json
++	$(PACKER) build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/ami/$(subst build-ami-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/ami/packer$(if $(findstring windows,$@),-windows,).json
+ 
+ .PHONY: $(AMI_VALIDATE_TARGETS)
+ $(AMI_VALIDATE_TARGETS): deps-ami
+-	packer validate $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/ami/$(subst validate-ami-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/ami/packer$(if $(findstring windows,$@),-windows,).json
++	$(PACKER) validate $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/ami/$(subst validate-ami-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/ami/packer$(if $(findstring windows,$@),-windows,).json
+ 
+ .PHONY: $(GCE_BUILD_TARGETS)
+ $(GCE_BUILD_TARGETS): deps-gce
+-	packer build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/gce/$(subst build-gce-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/gce/packer.json
++	$(PACKER) build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/gce/$(subst build-gce-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/gce/packer.json
+ 
+ .PHONY: $(GCE_VALIDATE_TARGETS)
+ $(GCE_VALIDATE_TARGETS): deps-gce
+-	packer validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/gce/$(subst validate-gce-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/gce/packer.json
++	$(PACKER) validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/gce/$(subst validate-gce-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/gce/packer.json
+ 
+ .PHONY: $(AZURE_BUILD_VHD_TARGETS)
+ $(AZURE_BUILD_VHD_TARGETS): deps-azure
+-	. $(abspath packer/azure/scripts/init-vhd.sh) && packer build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/azure-vhd.json)" -var-file="$(abspath packer/azure/$(subst build-azure-vhd-,,$@).json)" -only="$(subst build-azure-,,$@)" $(ABSOLUTE_PACKER_VAR_FILES) packer/azure/packer$(findstring -windows,$@).json
++	. $(abspath packer/azure/scripts/init-vhd.sh) && $(PACKER) build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/azure-vhd.json)" -var-file="$(abspath packer/azure/$(subst build-azure-vhd-,,$@).json)" -only="$(subst build-azure-,,$@)" $(ABSOLUTE_PACKER_VAR_FILES) packer/azure/packer$(findstring -windows,$@).json
+ 
+ .PHONY: $(AZURE_VALIDATE_VHD_TARGETS)
+ $(AZURE_VALIDATE_VHD_TARGETS): deps-azure
+-	packer validate $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/azure-vhd.json)" -var-file="$(abspath packer/azure/$(subst validate-azure-vhd-,,$@).json)" -only="$(subst validate-azure-,,$@)" $(ABSOLUTE_PACKER_VAR_FILES) packer/azure/packer$(findstring -windows,$@).json
++	$(PACKER) validate $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/azure-vhd.json)" -var-file="$(abspath packer/azure/$(subst validate-azure-vhd-,,$@).json)" -only="$(subst validate-azure-,,$@)" $(ABSOLUTE_PACKER_VAR_FILES) packer/azure/packer$(findstring -windows,$@).json
+ 
+ .PHONY: $(AZURE_BUILD_SIG_TARGETS)
+ $(AZURE_BUILD_SIG_TARGETS): deps-azure
+-	. $(abspath packer/azure/scripts/init-sig.sh) $(subst build-azure-sig-,,$@) && packer build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/azure-sig.json)" -var-file="$(abspath packer/azure/$(subst build-azure-sig-,,$@).json)" -only="$(subst build-azure-,,$@)" $(ABSOLUTE_PACKER_VAR_FILES) packer/azure/packer$(findstring -windows,$@).json
++	. $(abspath packer/azure/scripts/init-sig.sh) $(subst build-azure-sig-,,$@) && $(PACKER) build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/azure-sig.json)" -var-file="$(abspath packer/azure/$(subst build-azure-sig-,,$@).json)" -only="$(subst build-azure-,,$@)" $(ABSOLUTE_PACKER_VAR_FILES) packer/azure/packer$(findstring -windows,$@).json
+ 
+ .PHONY: $(AZURE_BUILD_SIG_GEN2_TARGETS)
+ $(AZURE_BUILD_SIG_GEN2_TARGETS): deps-azure
+-	. $(abspath packer/azure/scripts/init-sig.sh) $(subst build-azure-sig-,,$@) && packer build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/azure-sig-gen2.json)" -var-file="$(abspath packer/azure/$(subst build-azure-sig-,,$@).json)" -only="$(subst build-azure-,,$@)" $(ABSOLUTE_PACKER_VAR_FILES) packer/azure/packer$(findstring -windows,$@).json
++	. $(abspath packer/azure/scripts/init-sig.sh) $(subst build-azure-sig-,,$@) && $(PACKER) build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/azure-sig-gen2.json)" -var-file="$(abspath packer/azure/$(subst build-azure-sig-,,$@).json)" -only="$(subst build-azure-,,$@)" $(ABSOLUTE_PACKER_VAR_FILES) packer/azure/packer$(findstring -windows,$@).json
+ 
+ .PHONY: $(AZURE_VALIDATE_SIG_TARGETS)
+ $(AZURE_VALIDATE_SIG_TARGETS): deps-azure
+-	packer validate $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/azure-sig.json)" -var-file="$(abspath packer/azure/$(subst validate-azure-sig-,,$@).json)" -only="$(subst validate-azure-,,$@)" $(ABSOLUTE_PACKER_VAR_FILES) packer/azure/packer$(findstring -windows,$@).json
++	$(PACKER) validate $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/azure-sig.json)" -var-file="$(abspath packer/azure/$(subst validate-azure-sig-,,$@).json)" -only="$(subst validate-azure-,,$@)" $(ABSOLUTE_PACKER_VAR_FILES) packer/azure/packer$(findstring -windows,$@).json
+ 
+ .PHONY: $(AZURE_VALIDATE_SIG_GEN2_TARGETS)
+ $(AZURE_VALIDATE_SIG_GEN2_TARGETS): deps-azure
+-	packer validate $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/azure-sig-gen2.json)" -var-file="$(abspath packer/azure/$(subst validate-azure-sig-,,$@).json)" -only="$(subst validate-azure-,,$@)" $(ABSOLUTE_PACKER_VAR_FILES) packer/azure/packer$(findstring windows,$@).json
++	$(PACKER) validate $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="$(abspath packer/azure/azure-config.json)" -var-file="$(abspath packer/azure/azure-sig-gen2.json)" -var-file="$(abspath packer/azure/$(subst validate-azure-sig-,,$@).json)" -only="$(subst validate-azure-,,$@)" $(ABSOLUTE_PACKER_VAR_FILES) packer/azure/packer$(findstring windows,$@).json
+ 
+ .PHONY: $(DO_BUILD_TARGETS)
+ $(DO_BUILD_TARGETS): deps-do
+-	packer build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/digitalocean/$(subst build-do-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/digitalocean/packer.json
++	$(PACKER) build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/digitalocean/$(subst build-do-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/digitalocean/packer.json
+ 
+ .PHONY: $(DO_VALIDATE_TARGETS)
+ $(DO_VALIDATE_TARGETS): deps-do
+-	packer validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/digitalocean/$(subst validate-do-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/digitalocean/packer.json
++	$(PACKER) validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/digitalocean/$(subst validate-do-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/digitalocean/packer.json
+ 
+ .PHONY: $(QEMU_BUILD_TARGETS)
+ $(QEMU_BUILD_TARGETS): deps-qemu
+-	packer build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst build-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/qemu/packer.json
++	$(PACKER) build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst build-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/qemu/packer.json
+ 
+ .PHONY: $(QEMU_VALIDATE_TARGETS)
+ $(QEMU_VALIDATE_TARGETS): deps-qemu
+-	packer validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst validate-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/qemu/packer.json
++	$(PACKER) validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/qemu/$(subst validate-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/qemu/packer.json
+ 
+ .PHONY: $(RAW_BUILD_TARGETS)
+ $(RAW_BUILD_TARGETS): deps-raw
+-	packer build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/raw/$(subst build-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/raw/packer.json
++	$(PACKER) build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/raw/$(subst build-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/raw/packer.json
+ 
+ .PHONY: $(RAW_VALIDATE_TARGETS)
+ $(RAW_VALIDATE_TARGETS): deps-raw
+-	packer validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/raw/$(subst validate-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/raw/packer.json
++	$(PACKER) validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/raw/$(subst validate-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/raw/packer.json
+ 
+ .PHONY: $(OCI_BUILD_TARGETS)
+ $(OCI_BUILD_TARGETS): deps-oci
+-	packer build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/oci/$(subst build-oci-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/oci/packer.json
++	$(PACKER) build $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/oci/$(subst build-oci-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/oci/packer.json
+ 
+ .PHONY: $(OCI_VALIDATE_TARGETS)
+ $(OCI_VALIDATE_TARGETS): deps-oci
+-	packer validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/oci/$(subst validate-oci-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/oci/packer.json
++	$(PACKER) validate $(PACKER_NODE_FLAGS) -var-file="$(abspath packer/oci/$(subst validate-oci-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/oci/packer.json
+ 
+ .PHONY: $(VBOX_BUILD_TARGETS)
+ $(VBOX_BUILD_TARGETS): deps-vbox
+-	packer build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="packer/vbox/packer-common.json" -var-file="$(abspath packer/vbox/$(subst build-vbox-,,$@).json)" -only=virtualbox-iso $(ABSOLUTE_PACKER_VAR_FILES) packer/vbox/packer-$(if $(findstring windows,$@),windows).json
++	$(PACKER) build $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="packer/vbox/packer-common.json" -var-file="$(abspath packer/vbox/$(subst build-vbox-,,$@).json)" -only=virtualbox-iso $(ABSOLUTE_PACKER_VAR_FILES) packer/vbox/packer-$(if $(findstring windows,$@),windows).json
+ 
+ .PHONY: $(VBOX_VALIDATE_TARGETS)
+ $(VBOX_VALIDATE_TARGETS): deps-vbox
+-	packer validate $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="packer/vbox/packer-common.json" -var-file="$(abspath packer/vbox/$(subst validate-vbox-,,$@).json)" -only=virtualbox-iso $(ABSOLUTE_PACKER_VAR_FILES) packer/vbox/packer-$(if $(findstring windows,$@),windows).json
++	$(PACKER) validate $(if $(findstring windows,$@),$(PACKER_WINDOWS_NODE_FLAGS),$(PACKER_NODE_FLAGS)) -var-file="packer/vbox/packer-common.json" -var-file="$(abspath packer/vbox/$(subst validate-vbox-,,$@).json)" -only=virtualbox-iso $(ABSOLUTE_PACKER_VAR_FILES) packer/vbox/packer-$(if $(findstring windows,$@),windows).json
+ 
+ .PHONY: $(POWERVS_BUILD_TARGETS)
+ $(POWERVS_BUILD_TARGETS): deps-powervs
+-	packer build $(PACKER_POWERVS_NODE_FLAGS) -var-file="$(abspath packer/powervs/$(subst build-powervs-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) -except=flatcar packer/powervs/packer.json
++	$(PACKER) build $(PACKER_POWERVS_NODE_FLAGS) -var-file="$(abspath packer/powervs/$(subst build-powervs-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) -except=flatcar packer/powervs/packer.json
+ 
+ .PHONY: $(POWERVS_VALIDATE_TARGETS)
+ $(POWERVS_VALIDATE_TARGETS): deps-powervs
+-	packer validate $(PACKER_POWERVS_NODE_FLAGS) -var-file="$(abspath packer/powervs/$(subst validate-powervs-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) -except=flatcar packer/powervs/packer.json
++	$(PACKER) validate $(PACKER_POWERVS_NODE_FLAGS) -var-file="$(abspath packer/powervs/$(subst validate-powervs-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) -except=flatcar packer/powervs/packer.json
+ 
+ .PHONY: $(NUTANIX_BUILD_TARGETS)
+ $(NUTANIX_BUILD_TARGETS): deps-nutanix
+-	packer init packer/nutanix/config.pkr.hcl
+-	packer build $(PACKER_NODE_FLAGS) -var-file="packer/nutanix/nutanix.json" -var-file="$(abspath packer/nutanix/$(subst build-nutanix-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/nutanix/packer.json
++	$(PACKER) init packer/nutanix/config.pkr.hcl
++	$(PACKER) build $(PACKER_NODE_FLAGS) -var-file="packer/nutanix/nutanix.json" -var-file="$(abspath packer/nutanix/$(subst build-nutanix-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/nutanix/packer.json
+ 
+ .PHONY: $(NUTANIX_VALIDATE_TARGETS)
+ $(NUTANIX_VALIDATE_TARGETS): deps-nutanix
+-	packer init packer/nutanix/config.pkr.hcl
+-	packer validate $(PACKER_NODE_FLAGS) -var-file="packer/nutanix/nutanix.json" -var-file="$(abspath packer/nutanix/$(subst validate-nutanix-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/nutanix/packer.json
++	$(PACKER) init packer/nutanix/config.pkr.hcl
++	$(PACKER) validate $(PACKER_NODE_FLAGS) -var-file="packer/nutanix/nutanix.json" -var-file="$(abspath packer/nutanix/$(subst validate-nutanix-,,$@).json)" $(ABSOLUTE_PACKER_VAR_FILES) packer/nutanix/packer.json
+ 
+ ## --------------------------------------
+ ## Dynamic clean targets
+diff --git a/images/capi/hack/ensure-packer.sh b/images/capi/hack/ensure-packer.sh
+index 452dda590..161d3081b 100755
+--- a/images/capi/hack/ensure-packer.sh
++++ b/images/capi/hack/ensure-packer.sh
+@@ -28,7 +28,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
+ 
+ source hack/utils.sh
+ 
+-if command -v packer >/dev/null 2>&1; then exit 0; fi
++if (command -v packer && timeout 10 packer version) >/dev/null 2>&1; then exit 0; fi
+ 
+ mkdir -p .local/bin && cd .local/bin
+ 
+-- 
+2.39.2
+


### PR DESCRIPTION
Ref: kubernetes-sigs/image-builder#1108


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
