### PR TITLE
Split eks-anywhere-packages to have K8 version specific builds

### DIFF
--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -283,24 +283,31 @@ function build::common::get_latest_eksa_asset_url() {
   local -r arch=${3-amd64}
   local -r s3downloadpath=${4-latest}
   local -r gitcommitoverride=${5-false}
+  local -r releasebranch=${6-}
 
   s3artifactfolder=$s3downloadpath
-  git_tag=$(cat $BUILD_ROOT/../../projects/${project}/GIT_TAG)
+  if [ -z "${releasebranch}" ]; then
+    projectwithreleasebranch=$project
+  else
+    projectwithreleasebranch=$project/$releasebranch
+
+  fi
+  git_tag=$(cat $BUILD_ROOT/../../projects/${projectwithreleasebranch}/GIT_TAG)
   if [ "$gitcommitoverride" = "true" ]; then
     commit_hash=$(echo $s3downloadpath | cut -d- -f2)
-    git_tag=$(git show $commit_hash:projects/${project}/GIT_TAG)
+    git_tag=$(git show $commit_hash:projects/${projectwithreleasebranch}/GIT_TAG)
     s3artifactfolder=$s3downloadpath/artifacts
   fi
 
   local -r tar_file_prefix=$(MAKEFLAGS= make --no-print-directory -C $BUILD_ROOT/../../projects/${project} var-value-TAR_FILE_PREFIX)
  
-  local -r url="https://$(basename $artifact_bucket).s3-us-west-2.amazonaws.com/projects/$project/$s3artifactfolder/$tar_file_prefix-linux-$arch-${git_tag}.tar.gz"
+  local -r url="https://$(basename $artifact_bucket).s3-us-west-2.amazonaws.com/projects/$projectwithreleasebranch/$s3artifactfolder/$tar_file_prefix-linux-$arch-${git_tag}.tar.gz"
 
   local -r http_code=$(curl -I -L -s -o /dev/null -w "%{http_code}" $url)
   if [[ "$http_code" == "200" ]]; then 
     echo "$url"
   else
-    echo "https://$(basename $artifact_bucket).s3-us-west-2.amazonaws.com/projects/$project/latest/$tar_file_prefix-linux-$arch-${git_tag}.tar.gz"
+    echo "https://$(basename $artifact_bucket).s3-us-west-2.amazonaws.com/projects/$projectwithreleasebranch/latest/$tar_file_prefix-linux-$arch-${git_tag}.tar.gz"
   fi
 }
 

--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -286,13 +286,15 @@ function build::common::get_latest_eksa_asset_url() {
   local -r releasebranch=${6-}
 
   s3artifactfolder=$s3downloadpath
-  if [ -z "${releasebranch}" ]; then
-    projectwithreleasebranch=$project
-  else
-    projectwithreleasebranch=$project/$releasebranch
 
+  projectwithreleasebranch=$project
+  # If not able to find git_tag w/o specifying a branch, update projectwithreleasebranch and git_tag to use a branch.
+  git_tag=$(cat $BUILD_ROOT/../../projects/${projectwithreleasebranch}/GIT_TAG || echo "invalid")
+  if [ "$git_tag" = "invalid" ]; then
+    projectwithreleasebranch=$project/$releasebranch
+    git_tag=$(cat $BUILD_ROOT/../../projects/${projectwithreleasebranch}/GIT_TAG)
   fi
-  git_tag=$(cat $BUILD_ROOT/../../projects/${projectwithreleasebranch}/GIT_TAG)
+  
   if [ "$gitcommitoverride" = "true" ]; then
     commit_hash=$(echo $s3downloadpath | cut -d- -f2)
     git_tag=$(git show $commit_hash:projects/${projectwithreleasebranch}/GIT_TAG)

--- a/build/lib/fetch_binaries.sh
+++ b/build/lib/fetch_binaries.sh
@@ -25,7 +25,7 @@ BINARY_DEPS_DIR="$1"
 DEP="$2"
 ARTIFACTS_BUCKET="$3"
 LATEST_TAG="$4"
-RELEASE_BRANCH="${5-$(build::eksd_releases::get_release_branch)}"
+RELEASE_BRANCH="${5-}"
 
 DEP=${DEP#"$BINARY_DEPS_DIR"}
 OS_ARCH="$(cut -d '/' -f1 <<< ${DEP})"
@@ -51,6 +51,9 @@ fi
 
 if [[ $PRODUCT = 'eksd' ]]; then
     if [[ $REPO_OWNER = 'kubernetes' ]]; then
+        if [ -z "${RELEASE_BRANCH}" ]; then
+            RELEASE_BRANCH="$(build::eksd_releases::get_release_branch)"
+        fi
         TARBALL="kubernetes-$REPO-linux-$ARCH.tar.gz"
         URL=$(build::eksd_releases::get_eksd_kubernetes_asset_url $TARBALL $RELEASE_BRANCH $ARCH)
         # these tarballs will extra with the kubernetes/{client,server} folders
@@ -59,7 +62,7 @@ if [[ $PRODUCT = 'eksd' ]]; then
         URL=$(build::eksd_releases::get_eksd_component_url $REPO_OWNER $RELEASE_BRANCH $ARCH)
     fi
 else
-    URL=$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET $REPO_OWNER/$REPO $ARCH $S3_ARTIFACTS_FOLDER $GIT_COMMIT_OVERRIDE)
+    URL=$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET $REPO_OWNER/$REPO $ARCH $S3_ARTIFACTS_FOLDER $GIT_COMMIT_OVERRIDE $RELEASE_BRANCH)
 fi
 
 if [ "$CODEBUILD_CI" = "true" ]; then

