### PR TITLE
Use MAC addr in Bottlerocket net conf

### DIFF
--- a/projects/tinkerbell/hub/CHECKSUMS
+++ b/projects/tinkerbell/hub/CHECKSUMS
@@ -2,4 +2,4 @@
 66fa388e522a0e4c62b8c7d9bdfc4ab14b4610f280b2a2791a41a0093a3466aa  _output/bin/hub/linux-amd64/image2disk
 f5e8259c434c46b4a351c0e511e613bdb67114a94cda698a8fc3c67297fefcda  _output/bin/hub/linux-amd64/kexec
 839071a1352ac49048ecec99ef00ea824d0f9cfcece14bf4e554d0c895605db1  _output/bin/hub/linux-amd64/oci2disk
-4afc0a64b70f55a6f5ad9e30ac7e4a60f023c38c45c7db4cd82f5431a5fff03a  _output/bin/hub/linux-amd64/writefile
+9c4b0575dc0b5af6d6316936ebbea688a1085a473994616efbf18011bb8412a6  _output/bin/hub/linux-amd64/writefile

--- a/projects/tinkerbell/hub/CHECKSUMS
+++ b/projects/tinkerbell/hub/CHECKSUMS
@@ -2,4 +2,4 @@
 66fa388e522a0e4c62b8c7d9bdfc4ab14b4610f280b2a2791a41a0093a3466aa  _output/bin/hub/linux-amd64/image2disk
 f5e8259c434c46b4a351c0e511e613bdb67114a94cda698a8fc3c67297fefcda  _output/bin/hub/linux-amd64/kexec
 839071a1352ac49048ecec99ef00ea824d0f9cfcece14bf4e554d0c895605db1  _output/bin/hub/linux-amd64/oci2disk
-356358f6d080f224318045836da2fb375b42e7a42f78ffb09c951176b0547941  _output/bin/hub/linux-amd64/writefile
+4afc0a64b70f55a6f5ad9e30ac7e4a60f023c38c45c7db4cd82f5431a5fff03a  _output/bin/hub/linux-amd64/writefile

--- a/projects/tinkerbell/hub/patches/0009-Use-MAC-address-in-Bottlerocket-network-config.patch
+++ b/projects/tinkerbell/hub/patches/0009-Use-MAC-address-in-Bottlerocket-network-config.patch
@@ -1,0 +1,47 @@
+From a5d8410a200c7dd52714b511c9e39748c5391dc5 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Thu, 18 May 2023 22:47:28 -0600
+Subject: [PATCH] Use MAC address in Bottlerocket network config:
+
+Since Bottlerocket v1.11.0 we can use the MAC
+address to define the network config. This will
+make the network config more flexible across
+hardware.
+
+Signed-off-by: Jacob Weinstock <jakobweinstock@gmail.com>
+---
+ actions/writefile/v1/main.go | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/actions/writefile/v1/main.go b/actions/writefile/v1/main.go
+index 07e816a..db393fe 100644
+--- a/actions/writefile/v1/main.go
++++ b/actions/writefile/v1/main.go
+@@ -45,12 +45,12 @@ type Info struct {
+ 
+ var bottlerocketNetTOMLTemplate = `# Version is required, it will change as we support
+ # additional settings
+-version = 2
++version = 3
+ 
+-[{{ .IFName }}.static4]
++["{{ .IFName }}".static4]
+ addresses = ["{{ ToString .IPAddr }}"]
+ 
+-[[{{ .IFName }}.route]]
++[["{{ .IFName }}".route]]
+ to = "default"
+ via = "{{ ToString .Gateway }}"
+ route-metric = 100
+@@ -238,7 +238,7 @@ func main() {
+ 			log.Fatal(err, " IFName=", ifn)
+ 		}
+ 		i := translate(d)
+-		i.IFName = os.Getenv("IFNAME")
++		i.IFName = d.ClientHWAddr.String()
+ 		contents, err = doTemplating(bottlerocketNetTOMLTemplate, i)
+ 		if err != nil {
+ 			log.Fatal(err)
+-- 
+2.39.2
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This adds flexibility across hardware machines for the Bottlerocket network config.

This has been manually tested against HPE ProLiant DL160 Gen10 and have been successfully provisioning.

Fixes: https://github.com/aws/eks-anywhere/issues/3411

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
