### PR TITLE
Fix absolute path for Snow AMI scripts

### DIFF
--- a/projects/aws/image-builder/CHECKSUMS
+++ b/projects/aws/image-builder/CHECKSUMS
@@ -1,2 +1,2 @@
-b5fa2efddc56d0476db67946c1e1a900606c65db026187c91488cd83d1041f54  _output/bin/image-builder/linux-amd64/image-builder
-bd0697334523a212d08fe50f59f84f97cb787f3466efa4b684579f198a17908a  _output/bin/image-builder/linux-arm64/image-builder
+7fadeacc7fb2a6cb223bacc4f688fe18e91a50dc93aca7021715104b8e543faa  _output/bin/image-builder/linux-amd64/image-builder
+962f0273bbcc313e4d4c58e96f41d877ca1d431dd58aa0ec2ac3844922668a63  _output/bin/image-builder/linux-arm64/image-builder

--- a/projects/aws/image-builder/builder/constants.go
+++ b/projects/aws/image-builder/builder/constants.go
@@ -9,8 +9,6 @@ const (
 	DefaultAMIRootDeviceName       string = "/dev/sda1"
 	DefaultAMIVolumeSize           string = "25"
 	DefaultAMIVolumeType           string = "gp3"
-	DefaultAMICustomRoleNames      string = "projects/kubernetes-sigs/image-builder/ansible/roles/load_additional_files"
-	DefaultAMIAnsibleExtraVars     string = "projects/kubernetes-sigs/image-builder/packer/config/additional_files.yaml"
 	DefaultAMIManifestOutput       string = "manifest.json"
 
 	imageBuilderProjectDirectory     string = "projects/kubernetes-sigs/image-builder"
@@ -38,14 +36,14 @@ const (
 
 var DefaultAMIAdditionalFiles = []File{
 	{
-		Source:      "projects/kubernetes-sigs/image-builder/packer/ami/additional_files/bootstrap.sh",
+		Source:      "packer/ami/additional_files/bootstrap.sh",
 		Destination: "/etc/eks/",
 		Owner:       "root",
 		Group:       "root",
 		Mode:        744,
 	},
 	{
-		Source:      "projects/kubernetes-sigs/image-builder/packer/ami/additional_files/logging.sh",
+		Source:      "packer/ami/additional_files/logging.sh",
 		Destination: "/etc/eks/",
 		Owner:       "root",
 		Group:       "root",


### PR DESCRIPTION
These were getting prefixed with the image-builder project path so we don't need those folders in this path.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
