### PR TITLE
disables udp offload on redhat for vwmare

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0001-Add-goss-validations-for-EKS-D-artifacts.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0001-Add-goss-validations-for-EKS-D-artifacts.patch
@@ -1,7 +1,7 @@
 From 4b485baad0b89680444e4a994bdc384b26f304a3 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 18:36:56 -0800
-Subject: [PATCH 01/17] Add goss validations for EKS-D artifacts
+Subject: [PATCH 01/18] Add goss validations for EKS-D artifacts
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0002-Output-vsphere-builds-to-content-library-instead-of-.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0002-Output-vsphere-builds-to-content-library-instead-of-.patch
@@ -1,7 +1,7 @@
 From bcdde1a417a6123bac4685edfa246c486281cabd Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:00:12 -0800
-Subject: [PATCH 02/17] Output vsphere builds to content library instead of
+Subject: [PATCH 02/18] Output vsphere builds to content library instead of
  exports
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0003-Create-etc-pki-tls-certs-dir-as-part-of-image-builds.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0003-Create-etc-pki-tls-certs-dir-as-part-of-image-builds.patch
@@ -1,7 +1,7 @@
 From 2e01dc5b2d41b33cbff9b516df5380dcdf9c6452 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:05:13 -0800
-Subject: [PATCH 03/17] Create /etc/pki/tls/certs dir as part of image-builds
+Subject: [PATCH 03/18] Create /etc/pki/tls/certs dir as part of image-builds
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0004-Add-etcdadm-and-etcd.tar.gz-to-image-for-unstacked-e.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0004-Add-etcdadm-and-etcd.tar.gz-to-image-for-unstacked-e.patch
@@ -1,7 +1,7 @@
 From 514f9841d9747a970b7f91ff916ce30d01b4c6ee Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:12:53 -0800
-Subject: [PATCH 04/17] Add etcdadm and etcd.tar.gz to image for unstacked etcd
+Subject: [PATCH 04/18] Add etcdadm and etcd.tar.gz to image for unstacked etcd
  support
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0005-Additional-EKS-A-specific-goss-validations.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0005-Additional-EKS-A-specific-goss-validations.patch
@@ -1,7 +1,7 @@
 From efbe109ab433663f0846582c4bf637363888db76 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:26:09 -0800
-Subject: [PATCH 05/17] Additional EKS-A specific goss validations
+Subject: [PATCH 05/18] Additional EKS-A specific goss validations
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0006-Tweak-Product-info-in-OVF.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0006-Tweak-Product-info-in-OVF.patch
@@ -1,7 +1,7 @@
 From 09051e0599528bac2033abef1512698d35b1f415 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:29:16 -0800
-Subject: [PATCH 06/17] Tweak Product info in OVF
+Subject: [PATCH 06/18] Tweak Product info in OVF
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0007-Support-crictl-validation-from-input-checksum.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0007-Support-crictl-validation-from-input-checksum.patch
@@ -1,7 +1,7 @@
 From eb0ec6499bcf05e4683215c6bbcee1a74cbecdcc Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Fri, 2 Sep 2022 14:32:21 -0700
-Subject: [PATCH 08/17] Support crictl validation from input checksum
+Subject: [PATCH 08/18] Support crictl validation from input checksum
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0008-Exclude-kernel-and-cloud-init-from-yum-updates.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0008-Exclude-kernel-and-cloud-init-from-yum-updates.patch
@@ -1,7 +1,7 @@
 From 4aeccc58b24b6bed94f752ed73b593641e4fe004 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 6 Dec 2022 15:42:02 -0600
-Subject: [PATCH 09/17] Exclude kernel and cloud-init from yum updates
+Subject: [PATCH 09/18] Exclude kernel and cloud-init from yum updates
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0009-Patch-cloud-init-systemd-unit-to-wait-for-network-ma.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0009-Patch-cloud-init-systemd-unit-to-wait-for-network-ma.patch
@@ -1,7 +1,7 @@
 From f2b68b5226209c244c3cb243f75cd9da1a53bd0b Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Mon, 9 Jan 2023 14:11:18 -0600
