### PR TITLE
Revert "Uses eks-a build of containerd during image building"

### DIFF
--- a/projects/kubernetes-sigs/image-builder/build/setup_packer_configs.sh
+++ b/projects/kubernetes-sigs/image-builder/build/setup_packer_configs.sh
@@ -52,7 +52,7 @@ function env_and_envsubst()
 echo "Loading EKSD manifest from: $(build::eksd_releases::get_release_yaml_url $RELEASE_BRANCH)"
 build::eksd_releases::load_release_yaml $RELEASE_BRANCH > /dev/null
 
-echo "Loading EKSA manifest from: $(build::eksa_releases::get_eksa_release_manifest_url $DEV_RELEASE $LATEST_TAG)"
+echo "Loading EKSA manifest from: $(build::eksa_releases::get_eksa_release_manifest_url)"
 build::eksa_releases::load_bundle_manifest $DEV_RELEASE $LATEST_TAG > /dev/null
 
 OUTPUT_CONFIGS="$MAKE_ROOT/_output/$RELEASE_BRANCH/$IMAGE_FORMAT/$IMAGE_OS/config"
@@ -98,10 +98,8 @@ export ETCDADM_HTTP_SOURCE=${ETCDADM_HTTP_SOURCE:-$(build::eksa_releases::get_ek
 export ETCDADM_VERSION='v0.1.5'
 export CRICTL_URL=${CRICTL_URL:-$(build::eksa_releases::get_eksa_component_asset_url 'eksD' 'crictl' $RELEASE_BRANCH $DEV_RELEASE $LATEST_TAG)}
 export CRICTL_SHA256="${CRICTL_SHA256:-$(build::eksa_releases::get_eksa_component_asset_artifact_checksum 'eksD' 'crictl' 'sha256' $RELEASE_BRANCH $DEV_RELEASE $LATEST_TAG)}"
-export CONTAINERD_URL=${CONTAINERD_URL:-$(build::eksa_releases::get_eksa_component_asset_url 'eksD' 'containerd' $RELEASE_BRANCH $DEV_RELEASE $LATEST_TAG)}
-export CONTAINERD_SHA256="${CONTAINERD_SHA256:-$(build::eksa_releases::get_eksa_component_asset_artifact_checksum 'eksD' 'containerd' 'sha256' $RELEASE_BRANCH $DEV_RELEASE $LATEST_TAG)}"
 
-env_and_envsubst '$IMAGE_REPO:$KUBERNETES_ASSET_BASE_URL:$KUBERNETES_VERSION:$KUBERNETES_SERIES:$CRICTL_URL:$CRICTL_SHA256:$CONTAINERD_URL:$CONTAINERD_SHA256:$ETCD_HTTP_SOURCE:$ETCD_VERSION:$ETCDADM_HTTP_SOURCE:$ETCD_SHA256:$ETCDADM_VERSION:$KUBERNETES_FULL_VERSION' \
+env_and_envsubst '$IMAGE_REPO:$KUBERNETES_ASSET_BASE_URL:$KUBERNETES_VERSION:$KUBERNETES_SERIES:$CRICTL_URL:$CRICTL_SHA256:$ETCD_HTTP_SOURCE:$ETCD_VERSION:$ETCDADM_HTTP_SOURCE:$ETCD_SHA256:$ETCDADM_VERSION:$KUBERNETES_FULL_VERSION' \
     "$MAKE_ROOT/packer/config/kubernetes.json.tmpl" \
     "$OUTPUT_CONFIGS/kubernetes.json"
 

--- a/projects/kubernetes-sigs/image-builder/packer/config/kubernetes.json.tmpl
+++ b/projects/kubernetes-sigs/image-builder/packer/config/kubernetes.json.tmpl
@@ -1,6 +1,4 @@
 {
-  "containerd_sha256": "$CONTAINERD_SHA256",
-  "containerd_url": "$CONTAINERD_URL",  
   "crictl_source_type": "http",
   "crictl_url": "$CRICTL_URL",
   "crictl_sha256": "$CRICTL_SHA256",

--- a/projects/kubernetes-sigs/image-builder/patches/0015-bump-containerd-to-1.6.19.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0015-bump-containerd-to-1.6.19.patch
@@ -1,0 +1,27 @@
+From 02aa7bba5bd3c3ce84bfc72b7b8ff79898bf4c3d Mon Sep 17 00:00:00 2001
+From: Hans Rakers <h.rakers@global.leaseweb.com>
+Date: Tue, 14 Mar 2023 11:30:00 +0100
+Subject: [PATCH 15/16] bump containerd to 1.6.19
+
+---
+ images/capi/packer/config/containerd.json | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/images/capi/packer/config/containerd.json b/images/capi/packer/config/containerd.json
+index eadc24177..07b6d9d9c 100644
+--- a/images/capi/packer/config/containerd.json
++++ b/images/capi/packer/config/containerd.json
+@@ -1,7 +1,7 @@
+ {
+   "containerd_additional_settings": null,
+   "containerd_cri_socket": "/var/run/containerd/containerd.sock",
+-  "containerd_sha256": "974fdbd78875910a809b21aed0fa3356482fc4d438916a3c7f12bd6fe66c03f0",
+-  "containerd_sha256_windows": "99977deb97bc0a013e453c705530e663e8556bff7fb1721e9b047540e45922fc",
+-  "containerd_version": "1.6.18"
++  "containerd_sha256": "0457907ec410c2172829f6d1808f43fd2b83395a242bcb677cfe26320df13d5d",
++  "containerd_sha256_windows": "bf7df558fbed3f70502e511157f02ae4fc46f3c0f3361b4905950004c2aac78f",
++  "containerd_version": "1.6.19"
+ }
+-- 
+2.39.2
+


### PR DESCRIPTION
Reverts aws/eks-anywhere-build-tooling#2124

Going to some testing with build templates but this change looks like it broke our e2e last night.