### PR TITLE
Update BR Images to v1.13.0

### DIFF
--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_ADMIN_CONTAINER_METADATA
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_ADMIN_CONTAINER_METADATA
@@ -1,2 +1,2 @@
-tag: v0.9.4
-imageDigest: sha256:5af314144e2e349b0fdb504dba5c3bcac6f7594ea4051ce1365dd69a923cb57f
+tag: v0.10.0
+imageDigest: sha256:994f332ac4b2fb2a5c3acca75501e5c5ef34cc1bfdfcffb3d0af16ceb1bdb1ca

--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_CONTROL_CONTAINER_METADATA
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_CONTROL_CONTAINER_METADATA
@@ -1,2 +1,2 @@
-tag: v0.7.0
-imageDigest: sha256:d3dfdff919f32a5317ec82d06881c4151eaaf0d946112731674860a4229a66a2
+tag: v0.7.1
+imageDigest: sha256:a91f9e9e7ab7056fab84c85c0d8d6ad38b16f9c9d3d01baecdcec856bdd19c8e

--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
@@ -1,16 +1,16 @@
 1-22:
-    ami-release-version: v1.12.0
-    ova-release-version: v1.12.0
-    raw-release-version: v1.12.0
+    ami-release-version: v1.13.0
+    ova-release-version: v1.13.0
+    raw-release-version: v1.13.0
 1-23:
-    ami-release-version: v1.12.0
-    ova-release-version: v1.12.0
-    raw-release-version: v1.12.0
+    ami-release-version: v1.13.0
+    ova-release-version: v1.13.0
+    raw-release-version: v1.13.0
 1-24:
-    ami-release-version: v1.12.0
-    ova-release-version: v1.12.0
-    raw-release-version: v1.12.0
+    ami-release-version: v1.13.0
+    ova-release-version: v1.13.0
+    raw-release-version: v1.13.0
 1-25:
-    ami-release-version: v1.12.0
-    ova-release-version: v1.12.0
-    raw-release-version: v1.12.0
+    ami-release-version: v1.13.0
+    ova-release-version: v1.13.0
+    raw-release-version: v1.13.0


### PR DESCRIPTION
*Description of changes:*

v1.13.0 disables udp offloading in vSphere, which was causing udp packets to be dropped in some vSphere environments.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

BR Release: https://github.com/bottlerocket-os/bottlerocket/releases/tag/v1.13.0
BR Release tracking ticket: https://github.com/bottlerocket-os/bottlerocket/issues/2760
PR with fix: https://github.com/bottlerocket-os/bottlerocket/pull/2850
