### PR TITLE
copy cloudstack artifacts from metal EC2 instance to codebuild job

### DIFF
--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -307,7 +307,7 @@ upload-bottlerocket-%:
 .PHONY: release-image-build-on-metal-%
 release-image-build-on-metal-%: $(GIT_PATCH_TARGET)
 	@echo -e $(call TARGET_START_LOG)
-	build/build_image_on_metal.sh $(BASE_DIRECTORY) $(PROJECT_PATH) $(RELEASE_BRANCH) $(RAW_IMAGE_BUILD_AMI) $(RAW_IMAGE_BUILD_INSTANCE_TYPE) $(RAW_IMAGE_BUILD_KEY_NAME) $* $(IMAGE_FORMAT) $(LATEST)
+	build/build_image_on_metal.sh $(BASE_DIRECTORY) $(PROJECT_PATH) $(RELEASE_BRANCH) $(RAW_IMAGE_BUILD_AMI) $(RAW_IMAGE_BUILD_INSTANCE_TYPE) $(RAW_IMAGE_BUILD_KEY_NAME) $* $(IMAGE_FORMAT) $(LATEST) $(ARTIFACTS_PATH)/$(IMAGE_FORMAT)/$*
 	@echo -e $(call TARGET_END_LOG)
 
 .PHONY: build-qemu-rhel-local


### PR DESCRIPTION
*Description of changes:*
Copy cloudstack artifacts from metal EC2 instance to codebuild job to finally upload it on the s3 bucket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
