### PR TITLE
Provide default value for EKSA_USE_DEV_RELEASE variable

### DIFF
--- a/projects/kubernetes-sigs/image-builder/build/setup_packer_configs.sh
+++ b/projects/kubernetes-sigs/image-builder/build/setup_packer_configs.sh
@@ -30,6 +30,7 @@ IMAGE_OS_VERSION="${10? Specify tenth argument - image-os-version}"
 
 CI="${CI:-false}"
 CODEBUILD_CI="${CODEBUILD_CI:-false}"
+EKSA_USE_DEV_RELEASE="${EKSA_USE_DEV_RELEASE:-false}"
 DEV_RELEASE=false
 if [[ $CI == true || $CODEBUILD_CI == true || $EKSA_USE_DEV_RELEASE == true ]]; then
   DEV_RELEASE=true

--- a/projects/kubernetes-sigs/image-builder/packer/nutanix/nutanix.json
+++ b/projects/kubernetes-sigs/image-builder/packer/nutanix/nutanix.json
@@ -1,0 +1,5 @@
+{
+    "nutanix_endpoint": "nutanix_endpoint",
+    "cluster_name": "cluster_name",
+    "nutanix_password": "nutanix_password"
+}

--- a/projects/kubernetes-sigs/image-builder/patches/0001-Add-goss-validations-for-EKS-D-artifacts.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0001-Add-goss-validations-for-EKS-D-artifacts.patch
@@ -1,7 +1,7 @@
 From 1c8a0f202a9cec579266a8fed17a86165539b8c8 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 18:36:56 -0800
-Subject: [PATCH 01/18] Add goss validations for EKS-D artifacts
+Subject: [PATCH 01/19] Add goss validations for EKS-D artifacts
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---
@@ -31,5 +31,5 @@ index 189b5a4cc..1ab83545e 100644
      stderr: []
      timeout: 0
 -- 
-2.39.1
+2.39.2
 

--- a/projects/kubernetes-sigs/image-builder/patches/0002-Output-vsphere-builds-to-content-library-instead-of-.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0002-Output-vsphere-builds-to-content-library-instead-of-.patch
@@ -1,7 +1,7 @@
 From 7825eeb1333575bbc6ffad6e922ec82a5d17d461 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:00:12 -0800
-Subject: [PATCH 02/18] Output vsphere builds to content library instead of
+Subject: [PATCH 02/19] Output vsphere builds to content library instead of
  exports
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
@@ -98,5 +98,5 @@ index d6fc80fdd..0b3e48792 100644
    }
  }
 -- 
-2.39.1
+2.39.2
 

--- a/projects/kubernetes-sigs/image-builder/patches/0003-Create-etc-pki-tls-certs-dir-as-part-of-image-builds.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0003-Create-etc-pki-tls-certs-dir-as-part-of-image-builds.patch
@@ -1,7 +1,7 @@
 From bd4a51d1cb15048cf8daa8c38b166065c91ec22c Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:05:13 -0800
-Subject: [PATCH 03/18] Create /etc/pki/tls/certs dir as part of image-builds
+Subject: [PATCH 03/19] Create /etc/pki/tls/certs dir as part of image-builds
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---
@@ -29,5 +29,5 @@ index 04a07ad7f..0114e934d 100644
    file:
      path: /etc/systemd/system/containerd.service.d/http-proxy.conf
 -- 
-2.39.1
+2.39.2
 

--- a/projects/kubernetes-sigs/image-builder/patches/0004-Add-etcdadm-and-etcd.tar.gz-to-image-for-unstacked-e.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0004-Add-etcdadm-and-etcd.tar.gz-to-image-for-unstacked-e.patch
@@ -1,7 +1,7 @@
 From e2e3348655b316f9cc336331d674b6be42741960 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:12:53 -0800
-Subject: [PATCH 04/18] Add etcdadm and etcd.tar.gz to image for unstacked etcd
+Subject: [PATCH 04/19] Add etcdadm and etcd.tar.gz to image for unstacked etcd
  support
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
@@ -83,5 +83,5 @@ index 4d3a5f5a8..80f93c5c3 100644
    "kubernetes_series": "v1.25",
    "kubernetes_source_type": "pkg",
 -- 
-2.39.1
+2.39.2
 

