### PR TITLE
Fix metadata service queries treating 404s as OK

### DIFF
--- a/projects/tinkerbell/hub/CHECKSUMS
+++ b/projects/tinkerbell/hub/CHECKSUMS
@@ -2,4 +2,4 @@
 e004f52237340707b753fd226c6c369931d9d6c1f966615d6475d4c2fd13dcf0  _output/bin/hub/linux-amd64/image2disk
 dcfec6b7c4fc2452defdaaec7a611fbe6cdf00e8e5dae86768447578849a4766  _output/bin/hub/linux-amd64/kexec
 cdf00127e3c815c792e3eb7e61fa858095a62afb98bda2714f92e463ca95f0cb  _output/bin/hub/linux-amd64/oci2disk
-feeee51e0c5ff5056fa9b57107c32b7dadd5a3a6c94f23a5062bc3d4ab2697d3  _output/bin/hub/linux-amd64/writefile
+abd5d9e875dcebfed9948b49e74fbaeeb1c1a8385c5cf2c7ad1c05e5a48be239  _output/bin/hub/linux-amd64/writefile

--- a/projects/tinkerbell/hub/patches/0010-Handle-non-200-status-codes-from-metadata-service.patch
+++ b/projects/tinkerbell/hub/patches/0010-Handle-non-200-status-codes-from-metadata-service.patch
@@ -1,0 +1,28 @@
+From 9935e57fc9fb02b2af061f1de7ea9976c1b6ab17 Mon Sep 17 00:00:00 2001
+From: Chris Doherty <chris.doherty4@gmail.com>
+Date: Fri, 23 Jun 2023 09:18:26 -0500
+Subject: [PATCH] Handle non-200 status codes from metadata service
+
+---
+ actions/writefile/v1/main.go | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/actions/writefile/v1/main.go b/actions/writefile/v1/main.go
+index db393fe..954a45e 100644
+--- a/actions/writefile/v1/main.go
++++ b/actions/writefile/v1/main.go
+@@ -205,6 +205,11 @@ func main() {
+ 			}
+ 			defer resp.Body.Close()
+ 
++			// Ensure non-200 responses are considered an error and move to the next metadata server.
++			if resp.StatusCode != http.StatusOK {
++				continue
++			}
++
+ 			respBody, err := ioutil.ReadAll(resp.Body)
+ 			if err != nil {
+ 				log.Warnf("Error reading HTTP GET response body: %v", err)
+-- 
+2.34.1
+


### PR DESCRIPTION
Fixes https://github.com/aws/eks-anywhere/issues/5564

When the Hegel metadata service doesn't have a Hardware record it returns 404. Our writefile Tinkerbell action treats the 404 as OK resulting in invalid metadata being written to disk and ultimately consumed by kubelet on launch, causing it to fail.

This change treats non-200 responses as errors ensuring we move to query any additional metadata endpoints.