### PR TITLE
Fix 1-27 Cluster Autoscaler Reconciling Error

### DIFF
--- a/projects/kubernetes/autoscaler/1-27/helm/patches/0007-Authorize-MachinePool-Operations.patch
+++ b/projects/kubernetes/autoscaler/1-27/helm/patches/0007-Authorize-MachinePool-Operations.patch
@@ -1,0 +1,30 @@
+From ce8b20934c6cba955f0b2c5ad06113588e750d30 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Mon, 22 May 2023 16:56:31 -0400
+Subject: [PATCH] Authorize MachinePool Operations
+
+https://github.com/kubernetes/autoscaler/pull/4676 Introduced a bug where the autoscaler runtime fails to reconcile other CAPI machine resources when its ClusterRole is not authorized to list and watch MachinePool resources.
+
+See: https://github.com/kubernetes/autoscaler/commit/17d2bd968e756d97598be3ffb333957f0cfe99bf#diff-c8813a0942bbcd464aaa04a04c2c71897d5df30b65a2db86cb81773016f24406R786
+
+To resolve this issue, we authorize appropriate operations on MachinePool resources.
+---
+ charts/cluster-autoscaler/templates/clusterrole.yaml | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/charts/cluster-autoscaler/templates/clusterrole.yaml b/charts/cluster-autoscaler/templates/clusterrole.yaml
+index e3d36557f..63a65a044 100644
+--- a/charts/cluster-autoscaler/templates/clusterrole.yaml
++++ b/charts/cluster-autoscaler/templates/clusterrole.yaml
+@@ -152,6 +152,8 @@ rules:
+     resources:
+     - machinedeployments
+     - machinedeployments/scale
++    - machinepools
++    - machinepools/scale
+     - machines
+     - machinesets
+     verbs:
+-- 
+2.37.1 (Apple Git-137.1)
+


### PR DESCRIPTION
https://github.com/kubernetes/autoscaler/pull/4676 introduced a bug to the cluster autoscaler clusterapi reconciler.

The cluster autoscaler executable attempts to reconcile MachinePool resources, but does not have sufficient permissions to do so in its ClusterRole.


*Description of changes:*
Adds a patch to the helm chart's ClusterRole to properly list and watch MachinePool resources.

*Testing*
Manually applied these changes to a deployed helm chart and saw cluster autoscaler begin properly reconciling.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->