--- a/projects/kubernetes-sigs/image-builder/patches/0005-Additional-EKS-A-specific-goss-validations.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0005-Additional-EKS-A-specific-goss-validations.patch
@@ -1,7 +1,7 @@
 From d2b23cda807ba4782c6d6a6af7d5a9e929bb70c7 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:26:09 -0800
-Subject: [PATCH 05/18] Additional EKS-A specific goss validations
+Subject: [PATCH 05/19] Additional EKS-A specific goss validations
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---
@@ -128,5 +128,5 @@ index 0b3e48792..ff6430db3 100644
        "version": "{{user `goss_version`}}"
      }
 -- 
-2.39.1
+2.39.2
 

--- a/projects/kubernetes-sigs/image-builder/patches/0006-Tweak-Product-info-in-OVF.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0006-Tweak-Product-info-in-OVF.patch
@@ -1,7 +1,7 @@
 From e7622d7c38951b1d19b98638e5a027439327eb7a Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:29:16 -0800
-Subject: [PATCH 06/18] Tweak Product info in OVF
+Subject: [PATCH 06/19] Tweak Product info in OVF
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---
@@ -35,5 +35,5 @@ index 316427ec3..ca23db5f9 100644
        <Property ovf:userConfigurable="false" ovf:value="${BUILD_TIMESTAMP}" ovf:type="string" ovf:key="BUILD_TIMESTAMP"/>
        <Property ovf:userConfigurable="false" ovf:value="${BUILD_DATE}" ovf:type="string" ovf:key="BUILD_DATE"/>
 -- 
-2.39.1
+2.39.2
 

--- a/projects/kubernetes-sigs/image-builder/patches/0007-Support-crictl-validation-from-input-checksum.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0007-Support-crictl-validation-from-input-checksum.patch
@@ -1,7 +1,7 @@
 From 466adc2ce78964efe944d698ff27f9bffc73db61 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Fri, 2 Sep 2022 14:32:21 -0700
-Subject: [PATCH 07/18] Support crictl validation from input checksum
+Subject: [PATCH 07/19] Support crictl validation from input checksum
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---
@@ -38,5 +38,5 @@ index 9ae4f81b1..1ef16318a 100644
      mode: 0600
  
 -- 
-2.39.1
+2.39.2
 

--- a/projects/kubernetes-sigs/image-builder/patches/0008-Exclude-kernel-and-cloud-init-from-yum-updates.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0008-Exclude-kernel-and-cloud-init-from-yum-updates.patch
@@ -1,7 +1,7 @@
 From 014e064f435e54a7651ff73593f9dad01efd8ba8 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 6 Dec 2022 15:42:02 -0600
-Subject: [PATCH 08/18] Exclude kernel and cloud-init from yum updates
+Subject: [PATCH 08/19] Exclude kernel and cloud-init from yum updates
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---
@@ -21,5 +21,5 @@ index 66d9c8cac..0961f37d4 100644
  
  - name: install baseline dependencies
 -- 
-2.39.1
+2.39.2
 

--- a/projects/kubernetes-sigs/image-builder/patches/0009-Patch-cloud-init-systemd-unit-to-wait-for-network-ma.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0009-Patch-cloud-init-systemd-unit-to-wait-for-network-ma.patch
@@ -1,7 +1,7 @@
 From 1d2f0a81b1560756ce9362be03a4a106a92790d5 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Mon, 9 Jan 2023 14:11:18 -0600
-Subject: [PATCH 09/18] Patch cloud-init systemd unit to wait for network
+Subject: [PATCH 09/19] Patch cloud-init systemd unit to wait for network
  manager online
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
@@ -47,5 +47,5 @@ index 28c609177..e5f2ed16c 100644
  # Enable all cloud-init services on boot.
  - name: Make sure all cloud init services are enabled
 -- 
-2.39.1
+2.39.2
 

--- a/projects/kubernetes-sigs/image-builder/patches/0010-Add-instance-metadata-options-to-Packer-config.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0010-Add-instance-metadata-options-to-Packer-config.patch
@@ -1,7 +1,7 @@
 From 80b701ee528b6cb5de1d642eee75eeee2b107680 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Feb 2023 01:39:15 -0800
-Subject: [PATCH 10/18] Add instance metadata options to Packer config
+Subject: [PATCH 10/19] Add instance metadata options to Packer config
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 ---
@@ -35,5 +35,5 @@ index 7b957a8d6..d2c742649 100644
      "ib_version": "{{env `IB_VERSION`}}",
      "iops": "3000",
 -- 