-Subject: [PATCH 10/17] Patch cloud-init systemd unit to wait for network
+Subject: [PATCH 10/18] Patch cloud-init systemd unit to wait for network
  manager online
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0010-Add-instance-metadata-options-to-Packer-config.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0010-Add-instance-metadata-options-to-Packer-config.patch
@@ -1,7 +1,7 @@
 From 42f5a3b2caa7c5713d76df8ceefaa0d960a272b5 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Feb 2023 01:39:15 -0800
-Subject: [PATCH 11/17] Add instance metadata options to Packer config
+Subject: [PATCH 11/18] Add instance metadata options to Packer config
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0011-Rename-Snow-node-image-to-reflect-appropriate-CAPI-p.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0011-Rename-Snow-node-image-to-reflect-appropriate-CAPI-p.patch
@@ -1,7 +1,7 @@
 From f07bc7270d61743a6dfed026ea1dc49dc7da1bf0 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Fri, 10 Feb 2023 16:08:18 -0800
-Subject: [PATCH 12/17] Rename Snow node image to reflect appropriate CAPI
+Subject: [PATCH 12/18] Rename Snow node image to reflect appropriate CAPI
  provider
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0012-Add-EKS-A-specific-inline-Goss-vars-to-all-supported.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0012-Add-EKS-A-specific-inline-Goss-vars-to-all-supported.patch
@@ -1,7 +1,7 @@
 From 7d29f0f259dffc29129306dc9bd36738e4bfe921 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Mar 2023 19:27:50 -0800
-Subject: [PATCH 13/17] Add EKS-A specific inline Goss vars to all supported
+Subject: [PATCH 13/18] Add EKS-A specific inline Goss vars to all supported
  providers
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0013-Use-tar.gz-extension-for-CNI-plugins-tarball.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0013-Use-tar.gz-extension-for-CNI-plugins-tarball.patch
@@ -1,7 +1,7 @@
 From 695c60b097619f4c1c1b3b39fa5fe60e18e150fc Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 9 Mar 2023 16:05:22 -0800
-Subject: [PATCH 14/17] Use tar.gz extension for CNI plugins tarball
+Subject: [PATCH 14/18] Use tar.gz extension for CNI plugins tarball
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0014-uses-latest-ubuntu-22.04-iso.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0014-uses-latest-ubuntu-22.04-iso.patch
@@ -1,7 +1,7 @@
 From 2e69267b8f8ceb079ac263aafa5ea480d02d4d8e Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Fri, 23 Jun 2023 10:50:08 -0500
-Subject: [PATCH 14/17] uses latest ubuntu 22.04 iso
+Subject: [PATCH 14/18] uses latest ubuntu 22.04 iso
 
 ---
  images/capi/packer/ova/ubuntu-2204-efi.json | 4 ++--

--- a/projects/kubernetes-sigs/image-builder/patches/0015-Shrink-qemu-ubuntu-image-size.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0015-Shrink-qemu-ubuntu-image-size.patch
@@ -1,7 +1,7 @@
 From 5d7f131e2ed7190f3cb9c2a7f82b2d2a5ba25845 Mon Sep 17 00:00:00 2001
 From: Roman Hros <roman.hros@dnation.cloud>
 Date: Mon, 5 Jun 2023 16:29:45 +0200
-Subject: [PATCH 15/17] Shrink qemu ubuntu image size
+Subject: [PATCH 15/18] Shrink qemu ubuntu image size
 
 Use fstrim command at the end of sysprep role
 

--- a/projects/kubernetes-sigs/image-builder/patches/0016-adds-support-for-raw-ubuntu-22.04-builds.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0016-adds-support-for-raw-ubuntu-22.04-builds.patch
@@ -1,7 +1,7 @@
 From 91daaa82f64c7c0a80c63b739f2a01c54640873d Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Fri, 16 Jun 2023 15:27:15 -0500
-Subject: [PATCH 16/17] adds support for raw ubuntu 22.04 builds
+Subject: [PATCH 16/18] adds support for raw ubuntu 22.04 builds
 
 ---
  images/capi/Makefile                          |   6 +-

