### PR TITLE
Small improvement to bootconfig build to ensure arch is expected

### DIFF
--- a/projects/torvalds/linux/Makefile
+++ b/projects/torvalds/linux/Makefile
@@ -6,8 +6,13 @@ REPO_OWNER=torvalds
 REPO_SPARSE_CHECKOUT=tools lib/bootconfig.c include/linux/bootconfig.h
 
 SIMPLE_CREATE_BINARIES=false
-BINARY_TARGETS=$(OUTPUT_BIN_DIR)/linux-amd64/tools/bootconfig
-BINARY_PLATFORMS=linux/amd64
+
+# this is a native build which we can not cross compile
+# ensure we are building to a directory based on the current
+# host platform to avoid ever creating a different arch'd
+# binary in the wrong folder
+BINARY_PLATFORMS=$(BUILDER_PLATFORM)
+BINARY_TARGETS=$(OUTPUT_BIN_DIR)/$(subst /,-,$(BINARY_PLATFORMS))/tools/bootconfig
 
 HAS_LICENSES=false
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We ran into an issue yesterday when we switched our builder instance platform for this build in codebuild to arm.  Because its a native build, the compile step is always going to compile based on the current arch.  We only caught this after trying to boot a machine on amd using a bootconfig bin built for arm.  This small change will force it to always build to a platform folder which matches the current host and therefore when creating the tar will have the proper arch.  If we had this in place yesterday, instead of overwriting the amd bin with an arm based on, we would have just pushed a new arm one.

On one hand that scenario may have been harder to catch, however, we never would have broke anything instead we would have noticed the next time we update and realize the update wasn't actually built to the file we expected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
