### PR TITLE
Support etcdadm pulling from EKS-D

### DIFF
--- a/projects/kubernetes-sigs/etcdadm/CHECKSUMS
+++ b/projects/kubernetes-sigs/etcdadm/CHECKSUMS
@@ -1,2 +1,2 @@
-38182d45d436821cbf181aed6901b44131be00078a902eba70ef24ba0bf522bd  _output/bin/etcdadm/linux-amd64/etcdadm
-2b78d5b08089404228b42d13726874e5d55711ef683166ec9a35146011d99c82  _output/bin/etcdadm/linux-arm64/etcdadm
+8b40bd26aeefc251c6729267118a7ce3aade60abf5e2ed920603929f8227a536  _output/bin/etcdadm/linux-amd64/etcdadm
+468230d129db15bfca960b3883370f4840ff1f48cbe0094fa026ede873d56bc5  _output/bin/etcdadm/linux-arm64/etcdadm

--- a/projects/kubernetes-sigs/etcdadm/patches/0004-Support-pulling-etcd-from-EKS-D.patch
+++ b/projects/kubernetes-sigs/etcdadm/patches/0004-Support-pulling-etcd-from-EKS-D.patch
@@ -1,0 +1,77 @@
+From 6a6de45f94484bc2c8dbf683676973e9188112f9 Mon Sep 17 00:00:00 2001
+From: Vignesh Goutham Ganesh <vgg@amazon.com>
+Date: Wed, 12 Jul 2023 11:03:41 -0500
+Subject: [PATCH] Support pulling etcd from EKS-D
+
+Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
+---
+ binary/etcd.go         | 20 +++++++++++++++++++-
+ constants/constants.go |  2 +-
+ 2 files changed, 20 insertions(+), 2 deletions(-)
+
+diff --git a/binary/etcd.go b/binary/etcd.go
+index ebecc2db..f28f060c 100644
+--- a/binary/etcd.go
++++ b/binary/etcd.go
+@@ -21,6 +21,7 @@ import (
+ 	"io/ioutil"
+ 	"os"
+ 	"os/exec"
++	"path"
+ 	"path/filepath"
+ 	"runtime"
+ 	"strings"
+@@ -104,19 +105,36 @@ func Download(releaseURL, version, locationDir string) error {
+ 	}
+ 
+ 	url := downloadURL(releaseURL, version)
++	// get will download from any complete url and will rename downloaded binary to etcd name format
++	// upstream uses. This will also be the format `func InstallFromCache` expects.
+ 	if err := get(url, archive); err != nil {
+ 		return fmt.Errorf("unable to download etcd: %s", err)
+ 	}
+ 	return nil
+ }
+ 
++// releaseFile will always provide the etcd file name format upstream and image-builder uses
+ func releaseFile(version string) string {
+ 	return fmt.Sprintf("etcd-v%s-linux-%s.tar.gz", version, runtime.GOARCH)
+ }
+ 
+ func downloadURL(releaseURL, version string) string {
+ 	// FIXME use url.ResolveReference to join
+-	return fmt.Sprintf("%s/v%s/%s", releaseURL, version, releaseFile(version))
++	// check if release URL is full path to tar.gz file
++	if isFullEtcdReleaseUrl(releaseURL) {
++		return releaseURL
++	}
++
++	// returns with etcd file name format eks-d uses, this patched version of etcdadm will not support pulling from github
++	return fmt.Sprintf("%s/v%s/etcd-linux-%s-v%s.tar.gz", releaseURL, version, runtime.GOARCH, version)
++}
++
++func isFullEtcdReleaseUrl(releaseURL string) bool {
++	releaseUrlBase := path.Base(releaseURL)
++	if filepath.Ext(releaseUrlBase) == ".gz" {
++		return true
++	}
++	return false
+ }
+ 
+ // InstallFromCache method installs the binaries from cache directory
+diff --git a/constants/constants.go b/constants/constants.go
+index 6f3ec911..f2d35a75 100644
+--- a/constants/constants.go
++++ b/constants/constants.go
+@@ -23,7 +23,7 @@ const (
+ 	DefaultVersion    = "3.5.7"
+ 	DefaultInstallDir = "/opt/bin/"
+ 
+-	DefaultReleaseURL      = "https://github.com/coreos/etcd/releases/download"
++	DefaultReleaseURL      = "https://distro.eks.amazonaws.com/kubernetes-1-27/releases/7/artifacts/etcd"
+ 	DefaultImageRepository = "quay.io/coreos/etcd"
+ 	DefaultCertificateDir  = "/etc/etcd/pki"
+ 
+-- 
+2.37.1 (Apple Git-137.1)
+


### PR DESCRIPTION
*Description of changes:*
Etcdadm defaults to github.com to pull etcd binaries when the input etcd version and the version available in the cache dir doesn't match. This change allows etcdadm to pull from EKS-D as well as support pulling from a complete etcd release url as opposed to deriving complete full path url from hostname + etcd version. This will help EKS-A set complete full url to etcd release from EKS-D.

*Test runs*
Without release url
```
ubuntu@ip-172-31-7-153:~$ sudo ./etcdadm init --init-system systemd --version 3.5.7 --install-dir /usr/bin
2023-07-12 16:10:31.205303 I | [install] Artifact not found in cache. Trying to fetch from upstream: https://distro.eks.amazonaws.com/kubernetes-1-27/releases/7/artifacts/etcd
INFO[0000] [install] Downloading & installing etcd https://distro.eks.amazonaws.com/kubernetes-1-27/releases/7/artifacts/etcd from 3.5.7 to /var/cache/etcdadm/etcd/v3.5.7
INFO[0000] [install] downloading etcd from https://distro.eks.amazonaws.com/kubernetes-1-27/releases/7/artifacts/etcd/v3.5.7/etcd-linux-amd64-v3.5.7.tar.gz to /var/cache/etcdadm/etcd/v3.5.7/etcd-v3.5.7-linux-amd64.tar.gz
######################################################################## 100.0%
INFO[0000] [install] extracting etcd archive /var/cache/etcdadm/etcd/v3.5.7/etcd-v3.5.7-linux-amd64.tar.gz to /tmp/etcd484998304
```

With release-url
```
ubuntu@ip-172-31-7-153:~$ sudo ./etcdadm init --init-system systemd --version 3.5.7 --install-dir /usr/bin --release-url https://distro.eks.amazonaws.com/kubernetes-1-27/releases/7/artifacts/etcd/v3.5.7/etcd-linux-arm64-v3.5.7.tar.gz
2023-07-12 16:13:07.719322 I | [install] Artifact not found in cache. Trying to fetch from upstream: https://distro.eks.amazonaws.com/kubernetes-1-27/releases/7/artifacts/etcd/v3.5.7/etcd-linux-arm64-v3.5.7.tar.gz
INFO[0000] [install] Downloading & installing etcd https://distro.eks.amazonaws.com/kubernetes-1-27/releases/7/artifacts/etcd/v3.5.7/etcd-linux-arm64-v3.5.7.tar.gz from 3.5.7 to /var/cache/etcdadm/etcd/v3.5.7
INFO[0000] [install] downloading etcd from https://distro.eks.amazonaws.com/kubernetes-1-27/releases/7/artifacts/etcd/v3.5.7/etcd-linux-arm64-v3.5.7.tar.gz to /var/cache/etcdadm/etcd/v3.5.7/etcd-v3.5.7-linux-amd64.tar.gz
######################################################################## 100.0%
INFO[0001] [install] extracting etcd archive /var/cache/etcdadm/etcd/v3.5.7/etcd-v3.5.7-linux-amd64.tar.gz to /tmp/etcd241068552
INFO[0001] [install] verifying etcd 3.5.7 is installed in /usr/bin
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
