### PR TITLE
Fix Kubernetes version for EKS-D v1.24 latest release

### DIFF
--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -19,7 +19,7 @@ releases:
   kubeVersion: v1.23.17
 - branch: 1-24
   number: 20
-  kubeVersion: v1.24.14
+  kubeVersion: v1.24.15
 - branch: 1-25
   number: 16
   kubeVersion: v1.25.10


### PR DESCRIPTION
The Kubernetes version corresponding to the latest EKS-D v1.24 release is `v1.24.15`.

```bash
curl -sL https://distro.eks.amazonaws.com/kubernetes-1-24/kubernetes-1-24-eks-20.yaml | yq ".status.components[] | select(.name==\"kubernetes\")".gitTag
v1.24.15
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
