### PR TITLE
Provide full path to additional files config

### DIFF
--- a/projects/aws/image-builder/CHECKSUMS
+++ b/projects/aws/image-builder/CHECKSUMS
@@ -1,2 +1,2 @@
-8b6f85833e8a1de637d577c728b48de863c5af02bc57d5c8fba4e18b9ff283a0  _output/bin/image-builder/linux-amd64/image-builder
-6cac01cfd25e9c9c2812ec089c40d73e9cf54faae3d54a656626acdc36a7bdb0  _output/bin/image-builder/linux-arm64/image-builder
+a66ca2092dfd2b1ddee36dc70f5073932f1e552a99ac32fb9ab7eff8c54f8cf6  _output/bin/image-builder/linux-amd64/image-builder
+116304ffe6b28d5bba3c7f7a5333d7027c9db2077b7d3ed7607f6ff04eb07b79  _output/bin/image-builder/linux-arm64/image-builder

--- a/projects/aws/image-builder/builder/builder.go
+++ b/projects/aws/image-builder/builder/builder.go
@@ -73,7 +73,8 @@ func (b *BuildOptions) BuildImage() {
 			log.Fatalf("Error marshalling files ansible config data: %v", err)
 		}
 
-		err = ioutil.WriteFile(filepath.Join(imageBuilderProjectPath, packerAdditionalFilesConfigFile), filesAnsibleConfig, 0o644)
+		additionalFilesConfigFile := filepath.Join(imageBuilderProjectPath, packerAdditionalFilesConfigFile)
+		err = ioutil.WriteFile(additionalFilesConfigFile, filesAnsibleConfig, 0o644)
 		if err != nil {
 			log.Fatalf("Error writing additional files config file to Packer directory: %v", err)
 		}
@@ -88,7 +89,7 @@ func (b *BuildOptions) BuildImage() {
 			log.Fatalf("Error writing additional files config in Packer ansible directory: %v", err)
 		}
 
-		commandEnvVars = append(commandEnvVars, fmt.Sprintf("%s=%s", packerAdditionalFilesConfigFileEnvVar, packerAdditionalFilesConfigFile))
+		commandEnvVars = append(commandEnvVars, fmt.Sprintf("%s=%s", packerAdditionalFilesConfigFileEnvVar, additionalFilesConfigFile))
 	}
 	if b.Hypervisor == VSphere {
 		// Read and set the vsphere connection data


### PR DESCRIPTION
Provide full absolute path to additional files config so that Packer doesn't prefix it with the upstream path.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
