### PR TITLE
adds support for grealpath on mac

### DIFF
--- a/build/lib/create_release_checksums.sh
+++ b/build/lib/create_release_checksums.sh
@@ -26,6 +26,11 @@ elif which gnudate &>/dev/null; then
     FIND=gnufind
 fi
 
+REALPATH=realpath
+if which grealpath &>/dev/null; then
+    REALPATH=grealpath
+fi
+
 SHA256SUM=$(dirname ${ASSET_ROOT})/SHA256SUM
 SHA512SUM=$(dirname ${ASSET_ROOT})/SHA512SUM
 rm -f $SHA256SUM
@@ -34,7 +39,7 @@ echo "Writing artifact hashes to SHA256SUM/SHA512SUM files..."
 cd $ASSET_ROOT
 for file in $(find ${ASSET_ROOT} -type f -not -path '*\.sha[25][51][62]' -not -path '*\.docker_*' \
      \( -path '*bin/linux*' -o -path '*bin/windows*' -o -path '*bin/darwin*' -o -name '*\.gz' -o -name '*\.ova' -o -name '*\.qcow2' \) ); do
-    filepath=$(realpath --relative-base=${ASSET_ROOT} $file )
+    filepath=$($REALPATH --relative-base=${ASSET_ROOT} $file )
     sha256sum "$filepath" | tee -a $SHA256SUM > "$file.sha256" || return 1
     sha512sum "$filepath" | tee -a $SHA512SUM > "$file.sha512" || return 1
 done

--- a/build/lib/validate_artifacts.sh
+++ b/build/lib/validate_artifacts.sh
@@ -37,10 +37,15 @@ if [ -n "$IMAGE_FORMAT" ]; then
   fi
 fi
 
+REALPATH=realpath
+if which grealpath &>/dev/null; then
+    REALPATH=grealpath
+fi
+
 ACTUAL_FILES=$(mktemp)
 find "$ARTIFACTS_FOLDER" \
      -type f \
-     -exec realpath --relative-base="$ARTIFACTS_FOLDER" {} \; \
+     -exec $REALPATH --relative-base="$ARTIFACTS_FOLDER" {} \; \
      > "$ACTUAL_FILES"
 
 EXPECTED_FILES=$(mktemp)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

During the artifact validation phase of the build, there are a couple spots where we use realpath --relative-base which is not support on mac.  This adds a fallback to `grealpath` which comes with `brew install coreutils` similar to how we handle `find` in a few places where we rely on behavior that does not exist on mac's version of these utils.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
