### PR TITLE
Update kubeversions for 1-25 through 1-27 release branches

### DIFF
--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -22,11 +22,11 @@ releases:
   kubeVersion: v1.24.15
 - branch: 1-25
   number: 16
-  kubeVersion: v1.25.10
+  kubeVersion: v1.25.11
 - branch: 1-26
   number: 12
-  kubeVersion: v1.26.5
+  kubeVersion: v1.26.6
 - branch: 1-27
   number: 6
-  kubeVersion: v1.27.2
+  kubeVersion: v1.27.3
 latest: 1-25


### PR DESCRIPTION
Update Kubernetes git tag for release branches 1-25 through 1-27.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
