### PR TITLE
Use 1.26 for generated help.mk files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ clean: $(addprefix clean-project-, $(ALL_PROJECTS))
 .PHONY: add-generated-help-block-project-%
 add-generated-help-block-project-%:
 	$(eval PROJECT_PATH=$(call PROJECT_PATH_MAP,$*))
-	$(MAKE) add-generated-help-block -C $(PROJECT_PATH) RELEASE_BRANCH=1-21
+	$(MAKE) add-generated-help-block -C $(PROJECT_PATH) RELEASE_BRANCH=1-26
 
 .PHONY: add-generated-help-block
 add-generated-help-block: $(addprefix add-generated-help-block-project-, $(ALL_PROJECTS))

--- a/projects/aws/bottlerocket-bootstrap/Help.mk
+++ b/projects/aws/bottlerocket-bootstrap/Help.mk
@@ -22,12 +22,12 @@ bottlerocket-bootstrap/images/push: ## Builds/pushes `bottlerocket-bootstrap/ima
 bottlerocket-bootstrap-snow/images/push: ## Builds/pushes `bottlerocket-bootstrap-snow/images/push`
 
 ##@ Fetch Binary Targets
-_output/1-21/dependencies/linux-amd64/eksd/kubernetes/client: ## Fetch `_output/1-21/dependencies/linux-amd64/eksd/kubernetes/client`
-_output/1-21/dependencies/linux-arm64/eksd/kubernetes/client: ## Fetch `_output/1-21/dependencies/linux-arm64/eksd/kubernetes/client`
-_output/1-21/dependencies/linux-amd64/eksd/kubernetes/server: ## Fetch `_output/1-21/dependencies/linux-amd64/eksd/kubernetes/server`
-_output/1-21/dependencies/linux-arm64/eksd/kubernetes/server: ## Fetch `_output/1-21/dependencies/linux-arm64/eksd/kubernetes/server`
-_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm: ## Fetch `_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm`
-_output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/etcdadm: ## Fetch `_output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/etcdadm`
+_output/1-26/dependencies/linux-amd64/eksd/kubernetes/client: ## Fetch `_output/1-26/dependencies/linux-amd64/eksd/kubernetes/client`
+_output/1-26/dependencies/linux-arm64/eksd/kubernetes/client: ## Fetch `_output/1-26/dependencies/linux-arm64/eksd/kubernetes/client`
+_output/1-26/dependencies/linux-amd64/eksd/kubernetes/server: ## Fetch `_output/1-26/dependencies/linux-amd64/eksd/kubernetes/server`
+_output/1-26/dependencies/linux-arm64/eksd/kubernetes/server: ## Fetch `_output/1-26/dependencies/linux-arm64/eksd/kubernetes/server`
+_output/1-26/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm: ## Fetch `_output/1-26/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm`
+_output/1-26/dependencies/linux-arm64/eksa/kubernetes-sigs/etcdadm: ## Fetch `_output/1-26/dependencies/linux-arm64/eksa/kubernetes-sigs/etcdadm`
 
 ##@ Checksum Targets
 checksums: ## Update checksums file based on currently built binaries.

--- a/projects/aws/bottlerocket-bootstrap/Makefile
+++ b/projects/aws/bottlerocket-bootstrap/Makefile
@@ -97,6 +97,7 @@ unit-test:
 mocks: $(MOCKGEN)
 	go generate ./...
 
+
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block
 # This is added to help document dynamic targets and support shell autocompletion

--- a/projects/emissary-ingress/emissary/Makefile
+++ b/projects/emissary-ingress/emissary/Makefile
@@ -54,6 +54,7 @@ helm/push: helm/build
 	$(BUILD_LIB)/helm_push.sh $(IMAGE_REPO) $(HELM_DESTINATION_REPOSITORY) $(HELM_TAG) $(GIT_TAG) $(OUTPUT_DIR) $(LATEST)
 	$(BUILD_LIB)/helm_push.sh $(IMAGE_REPO) emissary-ingress/crds $(HELM_TAG) $(GIT_TAG) $(OUTPUT_DIR) $(LATEST)
 
+
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block
 # This is added to help document dynamic targets and support shell autocompletion

