### PR TITLE
Adding a patch to limit rufio bmclib drivers

### DIFF
--- a/projects/tinkerbell/rufio/CHECKSUMS
+++ b/projects/tinkerbell/rufio/CHECKSUMS
@@ -1,2 +1,2 @@
-5b3282c3f5f18814314bb995c571f0debeb068575e4db52d23dc0c6289952811  _output/bin/rufio/linux-amd64/manager
-ecf5faaa70d4f4b9098b807193279b14535cca614a4b92aeba91fe1d9d0c2857  _output/bin/rufio/linux-arm64/manager
+084f4e9374fd63cabbd65f92c53259568185213956c54d5c5e3efad891b11b33  _output/bin/rufio/linux-amd64/manager
+3c3d911763b2f576cbcd77627f2c605a4f5d99e002b01e47ce5d326461246c84  _output/bin/rufio/linux-arm64/manager

--- a/projects/tinkerbell/rufio/patches/0001-Adding-Using-to-select-bmc-lib-drivers-for-client.patch
+++ b/projects/tinkerbell/rufio/patches/0001-Adding-Using-to-select-bmc-lib-drivers-for-client.patch
@@ -1,0 +1,26 @@
+From 294df00eb3b4ec394863b633b96e262619f74960 Mon Sep 17 00:00:00 2001
+From: Aravind Ramalingam <ramaliar@amazon.com>
+Date: Tue, 25 Apr 2023 14:33:09 -0700
+Subject: [PATCH] Adding Using() to select bmc-lib drivers for client
+
+---
+ controllers/bmc_client.go | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/controllers/bmc_client.go b/controllers/bmc_client.go
+index 9dfd819..2519cca 100644
+--- a/controllers/bmc_client.go
++++ b/controllers/bmc_client.go
+@@ -37,6 +37,9 @@ func NewBMCClientFactoryFunc(ctx context.Context) BMCClientFactoryFunc {
+ 	return func(ctx context.Context, hostIP, port, username, password string) (BMCClient, error) {
+ 		client := bmclib.NewClient(hostIP, port, username, password)
+ 
++		using := client.Registry.Using
++		client.Registry.Drivers = append(using("redfish"), using("ipmi")...)
++
+ 		// TODO (pokearu): Make an option
+ 		client.Registry.Drivers = client.Registry.PreferDriver("gofish")
+ 		if err := client.Open(ctx); err != nil {
+-- 
+2.34.1
+


### PR DESCRIPTION
## Description
bmc-lib tries to establish a connection to check compatible protocols (redfish, ipmi etc) for all supported implementations. These changes modify Rufio to only use `Redfish` and `IPMI` protocols for all hardware.

## Why is this needed
Rufio opens a new connection via bmc-lib for every reconcile loop. In the latest version of bmc-lib support for IntelAMT protocol was added. It was noticed that on older hardware when users try to run Rufio, IntelAMT takes too long to establish a connection and hence blocks the reconcile thread. This was causing timeouts of Rufio Tasks when it exceeded 3 mins to hit the connection timeout. 

Fixes:
Timeout issues on older hardware due to Rufio reconcile threads getting blocked when bmc-lib provider open connection calls hang and timeout. 

## How Has This Been Tested?
`make docker-build` and tested the controller.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