-2.39.1
+2.39.2
 

--- a/projects/kubernetes-sigs/image-builder/patches/0011-Rename-Snow-node-image-to-reflect-appropriate-CAPI-p.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0011-Rename-Snow-node-image-to-reflect-appropriate-CAPI-p.patch
@@ -1,7 +1,7 @@
 From f1d37d26168f74ab9c100547a0aba19e3a59298a Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Fri, 10 Feb 2023 16:08:18 -0800
-Subject: [PATCH 11/18] Rename Snow node image to reflect appropriate CAPI
+Subject: [PATCH 11/19] Rename Snow node image to reflect appropriate CAPI
  provider
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
@@ -23,5 +23,5 @@ index d2c742649..d64b22278 100644
        "ami_regions": "{{user `ami_regions`}}",
        "ami_users": "{{user `ami_users`}}",
 -- 
-2.39.1
+2.39.2
 

--- a/projects/kubernetes-sigs/image-builder/patches/0012-Add-EKS-A-specific-inline-Goss-vars-to-all-supported.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0012-Add-EKS-A-specific-inline-Goss-vars-to-all-supported.patch
@@ -1,7 +1,7 @@
 From 74fad131b42949bbbdd033c4f51129408d2a564c Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Mar 2023 19:27:50 -0800
-Subject: [PATCH 12/18] Add EKS-A specific inline Goss vars to all supported
+Subject: [PATCH 12/19] Add EKS-A specific inline Goss vars to all supported
  providers
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
@@ -85,5 +85,5 @@ index e790e67d5..dc494a1e8 100644
        "version": "{{user `goss_version`}}"
      }
 -- 
-2.39.1
+2.39.2
 

--- a/projects/kubernetes-sigs/image-builder/patches/0013-Use-tar.gz-extension-for-CNI-plugins-tarball.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0013-Use-tar.gz-extension-for-CNI-plugins-tarball.patch
@@ -1,7 +1,7 @@
 From 2a291e5f7626d87f04b6a60c45a09f203d77dcb7 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 9 Mar 2023 16:05:22 -0800
-Subject: [PATCH 13/18] Use tar.gz extension for CNI plugins tarball
+Subject: [PATCH 13/19] Use tar.gz extension for CNI plugins tarball
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 ---
@@ -22,5 +22,5 @@ index 48a4a2177..99bf2f843 100644
      dest: /tmp/cni.tar.gz
      mode: 0755
 -- 
-2.39.1
+2.39.2
 

--- a/projects/kubernetes-sigs/image-builder/patches/0014-uses-latest-ubuntu-22.04-iso.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0014-uses-latest-ubuntu-22.04-iso.patch
@@ -1,7 +1,7 @@
 From 06b287df708bbb86f101cf26ea60aadb0abfe27e Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Fri, 23 Jun 2023 10:50:08 -0500
-Subject: [PATCH 14/18] uses latest ubuntu 22.04 iso
+Subject: [PATCH 14/19] uses latest ubuntu 22.04 iso
 
 ---
  images/capi/packer/ova/ubuntu-2204-efi.json | 4 ++--
@@ -41,5 +41,5 @@ index badbf1045..dffc6967f 100644
    "shutdown_command": "shutdown -P now",
    "vsphere_guest_os_type": "ubuntu64Guest"
 -- 
-2.39.1
+2.39.2
 

--- a/projects/kubernetes-sigs/image-builder/patches/0015-Shrink-qemu-ubuntu-image-size.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0015-Shrink-qemu-ubuntu-image-size.patch
@@ -1,7 +1,7 @@
 From de8d2056f14d6c6bb9a782eb9d11b0d39ae1084c Mon Sep 17 00:00:00 2001
 From: Roman Hros <roman.hros@dnation.cloud>
 Date: Mon, 5 Jun 2023 16:29:45 +0200
-Subject: [PATCH 15/18] Shrink qemu ubuntu image size
+Subject: [PATCH 15/19] Shrink qemu ubuntu image size
 
 Use fstrim command at the end of sysprep role
 
