### PR TITLE
Removes kubeadm config version during kind build

### DIFF
--- a/projects/kubernetes-sigs/kind/images/base/kubeadm.config.tmpl
+++ b/projects/kubernetes-sigs/kind/images/base/kubeadm.config.tmpl
@@ -1,7 +1,6 @@
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration
 dns:
-    type: CoreDNS
     imageRepository: $EKSD_IMAGE_REPO/coredns
     imageTag: $COREDNS_VERSION
 etcd:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In 1.27 `kubeadm.k8s.io/v1beta2` is removed, after being deprecated since 1.22.  Luckily we are only supporting 1.22+ at this point so we can just bump to beta3 and still support all versions, vs needing some kind of conditional.  

For reference, this particular config is only used during image build time to get the list of kube images that need to be downloaded and embedded in the kind image.  Before the build is over, this config is removed from the final image.

Similar to https://github.com/aws/eks-anywhere/pull/3014 but we can't just remove the api version in this case.  The reason we could remove it during the cli flow is because it calls kind instead of kubeadm directly and the kind code augments the config we pass with additional fields, such as the version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
