### PR TITLE
Ensure source AMI architecture is AMD64

### DIFF
--- a/projects/aws/eks-a-admin-image/eks-a-admin-snow.pkr.hcl
+++ b/projects/aws/eks-a-admin-image/eks-a-admin-snow.pkr.hcl
@@ -21,6 +21,7 @@ source "amazon-ebs" "amazonlinux2" {
       name                = "amzn2-ami-kernel-5.*-hvm-2*"
       root-device-type    = "ebs"
       virtualization-type = "hvm"
+      architecture        = "x86_64"
     }
     most_recent = true
     owners      = ["amazon"]


### PR DESCRIPTION
Most public AMIs matching the filter `amzn2-ami-kernel-5.*-hvm-2*` come in both AMD64 and ARM64 variants, where the build chooses the AMD64 variant. However filtering for the latest AL2 Kernel 5.10 AMI returned only one source AMI (`ami-0ae285eae0f72f673`) which was ARM64, and caused the build to fail with the message
```
Error launching source instance: InvalidParameterValue: The architecture 'x86_64' of the specified instance
type does not match the architecture 'arm64' of the specified AMI. Specify an instance type and an AMI that
have matching architectures, and try again. You can use 'describe-instance-types' or 'describe-images' to
discover the architecture of the instance type or AMI.
```
So we need to filter for an AMD64 source AMI even if it means we get a slightly older AMI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
