### PR TITLE
Fix condition for using prod image-builder for dev image builds

### DIFF
--- a/projects/aws/image-builder/CHECKSUMS
+++ b/projects/aws/image-builder/CHECKSUMS
@@ -1,2 +1,2 @@
-45661d41e2cb86ad4e6b9570365564bd7d8fd439fbbad97b94cf834c4cc5d008  _output/bin/image-builder/linux-amd64/image-builder
-58e1777dd64ad271a1d41f128fd55cf5849c46cb7c4728f65eed6ee2927c6c81  _output/bin/image-builder/linux-arm64/image-builder
+bc00332d9330797805807d970549e670581a8031f839becc3d18a9f204de17e1  _output/bin/image-builder/linux-amd64/image-builder
+27c05c8893233b9ea9d03bdd80c25a84aeaa528e21d9aa28c58f1646133cfd01  _output/bin/image-builder/linux-arm64/image-builder

--- a/projects/aws/image-builder/builder/utils.go
+++ b/projects/aws/image-builder/builder/utils.go
@@ -146,7 +146,7 @@ func (bo *BuildOptions) getGitCommitFromBundle() (string, string, error) {
 			bundleManifestUrl = r.BundleManifestUrl
 			break
 		} else {
-			if codebuild == "true" {
+			if codebuild == "true" || os.Getenv(eksaUseDevReleaseEnvVar) == "true" {
 				if strings.Contains(r.Version, eksAReleaseVersion) {
 					foundRelease = true
 					bundleManifestUrl = r.BundleManifestUrl


### PR DESCRIPTION
Fix condition for using prod image-builder for dev image builds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
