### PR TITLE
Make eks-anywhere-packages k8 version agnostic

### DIFF
--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -282,8 +282,7 @@ function build::common::get_latest_eksa_asset_url() {
   local -r project=$2
   local -r arch=${3-amd64}
   local -r s3downloadpath=${4-latest}
-  local -r gitcommitoverride=${5-false}
-  local -r releasebranch=${6-}
+  local -r releasebranch=${5-}
 
   s3artifactfolder=$s3downloadpath
 
@@ -293,13 +292,7 @@ function build::common::get_latest_eksa_asset_url() {
   if [ "$git_tag" = "invalid" ]; then
     projectwithreleasebranch=$project/$releasebranch
     git_tag=$(cat $BUILD_ROOT/../../projects/${projectwithreleasebranch}/GIT_TAG)
-  fi
-  
-  if [ "$gitcommitoverride" = "true" ]; then
-    commit_hash=$(echo $s3downloadpath | cut -d- -f2)
-    git_tag=$(git show $commit_hash:projects/${projectwithreleasebranch}/GIT_TAG)
-    s3artifactfolder=$s3downloadpath/artifacts
-  fi
+  fi  
 
   local -r tar_file_prefix=$(MAKEFLAGS= make --no-print-directory -C $BUILD_ROOT/../../projects/${project} var-value-TAR_FILE_PREFIX)
  

--- a/build/lib/fetch_binaries.sh
+++ b/build/lib/fetch_binaries.sh
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -25,24 +24,26 @@ BINARY_DEPS_DIR="$1"
 DEP="$2"
 ARTIFACTS_BUCKET="$3"
 LATEST_TAG="$4"
-RELEASE_BRANCH="${5-}"
+RELEASE_BRANCH="${5-$(build::eksd_releases::get_release_branch)}"
 
 DEP=${DEP#"$BINARY_DEPS_DIR"}
 OS_ARCH="$(cut -d '/' -f1 <<< ${DEP})"
 PRODUCT=$(cut -d '/' -f2 <<< ${DEP})
 REPO_OWNER=$(cut -d '/' -f3 <<< ${DEP})
 REPO=$(cut -d '/' -f4 <<< ${DEP})
-S3_ARTIFACTS_FOLDER_OVERRIDE=$(cut -d '/' -f5 <<< ${DEP})
+
+RELEASE_BRANCH_OVERRIDE=$(cut -d '/' -f5 <<< ${DEP})
+RELEASE_BRANCH=${RELEASE_BRANCH_OVERRIDE:-$RELEASE_BRANCH}
+
 ARCH="$(cut -d '-' -f2 <<< ${OS_ARCH})"
 CODEBUILD_CI="${CODEBUILD_CI:-false}"
 
-S3_ARTIFACTS_FOLDER=${S3_ARTIFACTS_FOLDER_OVERRIDE:-$LATEST_TAG}
-GIT_COMMIT_OVERRIDE=false
-if [ -n "$S3_ARTIFACTS_FOLDER_OVERRIDE" ]; then
-    GIT_COMMIT_OVERRIDE=true
+OUTPUT_DIR_FILE=$BINARY_DEPS_DIR/linux-$ARCH/$PRODUCT/$REPO_OWNER/$REPO
+
+if [[ -n "$RELEASE_BRANCH_OVERRIDE" ]]; then
+    OUTPUT_DIR_FILE+=/$RELEASE_BRANCH_OVERRIDE
 fi
 
-OUTPUT_DIR_FILE=$BINARY_DEPS_DIR/linux-$ARCH/$PRODUCT/$REPO_OWNER/$REPO
 if [[ $REPO == *.tar.gz ]]; then
     mkdir -p $(dirname $OUTPUT_DIR_FILE)
 else
@@ -50,9 +51,6 @@ else
 fi
 
 if [[ $PRODUCT = 'eksd' ]]; then
-    if [ -z "${RELEASE_BRANCH}" ]; then
-        RELEASE_BRANCH="$(build::eksd_releases::get_release_branch)"
-    fi
     if [[ $REPO_OWNER = 'kubernetes' ]]; then
         TARBALL="kubernetes-$REPO-linux-$ARCH.tar.gz"
         URL=$(build::eksd_releases::get_eksd_kubernetes_asset_url $TARBALL $RELEASE_BRANCH $ARCH)
@@ -62,7 +60,7 @@ if [[ $PRODUCT = 'eksd' ]]; then
         URL=$(build::eksd_releases::get_eksd_component_url $REPO_OWNER $RELEASE_BRANCH $ARCH)
     fi
 else
-    URL=$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET $REPO_OWNER/$REPO $ARCH $S3_ARTIFACTS_FOLDER $GIT_COMMIT_OVERRIDE $RELEASE_BRANCH)
+    URL=$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET $REPO_OWNER/$REPO $ARCH $LATEST_TAG $RELEASE_BRANCH)
 fi
 
 if [ "$CODEBUILD_CI" = "true" ]; then

--- a/projects/aws/eks-anywhere-packages/Makefile
+++ b/projects/aws/eks-anywhere-packages/Makefile
@@ -4,10 +4,6 @@ BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
 PROJECT_COMMIT_HASH=$(shell git -C $(REPO) rev-parse --short HEAD)
 TIME=$(shell git -C $(REPO) show -s --format=%ct HEAD)
 GIT_TAG?=$(shell cat GIT_TAG)
-GIT_HASH?=$(shell git -C $(BASE_DIRECTORY) rev-parse HEAD)
-IMAGE_TAG=v$(RELEASE_BRANCH)-$(subst v,,$(GIT_TAG))-$(GIT_HASH)
-HELM_TAG=v$(RELEASE_BRANCH)-$(subst v,,$(GIT_TAG))-$(GIT_HASH)
-
 GOLANG_VERSION?="1.19"
 GO_MOD_NAME=github.com/aws/eks-anywhere-packages/
 GO_VAR_PREFIX=pkg/config.

--- a/projects/aws/eks-anywhere-packages/Makefile
+++ b/projects/aws/eks-anywhere-packages/Makefile
@@ -9,20 +9,10 @@ GO_MOD_NAME=github.com/aws/eks-anywhere-packages/
 GO_VAR_PREFIX=pkg/config.
 GO_VARS=version=${GIT_TAG} gitHash=${PROJECT_COMMIT_HASH} buildTime=${TIME}
 EXTRA_GO_LDFLAGS=$(foreach v,$(GO_VARS),-X ${GO_MOD_NAME}${GO_VAR_PREFIX}${v})
-PROJECT_DEPENDENCIES=eksd/kubernetes/client eksa/aws/rolesanywhere-credential-helper eksa/kubernetes/cloud-provider-aws
 
-HAS_RELEASE_BRANCHES=true
-BUILDSPEC_VARS_KEYS=RELEASE_BRANCH
-BUILDSPEC_VARS_VALUES=SUPPORTED_K8S_VERSIONS
-
-# This project is a bit of odd ball when it comes to using the standard makefile targets
-# - the image builds are release branch aware but the binary is the same across all versions
-
-# force binaries to go to non-release branch bin folder
-BINARIES_ARE_RELEASE_BRANCHED=false
-
-# do not look for checksums in release branch folder, instead use project root
-PROJECT_ROOT=$(MAKE_ROOT)
+# cloud-provider-aws build for 1-25 works for all version <= 1.25 and the 1-26 build works for 1.26+
+# including both to avoid needing to make packages controller release branch specific
+PROJECT_DEPENDENCIES=eksd/kubernetes/client eksa/aws/rolesanywhere-credential-helper eksa/kubernetes/cloud-provider-aws/1-25 eksa/kubernetes/cloud-provider-aws/1-26
 
 DOCKERFILE_FOLDER=./docker/linux/$(IMAGE_NAME)
 GO_MOD_PATHS=. ecrtokenrefresher credentialproviderpackage

--- a/projects/aws/eks-anywhere-packages/docker/linux/credentialprovider/Dockerfile
+++ b/projects/aws/eks-anywhere-packages/docker/linux/credentialprovider/Dockerfile
@@ -3,10 +3,10 @@ FROM $BASE_IMAGE
 
 ARG TARGETARCH
 ARG TARGETOS
-ARG RELEASE_BRANCH
 
-COPY _output/$RELEASE_BRANCH/dependencies/$TARGETOS-$TARGETARCH/eksa/aws/rolesanywhere-credential-helper/aws_signing_helper /eksa-binaries/
-COPY _output/$RELEASE_BRANCH/dependencies/$TARGETOS-$TARGETARCH/eksa/kubernetes/cloud-provider-aws/ecr-credential-provider /eksa-binaries/
+COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksa/aws/rolesanywhere-credential-helper/aws_signing_helper /eksa-binaries/
+COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksa/kubernetes/cloud-provider-aws/1-25/ecr-credential-provider /eksa-binaries/1-25
+COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksa/kubernetes/cloud-provider-aws/1-26/ecr-credential-provider /eksa-binaries/1-26
 COPY _output/bin/eks-anywhere-packages/$TARGETOS-$TARGETARCH/credentialprovider /
 COPY _output/LICENSES /LICENSES
 COPY CREDENTIALPROVIDER_ATTRIBUTION.txt /ATTRIBUTION.txt

--- a/projects/aws/eks-anywhere-packages/docker/linux/credentialprovider/Dockerfile
+++ b/projects/aws/eks-anywhere-packages/docker/linux/credentialprovider/Dockerfile
@@ -5,7 +5,7 @@ ARG TARGETARCH
 ARG TARGETOS
 
 COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksa/aws/rolesanywhere-credential-helper/aws_signing_helper /eksa-binaries/
-COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksa/kubernetes/cloud-provider-aws/1-25/ecr-credential-provider /eksa-binaries/1-25/ecr-credential-provider
+COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksa/kubernetes/cloud-provider-aws/1-25/ecr-credential-provider /eksa-binaries/v1alpha1/ecr-credential-provider
 COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksa/kubernetes/cloud-provider-aws/1-26/ecr-credential-provider /eksa-binaries/1-26/ecr-credential-provider
 COPY _output/bin/eks-anywhere-packages/$TARGETOS-$TARGETARCH/credentialprovider /
 COPY _output/LICENSES /LICENSES

--- a/projects/aws/eks-anywhere-packages/docker/linux/credentialprovider/Dockerfile
+++ b/projects/aws/eks-anywhere-packages/docker/linux/credentialprovider/Dockerfile
@@ -5,8 +5,8 @@ ARG TARGETARCH
 ARG TARGETOS
 
 COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksa/aws/rolesanywhere-credential-helper/aws_signing_helper /eksa-binaries/
-COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksa/kubernetes/cloud-provider-aws/1-25/ecr-credential-provider /eksa-binaries/1-25
-COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksa/kubernetes/cloud-provider-aws/1-26/ecr-credential-provider /eksa-binaries/1-26
+COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksa/kubernetes/cloud-provider-aws/1-25/ecr-credential-provider /eksa-binaries/1-25/ecr-credential-provider
+COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksa/kubernetes/cloud-provider-aws/1-26/ecr-credential-provider /eksa-binaries/1-26/ecr-credential-provider
 COPY _output/bin/eks-anywhere-packages/$TARGETOS-$TARGETARCH/credentialprovider /
 COPY _output/LICENSES /LICENSES
 COPY CREDENTIALPROVIDER_ATTRIBUTION.txt /ATTRIBUTION.txt

--- a/projects/aws/eks-anywhere-packages/docker/linux/credentialprovider/Dockerfile
+++ b/projects/aws/eks-anywhere-packages/docker/linux/credentialprovider/Dockerfile
@@ -6,7 +6,7 @@ ARG TARGETOS
 
 COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksa/aws/rolesanywhere-credential-helper/aws_signing_helper /eksa-binaries/
 COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksa/kubernetes/cloud-provider-aws/1-25/ecr-credential-provider /eksa-binaries/v1alpha1/ecr-credential-provider
-COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksa/kubernetes/cloud-provider-aws/1-26/ecr-credential-provider /eksa-binaries/1-26/ecr-credential-provider
+COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksa/kubernetes/cloud-provider-aws/1-26/ecr-credential-provider /eksa-binaries/v1/ecr-credential-provider
 COPY _output/bin/eks-anywhere-packages/$TARGETOS-$TARGETARCH/credentialprovider /
 COPY _output/LICENSES /LICENSES
 COPY CREDENTIALPROVIDER_ATTRIBUTION.txt /ATTRIBUTION.txt

--- a/projects/aws/eks-anywhere-packages/docker/linux/eks-anywhere-packages/Dockerfile
+++ b/projects/aws/eks-anywhere-packages/docker/linux/eks-anywhere-packages/Dockerfile
@@ -3,10 +3,9 @@ FROM $BASE_IMAGE
 
 ARG TARGETARCH
 ARG TARGETOS
-ARG RELEASE_BRANCH
 
 COPY _output/bin/eks-anywhere-packages/$TARGETOS-$TARGETARCH/package-manager /package-manager
-COPY _output/$RELEASE_BRANCH/dependencies/$TARGETOS-$TARGETARCH/eksd/kubernetes/client/bin/kubectl /usr/local/bin/kubectl
+COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksd/kubernetes/client/bin/kubectl /usr/local/bin/kubectl
 COPY _output/LICENSES /LICENSES
 COPY ATTRIBUTION.txt /ATTRIBUTION.txt
 

--- a/release/staging-build.yml
+++ b/release/staging-build.yml
@@ -105,10 +105,11 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           PROJECT_PATH: projects/aws/eks-anywhere-build-tooling
-    - identifier: aws_eks_anywhere_packages_1_23
+    - identifier: aws_eks_anywhere_packages
       buildspec: buildspec.yml
       depend-on:
         - aws_rolesanywhere_credential_helper
+        - kubernetes_cloud_provider_aws
         - kubernetes_cloud_provider_aws
       env:
         type: ARM_CONTAINER
@@ -116,55 +117,6 @@ batch:
         variables:
           PROJECT_PATH: projects/aws/eks-anywhere-packages
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-packages
-          RELEASE_BRANCH: 1-23
-    - identifier: aws_eks_anywhere_packages_1_24
-      buildspec: buildspec.yml
-      depend-on:
-        - aws_rolesanywhere_credential_helper
-        - kubernetes_cloud_provider_aws
-      env:
-        type: ARM_CONTAINER
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          PROJECT_PATH: projects/aws/eks-anywhere-packages
-          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-packages
-          RELEASE_BRANCH: 1-24
-    - identifier: aws_eks_anywhere_packages_1_25
-      buildspec: buildspec.yml
-      depend-on:
-        - aws_rolesanywhere_credential_helper
-        - kubernetes_cloud_provider_aws
-      env:
-        type: ARM_CONTAINER
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          PROJECT_PATH: projects/aws/eks-anywhere-packages
-          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-packages
-          RELEASE_BRANCH: 1-25
-    - identifier: aws_eks_anywhere_packages_1_26
-      buildspec: buildspec.yml
-      depend-on:
-        - aws_rolesanywhere_credential_helper
-        - kubernetes_cloud_provider_aws
-      env:
-        type: ARM_CONTAINER
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          PROJECT_PATH: projects/aws/eks-anywhere-packages
-          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-packages
-          RELEASE_BRANCH: 1-26
-    - identifier: aws_eks_anywhere_packages_1_27
-      buildspec: buildspec.yml
-      depend-on:
-        - aws_rolesanywhere_credential_helper
-        - kubernetes_cloud_provider_aws
-      env:
-        type: ARM_CONTAINER
-        compute-type: BUILD_GENERAL1_LARGE
-        variables:
-          PROJECT_PATH: projects/aws/eks-anywhere-packages
-          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-packages
-          RELEASE_BRANCH: 1-27
     - identifier: aws_etcdadm_bootstrap_provider
       buildspec: buildspec.yml
       env:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
After further evaluation, we have decided to revert the changes on making eks-anywhere-packages k8 version specific, and instead adding two different versions of ecr-credential-provider into the credential-provider image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
