### PR TITLE
Update BR release version and admin container

### DIFF
--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_ADMIN_CONTAINER_METADATA
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_ADMIN_CONTAINER_METADATA
@@ -1,2 +1,2 @@
-tag: v0.10.0
-imageDigest: sha256:994f332ac4b2fb2a5c3acca75501e5c5ef34cc1bfdfcffb3d0af16ceb1bdb1ca
+tag: v0.10.1
+imageDigest: sha256:a1f0161cb9f6d7b0e2f5b66ddb40cc70c6fddcba9bd2e62e3ff337f236300dfe

--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_CONTROL_CONTAINER_METADATA
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_CONTROL_CONTAINER_METADATA
@@ -1,2 +1,2 @@
-tag: v0.7.1
-imageDigest: sha256:a91f9e9e7ab7056fab84c85c0d8d6ad38b16f9c9d3d01baecdcec856bdd19c8e
+tag: v0.7.2
+imageDigest: sha256:e0c844f682373faa43d5b5f006695cf4502b0a0747f617ff607591e09882e616

--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
@@ -1,20 +1,20 @@
-1-22:
-    ami-release-version: v1.13.1
-    ova-release-version: v1.13.1
-    raw-release-version: v1.13.1
 1-23:
-    ami-release-version: v1.13.1
-    ova-release-version: v1.13.1
-    raw-release-version: v1.13.1
+    ami-release-version: v1.14.0
+    ova-release-version: v1.14.0
+    raw-release-version: v1.14.0
 1-24:
-    ami-release-version: v1.13.1
-    ova-release-version: v1.13.1
-    raw-release-version: v1.13.1
+    ami-release-version: v1.14.0
+    ova-release-version: v1.14.0
+    raw-release-version: v1.14.0
 1-25:
-    ami-release-version: v1.13.1
-    ova-release-version: v1.13.1
-    raw-release-version: v1.13.1
+    ami-release-version: v1.14.0
+    ova-release-version: v1.14.0
+    raw-release-version: v1.14.0
 1-26:
-    ami-release-version: v1.13.1
-    ova-release-version: v1.13.1
-    raw-release-version: v1.13.1
+    ami-release-version: v1.14.0
+    ova-release-version: v1.14.0
+    raw-release-version: v1.14.0
+1-27:
+    ami-release-version: v1.14.0
+    ova-release-version: v1.14.0
+    raw-release-version: v1.14.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Updating BR version to 0.14.0

Based on https://github.com/bottlerocket-os/bottlerocket/blob/develop/sources/models/shared-defaults/public-host-containers.toml:

- Updating admin container to 0.10.1
- Updating host container to 0.7.2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