@@ -112,5 +112,5 @@ index 24bdce560..fdcb56c26 100644
 +    - curtin in-target --target=/target -- apt-get clean
 +    - curtin in-target --target=/target -- rm -rf /var/lib/apt/lists/*
 -- 
-2.39.1
+2.39.2
 

--- a/projects/kubernetes-sigs/image-builder/patches/0016-adds-support-for-raw-ubuntu-22.04-builds.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0016-adds-support-for-raw-ubuntu-22.04-builds.patch
@@ -1,7 +1,7 @@
 From 2787a5bd657cb37f2fb1d9be90b1ce34238526ce Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Fri, 16 Jun 2023 15:27:15 -0500
-Subject: [PATCH 16/18] adds support for raw ubuntu 22.04 builds
+Subject: [PATCH 16/19] adds support for raw ubuntu 22.04 builds
 
 ---
  images/capi/Makefile                          |   6 +-
@@ -311,5 +311,5 @@ index 000000000..38e827ef1
 +  "shutdown_command": "shutdown -P now"
 +  }
 -- 
-2.39.1
+2.39.2
 

--- a/projects/kubernetes-sigs/image-builder/patches/0017-sets-OS_VERSION-for-goss-validation-on-raw-image-bui.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0017-sets-OS_VERSION-for-goss-validation-on-raw-image-bui.patch
@@ -1,7 +1,7 @@
 From 2dfca2a7cdad5941c05f9f070b126d4b80398ce3 Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Wed, 28 Jun 2023 12:42:22 -0500
-Subject: [PATCH 17/18] sets OS_VERSION for goss validation on raw image builds
+Subject: [PATCH 17/19] sets OS_VERSION for goss validation on raw image builds
 
 ---
  images/capi/packer/raw/packer.json              | 1 +
@@ -87,5 +87,5 @@ index 38e827ef1..7a7b3109f 100644
    "iso_checksum": "5e38b55d57d94ff029719342357325ed3bda38fa80054f9330dc789cd2d43931",
    "iso_checksum_type": "sha256",
 -- 
-2.39.1
+2.39.2
 

--- a/projects/kubernetes-sigs/image-builder/patches/0018-Disable-UDP-offload-service-for-Redhat-and-Ubuntu.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0018-Disable-UDP-offload-service-for-Redhat-and-Ubuntu.patch
@@ -1,7 +1,7 @@
-From b1d69b87ea150387e738af951ef4723a8f2c040a Mon Sep 17 00:00:00 2001
+From 6657f087315015a608a0f088de41ea47da4a6232 Mon Sep 17 00:00:00 2001
 From: Taylor Neyland <tneyla@amazon.com>
 Date: Wed, 19 Jul 2023 12:51:30 -0500
-Subject: [PATCH 18/18] Disable UDP offload service for Redhat and Ubuntu
+Subject: [PATCH 18/19] Disable UDP offload service for Redhat and Ubuntu
 
 ---
  .../system/disable-udp-offload-redhat.service  | 15 +++++++++++++++
@@ -108,5 +108,5 @@ index 8a63b50ce..392a6fc4e 100644
 +    state: stopped
 +  when: ansible_distribution_version is version('22.04', '>=')
 -- 
-2.39.1
+2.39.2
 

--- a/projects/kubernetes-sigs/image-builder/patches/0019-Pin-packer-plugin-nutanix-to-v0.7.1.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0019-Pin-packer-plugin-nutanix-to-v0.7.1.patch
@@ -1,0 +1,25 @@
+From 5b54acdcaec5e5a1476d190b8658145a4aa04a35 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Thu, 10 Aug 2023 14:47:53 -0700
+Subject: [PATCH 19/19] Pin packer-plugin-nutanix to v0.7.1
+
+---
+ images/capi/packer/nutanix/config.pkr.hcl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/images/capi/packer/nutanix/config.pkr.hcl b/images/capi/packer/nutanix/config.pkr.hcl
+index 3f0d26dd7..3714bc23b 100644
+--- a/images/capi/packer/nutanix/config.pkr.hcl
++++ b/images/capi/packer/nutanix/config.pkr.hcl
+@@ -1,7 +1,7 @@
+ packer {
+   required_plugins {
+     nutanix = {
+-      version = ">= 0.7.0"
++      version = "0.7.1"
+       source = "github.com/nutanix-cloud-native/nutanix"
+     }
+   }
+-- 
+2.39.2
+


### PR DESCRIPTION
* Providing default value for EKSA_USE_DEV_RELEASE variable so that we don't get unbound variable errors.
* Pinning packer-plugin-nutanix to version v0.7.1 so that we avoid including [this change](https://github.com/nutanix-cloud-native/packer-plugin-nutanix/pull/142) that breaks presubmits due to empty configs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
