### PR TITLE
brings back fix for kind tarballs due to license file overwrites

### DIFF
--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -413,3 +413,23 @@ function build::jq::update_in_place() {
 
   cat $json_file | jq -S ''"$jq_query"'' > $json_file.tmp && mv $json_file.tmp $json_file
 }
+
+function build::common::copy_if_source_destination_different() {
+  local source=$1
+  local destination=$2
+
+  source_inode=$(stat -c %i $source)
+  destination_inode=""
+  if [ -d $destination ] && [ -e $destination/$(basename $source) ]; then
+    destination_inode=$(stat -c %i $destination/$(basename $source))
+  elif [ -f $destination ] && [ -e $destination ]; then
+    destination_inode=$(stat -c %i $destination)
+  fi
+
+  if [ -n "$destination_inode" ] && [ "$source_inode" = "$destination_inode" ]; then
+    echo "Source and destination are the same file"
+    exit 0
+  fi
+
+  cp -rf $source $destination
+}

--- a/build/lib/simple_create_tarballs.sh
+++ b/build/lib/simple_create_tarballs.sh
@@ -41,10 +41,10 @@ function build::simple::tarball() {
     TAR_FILE="${TAR_FILE_PREFIX}-${OS}-${ARCH}-${TAG}.tar.gz"
 
     for path in "${LICENSE_PATHS[@]}"; do
-      build::common::echo_and_run cp -rf $path ${OUTPUT_BIN_DIR}/${OS}-${ARCH}/
+      build::common::echo_and_run build::common::copy_if_source_destination_different $path ${OUTPUT_BIN_DIR}/${OS}-${ARCH}/
     done
     for path in "${ATTRIBUTION_PATHS[@]}"; do
-      build::common::echo_and_run cp $path ${OUTPUT_BIN_DIR}/${OS}-${ARCH}/
+      build::common::echo_and_run build::common::copy_if_source_destination_different $path ${OUTPUT_BIN_DIR}/${OS}-${ARCH}/
     done
     build::common::create_tarball ${TAR_PATH}/${TAR_FILE} ${OUTPUT_BIN_DIR}/${OS}-${ARCH} .
   done


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We needed this that was reverted in the kind update PR [revert](https://github.com/aws/eks-anywhere-build-tooling/pull/2277/files#diff-a5ed650d97e91497a26f14a346a388676aba4e377ea1efff495154c860b3171b)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
