### PR TITLE
Backport image-builder cli fix for getting bundle

### DIFF
--- a/projects/aws/image-builder/CHECKSUMS
+++ b/projects/aws/image-builder/CHECKSUMS
@@ -1,2 +1,2 @@
-3ec2092f2db2a9280c150362057404b04173b677d24f3d4626184de6013773e2  _output/bin/image-builder/linux-amd64/image-builder
-771ec2df52fe94eee856e811bf26b61e153755d0f92bdd4b36c714a9b9efb0db  _output/bin/image-builder/linux-arm64/image-builder
+d2860b0716a4765bbf86822270750b2a3fbb9e5c0f8982e708d7f351a8965424  _output/bin/image-builder/linux-amd64/image-builder
+829f0525ebeb7e0efaf63dd58371338509fc45236796a0e494977049c1ba5cb0  _output/bin/image-builder/linux-arm64/image-builder

--- a/projects/aws/image-builder/builder/utils.go
+++ b/projects/aws/image-builder/builder/utils.go
@@ -111,7 +111,7 @@ func execCommand(cmd *exec.Cmd) (string, error) {
 
 func getGitCommitFromBundle(repoPath string) (string, error) {
 	log.Println("Getting git commit from bundle")
-	loadBundleManifestCommandSequence := fmt.Sprintf("source %s/build/lib/eksa_releases.sh && build::eksa_releases::load_bundle_manifest", repoPath, repoPath)
+	loadBundleManifestCommandSequence := fmt.Sprintf("source %s/build/lib/eksa_releases.sh && build::eksa_releases::load_bundle_manifest", repoPath)
 	cmd := exec.Command("bash", "-c", fmt.Sprintf("%s", loadBundleManifestCommandSequence))
 	commandOut, err := execCommand(cmd)
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Backportting from main so we can produce a 0.16.x build that actually works.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