--- a/projects/aws/eks-anywhere-packages/Makefile
+++ b/projects/aws/eks-anywhere-packages/Makefile
@@ -15,6 +15,15 @@ HAS_RELEASE_BRANCHES=true
 BUILDSPEC_VARS_KEYS=RELEASE_BRANCH
 BUILDSPEC_VARS_VALUES=SUPPORTED_K8S_VERSIONS
 
+# This project is a bit of odd ball when it comes to using the standard makefile targets
+# - the image builds are release branch aware but the binary is the same across all versions
+
+# force binaries to go to non-release branch bin folder
+BINARIES_ARE_RELEASE_BRANCHED=false
+
+# do not look for checksums in release branch folder, instead use project root
+PROJECT_ROOT=$(MAKE_ROOT)
+
 DOCKERFILE_FOLDER=./docker/linux/$(IMAGE_NAME)
 GO_MOD_PATHS=. ecrtokenrefresher credentialproviderpackage
 

--- a/projects/aws/eks-anywhere-packages/Makefile
+++ b/projects/aws/eks-anywhere-packages/Makefile
@@ -11,6 +11,9 @@ GO_VARS=version=${GIT_TAG} gitHash=${PROJECT_COMMIT_HASH} buildTime=${TIME}
 EXTRA_GO_LDFLAGS=$(foreach v,$(GO_VARS),-X ${GO_MOD_NAME}${GO_VAR_PREFIX}${v})
 PROJECT_DEPENDENCIES=eksd/kubernetes/client eksa/aws/rolesanywhere-credential-helper eksa/kubernetes/cloud-provider-aws
 
+HAS_RELEASE_BRANCHES=true
+BUILDSPEC_VARS_KEYS=RELEASE_BRANCH
+BUILDSPEC_VARS_VALUES=SUPPORTED_K8S_VERSIONS
 
 DOCKERFILE_FOLDER=./docker/linux/$(IMAGE_NAME)
 GO_MOD_PATHS=. ecrtokenrefresher credentialproviderpackage

--- a/projects/aws/eks-anywhere-packages/docker/linux/credentialprovider/Dockerfile
+++ b/projects/aws/eks-anywhere-packages/docker/linux/credentialprovider/Dockerfile
@@ -3,6 +3,7 @@ FROM $BASE_IMAGE
 
 ARG TARGETARCH
 ARG TARGETOS
+ARG RELEASE_BRANCH
 
 COPY _output/$RELEASE_BRANCH/dependencies/$TARGETOS-$TARGETARCH/eksa/aws/rolesanywhere-credential-helper/aws_signing_helper /eksa-binaries/
 COPY _output/$RELEASE_BRANCH/dependencies/$TARGETOS-$TARGETARCH/eksa/kubernetes/cloud-provider-aws/ecr-credential-provider /eksa-binaries/