--- a/projects/fluxcd/source-controller/Makefile
+++ b/projects/fluxcd/source-controller/Makefile
@@ -88,6 +88,7 @@ fake-binary-prereqs: $(GO_MOD_DOWNLOAD_TARGETS)
 	touch $(CGO_SOURCE)/linux-amd64/usr/lib64/libgit2.so $(CGO_SOURCE)/linux-arm64/usr/lib64/libgit2.so
 	
 
+
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block
 # This is added to help document dynamic targets and support shell autocompletion

--- a/projects/kubernetes-sigs/image-builder/Help.mk
+++ b/projects/kubernetes-sigs/image-builder/Help.mk
@@ -18,10 +18,10 @@ image-builder/images/amd64: ## Builds/pushes `image-builder/images/amd64`
 image-builder/images/push: ## Builds/pushes `image-builder/images/push`
 
 ##@ Fetch Binary Targets
-_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm: ## Fetch `_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm`
-_output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/etcdadm: ## Fetch `_output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/etcdadm`
-_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/cri-tools: ## Fetch `_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/cri-tools`
-_output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/cri-tools: ## Fetch `_output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/cri-tools`
+_output/1-26/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm: ## Fetch `_output/1-26/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm`
+_output/1-26/dependencies/linux-arm64/eksa/kubernetes-sigs/etcdadm: ## Fetch `_output/1-26/dependencies/linux-arm64/eksa/kubernetes-sigs/etcdadm`
+_output/1-26/dependencies/linux-amd64/eksa/kubernetes-sigs/cri-tools: ## Fetch `_output/1-26/dependencies/linux-amd64/eksa/kubernetes-sigs/cri-tools`
+_output/1-26/dependencies/linux-arm64/eksa/kubernetes-sigs/cri-tools: ## Fetch `_output/1-26/dependencies/linux-arm64/eksa/kubernetes-sigs/cri-tools`
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
@@ -42,6 +42,6 @@ patch-for-dep-update: ## After bumping dep in go.mod file and updating vendor, g
 create-ecr-repos: ## Create repos in ECR for project images for local testing
 
 ##@ Build Targets
-build: ## Called via prow presubmit, calls `release-image-build-on-metal-ubuntu fake-ubuntu.gz _output/tar/1-21/raw/ubuntu/ubuntu.gz upload-artifacts-raw download-bottlerocket-raw _output/tar/1-21/raw/bottlerocket/bottlerocket.img.gz upload-bottlerocket-raw build-ami-ubuntu-2004 download-bottlerocket-ami _output/tar/1-21/ami/bottlerocket/bottlerocket.img.gz upload-bottlerocket-ami setup-packer-configs-ova  fake-ubuntu.ova _output/tar/1-21/ova/ubuntu/ubuntu.ova  upload-artifacts-ova download-bottlerocket-ova _output/tar/1-21/ova/bottlerocket/bottlerocket.ova upload-bottlerocket-ova`
+build: ## Called via prow presubmit, calls `release-image-build-on-metal-ubuntu fake-ubuntu.gz _output/tar/1-26/raw/ubuntu/ubuntu.gz upload-artifacts-raw build-ami-ubuntu-2004 setup-packer-configs-ova  fake-ubuntu.ova _output/tar/1-26/ova/ubuntu/ubuntu.ova  upload-artifacts-ova`
 release: ## Called via prow postsubmit + release jobs, calls `release-image-build-on-metal-ubuntu upload-artifacts-raw`
 ########### END GENERATED ###########################

--- a/projects/kubernetes-sigs/kind/Help.mk
+++ b/projects/kubernetes-sigs/kind/Help.mk
@@ -29,16 +29,16 @@ kindnetd/images/push: ## Builds/pushes `kindnetd/images/push`
 kind-base/images/push: ## Builds/pushes `kind-base/images/push`
 
 ##@ Fetch Binary Targets
