### PR TITLE
Fix Leaky capv vSphere Sessions

### DIFF
--- a/projects/kubernetes-sigs/cluster-api-provider-vsphere/CHECKSUMS
+++ b/projects/kubernetes-sigs/cluster-api-provider-vsphere/CHECKSUMS
@@ -1,2 +1,2 @@
-de96c7900fc1a3405ad5e4eda7b264f30ffeac2570f2c52755d2eb62f1e3a826  _output/bin/cluster-api-provider-vsphere/linux-amd64/manager
-917a3ae8da9065caa1183622f0c7bb3dcf81e17141ffbda1ce3bf6f98b080db5  _output/bin/cluster-api-provider-vsphere/linux-arm64/manager
+d9c9a12bc3412cd1516cb21c4c80a830ef6f221eee9944307f28b88f311e2857  _output/bin/cluster-api-provider-vsphere/linux-amd64/manager
+db495de904d618a0f76185e5c4953f99a401394ccde8cb14e42ff88422e3d8c0  _output/bin/cluster-api-provider-vsphere/linux-arm64/manager

--- a/projects/kubernetes-sigs/cluster-api-provider-vsphere/patches/0004-Fix-vCenter-session-leaks.patch
+++ b/projects/kubernetes-sigs/cluster-api-provider-vsphere/patches/0004-Fix-vCenter-session-leaks.patch
@@ -1,0 +1,151 @@
+From e5ebf423b7b8b2ef7455f51faf64d7aaa38262bf Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Thu, 23 Mar 2023 14:45:03 -0400
+Subject: [PATCH] Fix vCenter session leaks
+
+---
+ main.go                     |  2 ++
+ pkg/session/session.go      | 65 ++++++++++++++++++++++---------------
+ pkg/session/session_test.go |  2 +-
+ 3 files changed, 41 insertions(+), 28 deletions(-)
+
+diff --git a/main.go b/main.go
+index 38f36360..67469eae 100644
+--- a/main.go
++++ b/main.go
+@@ -41,6 +41,7 @@ import (
+ 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/constants"
+ 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/context"
+ 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/manager"
++	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/session"
+ 	"sigs.k8s.io/cluster-api-provider-vsphere/pkg/version"
+ )
+ 
+@@ -222,6 +223,7 @@ func main() {
+ 	defer func(watch *fsnotify.Watcher) {
+ 		_ = watch.Close()
+ 	}(watch)
++	defer session.Clear()
+ }
+ 
+ func setupVAPIControllers(ctx *context.ControllerManagerContext, mgr ctrlmgr.Manager) error {
+diff --git a/pkg/session/session.go b/pkg/session/session.go
+index 76b1c54d..f25d2bb0 100644
+--- a/pkg/session/session.go
++++ b/pkg/session/session.go
+@@ -39,9 +39,14 @@ import (
+ 	"sigs.k8s.io/cluster-api-provider-vsphere/apis/v1beta1"
+ )
+ 
+-// global Session map against sessionKeys
+-// in map[sessionKey]Session.
+-var sessionCache sync.Map
++var (
++	// global Session map against sessionKeys in map[sessionKey]Session.
++	sessionCache sync.Map
++
++	// mutex to control access to the GetOrCreate function to avoid duplicate
++	// session creations on startup.
++	sessionMU sync.Mutex
++)
+ 
+ // Session is a vSphere session with a configured Finder.
+ type Session struct {
+@@ -102,6 +107,8 @@ func (p *Params) WithFeatures(feature Feature) *Params {
+ // already exist.
+ func GetOrCreate(ctx context.Context, params *Params) (*Session, error) {
+ 	logger := ctrl.LoggerFrom(ctx).WithName("session")
++	sessionMU.Lock()
++	defer sessionMU.Unlock()
+ 
+ 	sessionKey := params.server + params.userinfo.Username() + params.datacenter
+ 	if cachedSession, ok := sessionCache.Load(sessionKey); ok {
+@@ -213,29 +220,9 @@ func clearCache(logger logr.Logger, sessionKey string) {
+ 	if cachedSession, ok := sessionCache.Load(sessionKey); ok {
+ 		s := cachedSession.(*Session)
+ 
+-		// check for the presence of tagmanager session
+-		// since calling Logout on an expired session blocks
+-		session, err := s.TagManager.Session(context.Background())
+-		if err != nil {
+-			logger.Error(err, "unable to get tag manager session")
+-		}
+-		if session != nil {
+-			logger.V(6).Info("found active tag manager session, logging out")
+-			err := s.TagManager.Logout(context.Background())
+-			if err != nil {
+-				logger.Error(err, "unable to logout tag manager session")
+-			}
+-		}
+-
+-		vimSessionActive, err := s.SessionManager.SessionIsActive(context.Background())
+-		if err != nil {
+-			logger.Error(err, "unable to get vim client session")
+-		} else if vimSessionActive {
+-			logger.V(6).Info("found active vim session, logging out")
+-			err := s.SessionManager.Logout(context.Background())
+-			if err != nil {
+-				logger.Error(err, "unable to logout vim session")
+-			}
++		logger.Info("performing session log out and clearing session", "key", sessionKey)
++		if err := s.Logout(context.Background()); err != nil {
++			logger.Error(err, "unable to logout session")
+ 		}
+ 	}
+ 	sessionCache.Delete(sessionKey)
+@@ -253,7 +240,7 @@ func newManager(ctx context.Context, logger logr.Logger, sessionKey string, clie
+ 			return nil
+ 		}
+ 
+-		logger.V(6).Info("rest client session expired, clearing cache")
++		logger.Info("rest client session expired, clearing cache")
+ 		clearCache(logger, sessionKey)
+ 		return errors.New("rest client session expired")
+ 	})
+@@ -263,6 +250,30 @@ func newManager(ctx context.Context, logger logr.Logger, sessionKey string, clie
+ 	return tags.NewManager(rc), nil
+ }
+ 
++func (s *Session) GetVersion() (infrav1.VCenterVersion, error) {
++	svcVersion := s.ServiceContent.About.Version
++	version, err := semver.New(svcVersion)
++	if err != nil {
++		return "", err
++	}
++
++	switch version.Major {
++	case 6, 7, 8:
++		return infrav1.NewVCenterVersion(svcVersion), nil
++	default:
++		return "", unidentifiedVCenterVersion{version: svcVersion}
++	}
++}
++
++// Clear is meant to destroy all the cached sessions.
++func Clear() {
++	sessionCache.Range(func(key, s any) bool {
++		cachedSession := s.(*Session)
++		_ = cachedSession.Logout(context.Background())
++		return true
++	})
++}
++
+ // FindByBIOSUUID finds an object by its BIOS UUID.
+ //
+ // To avoid comments about this function's name, please see the Golang
+diff --git a/pkg/session/session_test.go b/pkg/session/session_test.go
+index a938aed3..ffdbbdc2 100644
+--- a/pkg/session/session_test.go
++++ b/pkg/session/session_test.go
+@@ -160,7 +160,7 @@ func TestGetSessionWithKeepAlive(t *testing.T) {
+ 	// Try to remove vim session
+ 	g.Expect(s.Logout(context.Background())).To(Succeed())
+ 
+-	// after logging out old session must be deleted and
++	// after logging out old session must be deleted,
+ 	// we must get a new different session
+ 	// total session count must remain 1
+ 	s, err = GetOrCreate(context.Background(), params)
+-- 
+2.37.1 (Apple Git-137.1)
+

--- a/projects/kubernetes-sigs/cluster-api-provider-vsphere/patches/0005-Fixup-Fix-vCenter-session-leaks.patch
+++ b/projects/kubernetes-sigs/cluster-api-provider-vsphere/patches/0005-Fixup-Fix-vCenter-session-leaks.patch
@@ -1,0 +1,42 @@
+From 7dcafd4a8dfd59fb7d18599a42233c2ef39b33b3 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Thu, 23 Mar 2023 15:01:55 -0400
+Subject: [PATCH] Fixup patch
+
+---
+ pkg/session/session.go | 17 +----------------
+ 1 file changed, 1 insertion(+), 16 deletions(-)
+
+diff --git a/pkg/session/session.go b/pkg/session/session.go
+index f25d2bb0..1a172f37 100644
+--- a/pkg/session/session.go
++++ b/pkg/session/session.go
+@@ -250,24 +250,9 @@ func newManager(ctx context.Context, logger logr.Logger, sessionKey string, clie
+ 	return tags.NewManager(rc), nil
+ }
+ 
+-func (s *Session) GetVersion() (infrav1.VCenterVersion, error) {
+-	svcVersion := s.ServiceContent.About.Version
+-	version, err := semver.New(svcVersion)
+-	if err != nil {
+-		return "", err
+-	}
+-
+-	switch version.Major {
+-	case 6, 7, 8:
+-		return infrav1.NewVCenterVersion(svcVersion), nil
+-	default:
+-		return "", unidentifiedVCenterVersion{version: svcVersion}
+-	}
+-}
+-
+ // Clear is meant to destroy all the cached sessions.
+ func Clear() {
+-	sessionCache.Range(func(key, s any) bool {
++	sessionCache.Range(func(key, s interface{}) bool {
+ 		cachedSession := s.(*Session)
+ 		_ = cachedSession.Logout(context.Background())
+ 		return true
+-- 
+2.37.1 (Apple Git-137.1)
+


### PR DESCRIPTION
*Issue #, if available:*
Applies patch from this fix for leaky sessions: https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/1767

*Description of changes:*
Fixes a problem with leaky sessions in capv.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->