--- a/projects/aws/eks-anywhere-packages/docker/linux/eks-anywhere-packages/Dockerfile
+++ b/projects/aws/eks-anywhere-packages/docker/linux/eks-anywhere-packages/Dockerfile
@@ -3,9 +3,10 @@ FROM $BASE_IMAGE
 
 ARG TARGETARCH
 ARG TARGETOS
+ARG RELEASE_BRANCH
 
 COPY _output/bin/eks-anywhere-packages/$TARGETOS-$TARGETARCH/package-manager /package-manager
-COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksd/kubernetes/client/bin/kubectl /usr/local/bin/kubectl
+COPY _output/$RELEASE_BRANCH/dependencies/$TARGETOS-$TARGETARCH/eksd/kubernetes/client/bin/kubectl /usr/local/bin/kubectl
 COPY _output/LICENSES /LICENSES
 COPY ATTRIBUTION.txt /ATTRIBUTION.txt
 

--- a/release/checksums-build.yml
+++ b/release/checksums-build.yml
@@ -55,7 +55,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           PROJECT_PATH: projects/aws/eks-anywhere
-    - identifier: aws_eks_anywhere_packages
+    - identifier: aws_eks_anywhere_packages_1_23
       buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
@@ -63,6 +63,43 @@ batch:
         variables:
           PROJECT_PATH: projects/aws/eks-anywhere-packages
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-packages
+          RELEASE_BRANCH: 1-23
+    - identifier: aws_eks_anywhere_packages_1_24
+      buildspec: buildspecs/checksums-buildspec.yml
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          PROJECT_PATH: projects/aws/eks-anywhere-packages
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-packages
+          RELEASE_BRANCH: 1-24
+    - identifier: aws_eks_anywhere_packages_1_25
+      buildspec: buildspecs/checksums-buildspec.yml
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          PROJECT_PATH: projects/aws/eks-anywhere-packages
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-packages
+          RELEASE_BRANCH: 1-25
+    - identifier: aws_eks_anywhere_packages_1_26
+      buildspec: buildspecs/checksums-buildspec.yml
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          PROJECT_PATH: projects/aws/eks-anywhere-packages
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-packages
+          RELEASE_BRANCH: 1-26
+    - identifier: aws_eks_anywhere_packages_1_27
+      buildspec: buildspecs/checksums-buildspec.yml
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          PROJECT_PATH: projects/aws/eks-anywhere-packages
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-packages
+          RELEASE_BRANCH: 1-27
     - identifier: aws_etcdadm_bootstrap_provider
       buildspec: buildspecs/checksums-buildspec.yml
       env:
@@ -577,7 +614,11 @@ batch:
         - aquasecurity_trivy
         - aws_bottlerocket_bootstrap
         - aws_eks_anywhere
-        - aws_eks_anywhere_packages
+        - aws_eks_anywhere_packages_1_23
+        - aws_eks_anywhere_packages_1_24
+        - aws_eks_anywhere_packages_1_25
+        - aws_eks_anywhere_packages_1_26
+        - aws_eks_anywhere_packages_1_27
         - aws_etcdadm_bootstrap_provider
         - aws_etcdadm_controller
         - aws_image_builder

--- a/release/checksums-build.yml
+++ b/release/checksums-build.yml
@@ -55,7 +55,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           PROJECT_PATH: projects/aws/eks-anywhere
-    - identifier: aws_eks_anywhere_packages_1_23
+    - identifier: aws_eks_anywhere_packages
       buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
