### PR TITLE
Make EKS-A release version mutable in script

### DIFF
--- a/build/lib/eksa_releases.sh
+++ b/build/lib/eksa_releases.sh
@@ -36,7 +36,7 @@ function build::eksa_releases::load_bundle_manifest() {
     # dev EKS-A releases manifest and so the yq search will fail. Hence if are running in dev, we append
     # a wildcard build metadata to the EKSA_RELEASE_VERSION var that will make it pass the yq select check.
     EKSA_RELEASE_VERSION="${EKSA_RELEASE_VERSION:-}"
-    local -r eksa_release_version=${EKSA_RELEASE_VERSION:-$(echo "$release_manifest" | yq e ".spec.latestVersion" -)}
+    local eksa_release_version=${EKSA_RELEASE_VERSION:-$(echo "$release_manifest" | yq e ".spec.latestVersion" -)}
     if [ $dev_release = true ] && [ -n "$EKSA_RELEASE_VERSION" ]; then
       eksa_release_version="$eksa_release_version+build.*"
     fi


### PR DESCRIPTION
Removing the readonly flag at variable declaration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
