### PR TITLE
Point ISO URL to Ubuntu old releases CDN

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0014-uses-latest-ubuntu-22.04-iso.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0014-uses-latest-ubuntu-22.04-iso.patch
@@ -20,7 +20,7 @@ index 0bc473353..c70d46841 100644
 +  "iso_checksum": "5e38b55d57d94ff029719342357325ed3bda38fa80054f9330dc789cd2d43931",
    "iso_checksum_type": "sha256",
 -  "iso_url": "https://old-releases.ubuntu.com/releases/jammy/ubuntu-22.04.1-live-server-amd64.iso",
-+  "iso_url": "https://releases.ubuntu.com/22.04/ubuntu-22.04.2-live-server-amd64.iso",
++  "iso_url": "https://old-releases.ubuntu.com/releases/jammy/ubuntu-22.04.2-live-server-amd64.iso",
    "os_display_name": "Ubuntu 22.04",
    "shutdown_command": "shutdown -P now",
    "vsphere_guest_os_type": "ubuntu64Guest"
@@ -36,7 +36,7 @@ index badbf1045..dffc6967f 100644
 +  "iso_checksum": "5e38b55d57d94ff029719342357325ed3bda38fa80054f9330dc789cd2d43931",
    "iso_checksum_type": "sha256",
 -  "iso_url": "https://old-releases.ubuntu.com/releases/jammy/ubuntu-22.04.1-live-server-amd64.iso",
-+  "iso_url": "https://releases.ubuntu.com/22.04/ubuntu-22.04.2-live-server-amd64.iso",
++  "iso_url": "https://old-releases.ubuntu.com/releases/jammy/ubuntu-22.04.2-live-server-amd64.iso",
    "os_display_name": "Ubuntu 22.04",
    "shutdown_command": "shutdown -P now",
    "vsphere_guest_os_type": "ubuntu64Guest"

--- a/projects/kubernetes-sigs/image-builder/patches/0016-adds-support-for-raw-ubuntu-22.04-builds.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0016-adds-support-for-raw-ubuntu-22.04-builds.patch
@@ -288,7 +288,7 @@ index 000000000..7d2f921c5
 +  "guest_os_type": "ubuntu-64",
 +  "iso_checksum": "5e38b55d57d94ff029719342357325ed3bda38fa80054f9330dc789cd2d43931",
 +  "iso_checksum_type": "sha256",
-+  "iso_url": "https://releases.ubuntu.com/22.04/ubuntu-22.04.2-live-server-amd64.iso",
++  "iso_url": "https://old-releases.ubuntu.com/releases/jammy/ubuntu-22.04.2-live-server-amd64.iso",
 +  "os_display_name": "Ubuntu 22.04",
 +  "shutdown_command": "shutdown -P now"
 +  }
@@ -306,7 +306,7 @@ index 000000000..38e827ef1
 +  "guest_os_type": "ubuntu-64",
 +  "iso_checksum": "5e38b55d57d94ff029719342357325ed3bda38fa80054f9330dc789cd2d43931",
 +  "iso_checksum_type": "sha256",
-+  "iso_url": "https://releases.ubuntu.com/22.04/ubuntu-22.04.2-live-server-amd64.iso",
++  "iso_url": "https://old-releases.ubuntu.com/releases/jammy/ubuntu-22.04.2-live-server-amd64.iso",
 +  "os_display_name": "Ubuntu 22.04",
 +  "shutdown_command": "shutdown -P now"
 +  }


### PR DESCRIPTION
Ubuntu released 22.04.3 today 3 hours ago and they migrated version 22.04.2 to the old-releases CDN, hence 22.04 builds can't find the 22.04.2 ISO image to pull from the current URL. Hence configuring the `iso_url` to be the old releases URL.

```bash
$ curl -sIo /dev/null  -w "%{http_code}" https://releases.ubuntu.com/22.04/ubuntu-22.04.2-live-server-amd64.iso
404

$ curl -sIo /dev/null -w "%{http_code}" https://old-releases.ubuntu.com/releases/jammy/ubuntu-22.04.2-live-server-amd64.iso  
200
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