@@ -63,43 +63,6 @@ batch:
         variables:
           PROJECT_PATH: projects/aws/eks-anywhere-packages
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-packages
-          RELEASE_BRANCH: 1-23
-    - identifier: aws_eks_anywhere_packages_1_24
-      buildspec: buildspecs/checksums-buildspec.yml
-      env:
-        type: ARM_CONTAINER
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          PROJECT_PATH: projects/aws/eks-anywhere-packages
-          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-packages
-          RELEASE_BRANCH: 1-24
-    - identifier: aws_eks_anywhere_packages_1_25
-      buildspec: buildspecs/checksums-buildspec.yml
-      env:
-        type: ARM_CONTAINER
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          PROJECT_PATH: projects/aws/eks-anywhere-packages
-          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-packages
-          RELEASE_BRANCH: 1-25
-    - identifier: aws_eks_anywhere_packages_1_26
-      buildspec: buildspecs/checksums-buildspec.yml
-      env:
-        type: ARM_CONTAINER
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          PROJECT_PATH: projects/aws/eks-anywhere-packages
-          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-packages
-          RELEASE_BRANCH: 1-26
-    - identifier: aws_eks_anywhere_packages_1_27
-      buildspec: buildspecs/checksums-buildspec.yml
-      env:
-        type: ARM_CONTAINER
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          PROJECT_PATH: projects/aws/eks-anywhere-packages
-          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-packages
-          RELEASE_BRANCH: 1-27
     - identifier: aws_etcdadm_bootstrap_provider
       buildspec: buildspecs/checksums-buildspec.yml
       env:
@@ -614,11 +577,7 @@ batch:
         - aquasecurity_trivy
         - aws_bottlerocket_bootstrap
         - aws_eks_anywhere
-        - aws_eks_anywhere_packages_1_23
-        - aws_eks_anywhere_packages_1_24
-        - aws_eks_anywhere_packages_1_25
-        - aws_eks_anywhere_packages_1_26
-        - aws_eks_anywhere_packages_1_27
+        - aws_eks_anywhere_packages
         - aws_etcdadm_bootstrap_provider
         - aws_etcdadm_controller
         - aws_image_builder

--- a/release/staging-build.yml
+++ b/release/staging-build.yml
@@ -105,7 +105,7 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           PROJECT_PATH: projects/aws/eks-anywhere-build-tooling
-    - identifier: aws_eks_anywhere_packages
+    - identifier: aws_eks_anywhere_packages_1_23
       buildspec: buildspec.yml
       depend-on:
         - aws_rolesanywhere_credential_helper
@@ -116,6 +116,55 @@ batch:
         variables:
           PROJECT_PATH: projects/aws/eks-anywhere-packages
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-packages
+          RELEASE_BRANCH: 1-23
+    - identifier: aws_eks_anywhere_packages_1_24
+      buildspec: buildspec.yml
+      depend-on:
+        - aws_rolesanywhere_credential_helper
+        - kubernetes_cloud_provider_aws
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          PROJECT_PATH: projects/aws/eks-anywhere-packages
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-packages
+          RELEASE_BRANCH: 1-24
+    - identifier: aws_eks_anywhere_packages_1_25
+      buildspec: buildspec.yml
+      depend-on:
+        - aws_rolesanywhere_credential_helper
+        - kubernetes_cloud_provider_aws
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          PROJECT_PATH: projects/aws/eks-anywhere-packages
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-packages
+          RELEASE_BRANCH: 1-25
+    - identifier: aws_eks_anywhere_packages_1_26
+      buildspec: buildspec.yml
+      depend-on:
+        - aws_rolesanywhere_credential_helper
+        - kubernetes_cloud_provider_aws
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          PROJECT_PATH: projects/aws/eks-anywhere-packages
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-packages
+          RELEASE_BRANCH: 1-26
+    - identifier: aws_eks_anywhere_packages_1_27
+      buildspec: buildspec.yml
+      depend-on:
+        - aws_rolesanywhere_credential_helper
+        - kubernetes_cloud_provider_aws
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          PROJECT_PATH: projects/aws/eks-anywhere-packages
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-packages
+          RELEASE_BRANCH: 1-27
     - identifier: aws_etcdadm_bootstrap_provider
       buildspec: buildspec.yml
       env:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`eks-anywhere-packages` has a dependency `eksa/kubernetes/cloud-provider-aws` which is K8 version specific. Therefore, we need to modify `eks-anywhere-packages` to support branches, and also able to read dependencies that are K8 version specific, which requires an update to `build::common::get_latest_eksa_asset_url()`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