-_output/1-21/dependencies/linux-amd64/eksd/kubernetes/client: ## Fetch `_output/1-21/dependencies/linux-amd64/eksd/kubernetes/client`
-_output/1-21/dependencies/linux-arm64/eksd/kubernetes/client: ## Fetch `_output/1-21/dependencies/linux-arm64/eksd/kubernetes/client`
-_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm: ## Fetch `_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm`
-_output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/etcdadm: ## Fetch `_output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/etcdadm`
-_output/1-21/dependencies/linux-amd64/eksd/cni-plugins: ## Fetch `_output/1-21/dependencies/linux-amd64/eksd/cni-plugins`
-_output/1-21/dependencies/linux-arm64/eksd/cni-plugins: ## Fetch `_output/1-21/dependencies/linux-arm64/eksd/cni-plugins`
-_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/cri-tools: ## Fetch `_output/1-21/dependencies/linux-amd64/eksa/kubernetes-sigs/cri-tools`
-_output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/cri-tools: ## Fetch `_output/1-21/dependencies/linux-arm64/eksa/kubernetes-sigs/cri-tools`
-_output/1-21/dependencies/linux-amd64/eksd/etcd/etcd.tar.gz: ## Fetch `_output/1-21/dependencies/linux-amd64/eksd/etcd/etcd.tar.gz`
-_output/1-21/dependencies/linux-arm64/eksd/etcd/etcd.tar.gz: ## Fetch `_output/1-21/dependencies/linux-arm64/eksd/etcd/etcd.tar.gz`
+_output/1-26/dependencies/linux-amd64/eksd/kubernetes/client: ## Fetch `_output/1-26/dependencies/linux-amd64/eksd/kubernetes/client`
+_output/1-26/dependencies/linux-arm64/eksd/kubernetes/client: ## Fetch `_output/1-26/dependencies/linux-arm64/eksd/kubernetes/client`
+_output/1-26/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm: ## Fetch `_output/1-26/dependencies/linux-amd64/eksa/kubernetes-sigs/etcdadm`
+_output/1-26/dependencies/linux-arm64/eksa/kubernetes-sigs/etcdadm: ## Fetch `_output/1-26/dependencies/linux-arm64/eksa/kubernetes-sigs/etcdadm`
+_output/1-26/dependencies/linux-amd64/eksd/cni-plugins: ## Fetch `_output/1-26/dependencies/linux-amd64/eksd/cni-plugins`
+_output/1-26/dependencies/linux-arm64/eksd/cni-plugins: ## Fetch `_output/1-26/dependencies/linux-arm64/eksd/cni-plugins`
+_output/1-26/dependencies/linux-amd64/eksa/kubernetes-sigs/cri-tools: ## Fetch `_output/1-26/dependencies/linux-amd64/eksa/kubernetes-sigs/cri-tools`
+_output/1-26/dependencies/linux-arm64/eksa/kubernetes-sigs/cri-tools: ## Fetch `_output/1-26/dependencies/linux-arm64/eksa/kubernetes-sigs/cri-tools`
+_output/1-26/dependencies/linux-amd64/eksd/etcd/etcd.tar.gz: ## Fetch `_output/1-26/dependencies/linux-amd64/eksd/etcd/etcd.tar.gz`
+_output/1-26/dependencies/linux-arm64/eksd/etcd/etcd.tar.gz: ## Fetch `_output/1-26/dependencies/linux-arm64/eksd/etcd/etcd.tar.gz`
 
 ##@ Checksum Targets
 checksums: ## Update checksums file based on currently built binaries.

--- a/projects/kubernetes/autoscaler/Help.mk
+++ b/projects/kubernetes/autoscaler/Help.mk
@@ -9,12 +9,11 @@
 ##@ GIT/Repo Targets
 clone-repo:  ## Clone upstream `autoscaler`
 checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
-patch-repo: ## Patch upstream repo with patches in patches directory
 
 ##@ Binary Targets
 binaries: ## Build all binaries: `cluster-autoscaler` for `linux/amd64 linux/arm64`
-_output/1-21/bin/autoscaler/linux-amd64/cluster-autoscaler: ## Build `_output/1-21/bin/autoscaler/linux-amd64/cluster-autoscaler`
-_output/1-21/bin/autoscaler/linux-arm64/cluster-autoscaler: ## Build `_output/1-21/bin/autoscaler/linux-arm64/cluster-autoscaler`
+_output/1-26/bin/autoscaler/linux-amd64/cluster-autoscaler: ## Build `_output/1-26/bin/autoscaler/linux-amd64/cluster-autoscaler`
+_output/1-26/bin/autoscaler/linux-arm64/cluster-autoscaler: ## Build `_output/1-26/bin/autoscaler/linux-arm64/cluster-autoscaler`
 
 ##@ Image Targets
 local-images: ## Builds `autoscaler/images/amd64` as oci tars for presumbit validation

