### PR TITLE
Updated EKS-D to latest releases (#2160)

### DIFF
--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -12,18 +12,18 @@ releases:
   number: 26
   kubeVersion: v1.21.14
 - branch: 1-22
-  number: 26
+  number: 27
   kubeVersion: v1.22.17
 - branch: 1-23
-  number: 21
+  number: 22
   kubeVersion: v1.23.17
 - branch: 1-24
-  number: 16
+  number: 17
   kubeVersion: v1.24.13
 - branch: 1-25
-  number: 12
+  number: 13
   kubeVersion: v1.25.9
 - branch: 1-26
-  number: 8
+  number: 9
   kubeVersion: v1.26.4
 latest: 1-25


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Automatic cherry pick from https://github.com/aws/eks-anywhere-build-tooling/pull/2160 failed due to main having 1.27. Simple cherry-pick, removing the 1.27 block since 0.15 does not have 1.27 support.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