--- a/projects/kubernetes-sigs/image-builder/patches/0017-sets-OS_VERSION-for-goss-validation-on-raw-image-bui.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0017-sets-OS_VERSION-for-goss-validation-on-raw-image-bui.patch
@@ -1,7 +1,7 @@
 From 38977df506b782e779085b6a0cebe87ea080de5c Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Wed, 28 Jun 2023 12:42:22 -0500
-Subject: [PATCH 16/17] sets OS_VERSION for goss validation on raw image builds
+Subject: [PATCH 16/18] sets OS_VERSION for goss validation on raw image builds
 
 ---
  images/capi/packer/raw/packer.json              | 1 +

--- a/projects/kubernetes-sigs/image-builder/patches/0018-adds-disable-udp-service-for-redhat-on-vmware.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0018-adds-disable-udp-service-for-redhat-on-vmware.patch
@@ -1,0 +1,62 @@
+From 0e16d0d44f1e5ab2041f6e6fb6a9cecc15b601c4 Mon Sep 17 00:00:00 2001
+From: Prow Bot <jgw@amazon.com>
+Date: Mon, 10 Jul 2023 14:34:01 -0500
+Subject: [PATCH 18/18] adds disable udp service for redhat on vmware
+
+---
+ .../systemd/system/disable-udp-offload.service | 15 +++++++++++++++
+ .../roles/providers/tasks/vmware-redhat.yml    | 18 ++++++++++++++++++
+ 2 files changed, 33 insertions(+)
+ create mode 100644 images/capi/ansible/roles/providers/files/etc/systemd/system/disable-udp-offload.service
+
+diff --git a/images/capi/ansible/roles/providers/files/etc/systemd/system/disable-udp-offload.service b/images/capi/ansible/roles/providers/files/etc/systemd/system/disable-udp-offload.service
+new file mode 100644
+index 000000000..247a42c56
+--- /dev/null
++++ b/images/capi/ansible/roles/providers/files/etc/systemd/system/disable-udp-offload.service
+@@ -0,0 +1,15 @@
++[Unit]
++Description=Disables UDP offload
++After=NetworkManager-wait-online.service
++# Block manual interactions with this service
++RefuseManualStart=true
++RefuseManualStop=true
++
++[Service]
++Type=oneshot
++ExecStart=/usr/sbin/ethtool -K eth0 tx-udp_tnl-segmentation off
++ExecStart=/usr/sbin/ethtool -K eth0 tx-udp_tnl-csum-segmentation off
++RemainAfterExit=true
++
++[Install]
++WantedBy=multi-user.target
+diff --git a/images/capi/ansible/roles/providers/tasks/vmware-redhat.yml b/images/capi/ansible/roles/providers/tasks/vmware-redhat.yml
+index 0047e90a7..105348b2f 100644
+--- a/images/capi/ansible/roles/providers/tasks/vmware-redhat.yml
++++ b/images/capi/ansible/roles/providers/tasks/vmware-redhat.yml
+@@ -49,3 +49,21 @@
+   file:
+     path:  /tmp/cloud-init-vmware.sh
+     state: absent
++
++- name: Create service disable udp offload
++  copy:
++    src: files/etc/systemd/system/disable-udp-offload.service
++    dest: /etc/systemd/system/disable-udp-offload.service
++    owner: root
++    group: root
++    mode: 0644
++  when: ansible_os_family != "Flatcar"
++
++- name: Enable disable-udp-offload.service
++  systemd:
++    name: disable-udp-offload.service
++    daemon_reload: yes
++    enabled: True
++    state: stopped
++  when: ansible_os_family != "Flatcar"
++  
+\ No newline at end of file
+-- 
+2.40.1
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When updating to cilium 1.12 we ran into the udp overload issue on vmware with Redhat 8. We have seen this problem off an on, seems to depend on the specific version of vpshere, with BR for a while due to their use are pretty new kernels.  Recently they implemented a [solution](https://github.com/bottlerocket-os/bottlerocket/pull/2850) by disabling udp offloading.  There is also potentially some official [guidance](https://github.com/cilium/cilium/issues/21801) coming from the cilium community on this issue for vmware environments. 

This patches our build of image builder to add a similar systemd unit to the Redhat build for vmware.  @taneyland has tested this manually.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