--- a/projects/kubernetes/cloud-provider-vsphere/Help.mk
+++ b/projects/kubernetes/cloud-provider-vsphere/Help.mk
@@ -9,12 +9,11 @@
 ##@ GIT/Repo Targets
 clone-repo:  ## Clone upstream `cloud-provider-vsphere`
 checkout-repo: ## Checkout upstream tag based on value in GIT_TAG file
-patch-repo: ## Patch upstream repo with patches in patches directory
 
 ##@ Binary Targets
 binaries: ## Build all binaries: `vsphere-cloud-controller-manager` for `linux/amd64 linux/arm64`
-_output/1-21/bin/cloud-provider-vsphere/linux-amd64/vsphere-cloud-controller-manager: ## Build `_output/1-21/bin/cloud-provider-vsphere/linux-amd64/vsphere-cloud-controller-manager`
-_output/1-21/bin/cloud-provider-vsphere/linux-arm64/vsphere-cloud-controller-manager: ## Build `_output/1-21/bin/cloud-provider-vsphere/linux-arm64/vsphere-cloud-controller-manager`
+_output/1-26/bin/cloud-provider-vsphere/linux-amd64/vsphere-cloud-controller-manager: ## Build `_output/1-26/bin/cloud-provider-vsphere/linux-amd64/vsphere-cloud-controller-manager`
+_output/1-26/bin/cloud-provider-vsphere/linux-arm64/vsphere-cloud-controller-manager: ## Build `_output/1-26/bin/cloud-provider-vsphere/linux-arm64/vsphere-cloud-controller-manager`
 
 ##@ Image Targets
 local-images: ## Builds `cloud-provider-vsphere/images/amd64` as oci tars for presumbit validation

--- a/projects/metallb/metallb/Makefile
+++ b/projects/metallb/metallb/Makefile
@@ -46,6 +46,7 @@ helm/push: helm/build
 	$(BUILD_LIB)/helm_push.sh $(IMAGE_REPO) $(HELM_DESTINATION_REPOSITORY) $(HELM_TAG) $(GIT_TAG) $(OUTPUT_DIR) $(LATEST)
 	$(BUILD_LIB)/helm_push.sh $(IMAGE_REPO) metallb/crds $(HELM_TAG) $(GIT_TAG) $(OUTPUT_DIR) $(LATEST)
 
+
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block
 # This is added to help document dynamic targets and support shell autocompletion

--- a/projects/prometheus/node_exporter/Makefile
+++ b/projects/prometheus/node_exporter/Makefile
@@ -30,6 +30,7 @@ $(FIX_LICENSES_DENNWC_TARGETS): | $(GO_MOD_DOWNLOAD_TARGETS)
 			$(REPO)/vendor/github.com/dennwc/$$package/LICENSE; \
 	done;
 
+
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block
 # This is added to help document dynamic targets and support shell autocompletion

--- a/projects/prometheus/prometheus/Makefile
+++ b/projects/prometheus/prometheus/Makefile
@@ -74,6 +74,7 @@ $(EXTRA_DOCKER_FILE_TARGETS):
 
 	cp prometheus/npm_licenses.tar.bz2 $(OUTPUT_DIR)/npm_licenses.tar.bz2
 
+
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block
 # This is added to help document dynamic targets and support shell autocompletion

--- a/projects/tinkerbell/hegel/Makefile
+++ b/projects/tinkerbell/hegel/Makefile
@@ -16,6 +16,7 @@ include $(BASE_DIRECTORY)/Common.mk
 
 $(call IMAGE_TARGETS_FOR_NAME, hegel): hegel-useradd/images/export
 
+
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block
 # This is added to help document dynamic targets and support shell autocompletion

--- a/projects/tinkerbell/rufio/Makefile
+++ b/projects/tinkerbell/rufio/Makefile
@@ -31,6 +31,7 @@ $(FIX_LICENSE_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
 	wget -q --retry-connrefused -O $$dest \
 		https://raw.githubusercontent.com/bmc-toolbox/common/main/LICENSE;
 
+
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block
 # This is added to help document dynamic targets and support shell autocompletion


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Kind of a weird thing, but doesnt affect too much what version is in the help, we just need a version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
