### PR TITLE
Fix getting git commit from bundle cmd

### DIFF
--- a/build/lib/eksa_releases.sh
+++ b/build/lib/eksa_releases.sh
@@ -21,7 +21,7 @@ function build::eksa_releases::load_bundle_manifest() {
   local -r dev_release=${1-false}
   local -r latest=${2-latest}
   local -r echo=${3-true}
-  oldopt=$-
+  oldopt="$(set +o)"
   set +o nounset
   set +x
 
@@ -37,7 +37,7 @@ function build::eksa_releases::load_bundle_manifest() {
   if $echo; then
     echo "${BUNDLE_MANIFEST[$bundle_manifest_key]}"
   fi
-  set -$oldopt
+  set -vx; eval "$oldopt"
 }
 
 function build::eksa_releases::get_eksa_component_asset_url() {
@@ -71,7 +71,7 @@ function build::eksa_releases::get_eksa_component_asset_path() {
   local -r dev_release=${3-false}
   local -r latest=${4-main}
 
-  oldopt=$-
+  oldopt="$(set +o)"
   set +x
 
   # Get latest bundle manifest url
@@ -82,7 +82,7 @@ function build::eksa_releases::get_eksa_component_asset_path() {
 
   echo "$bundle_manifest" | yq e "$query" -
 
-  set -$oldopt
+  set -vx; eval "$oldopt"
 }
 
 function build::eksa_releases::get_eksa_release_manifest_url() {

--- a/projects/aws/image-builder/CHECKSUMS
+++ b/projects/aws/image-builder/CHECKSUMS
@@ -1,2 +1,2 @@
-de076c1e59c3dd85cb26df343eb5487f723977682e43c768d38867b0d25c64b8  _output/bin/image-builder/linux-amd64/image-builder
-66cf07a3b6c911da172fda195419e39f1332a2e9b90a5acaf585c8b47df43006  _output/bin/image-builder/linux-arm64/image-builder
+16a84316d4560af1c987f873bf0ec4af57f2e1702d20cd70a3583ea85490ef21  _output/bin/image-builder/linux-amd64/image-builder
+db29f48d34c69fd0fad07ee4cf87f2afb6bedd45d3969c12a6a0fe448e374f07  _output/bin/image-builder/linux-arm64/image-builder

--- a/projects/aws/image-builder/builder/utils.go
+++ b/projects/aws/image-builder/builder/utils.go
@@ -111,8 +111,8 @@ func execCommand(cmd *exec.Cmd) (string, error) {
 
 func getGitCommitFromBundle(repoPath string) (string, error) {
 	log.Println("Getting git commit from bundle")
-	loadBundleManifestCommandSequence := fmt.Sprintf("source %s/build/lib/eksa_releases.sh && build::eksa_releases::load_bundle_manifest", repoPath, repoPath)
-	cmd := exec.Command("bash", "-c", fmt.Sprintf("%s", loadBundleManifestCommandSequence))
+	loadBundleManifestCommandSequence := fmt.Sprintf("source %s/build/lib/eksa_releases.sh && build::eksa_releases::load_bundle_manifest", repoPath)
+	cmd := exec.Command("bash", "-c", fmt.Sprintf("\"%s\"", loadBundleManifestCommandSequence))
 	commandOut, err := execCommand(cmd)
 	if err != nil {
 		return commandOut, err


### PR DESCRIPTION
*Issue #, if available:* `build --os ubuntu --hypervisor baremetal --release-channel 1-24` cannot run because it fails to fetch git commit

*Description of changes:* fix the command to fetch git commit


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
