### PR TITLE
Backport script changes to support cross-version image builds

### DIFF
--- a/projects/kubernetes-sigs/image-builder/build/setup_packer_configs.sh
+++ b/projects/kubernetes-sigs/image-builder/build/setup_packer_configs.sh
@@ -28,8 +28,9 @@ IMAGE_BUILDER_DIR="${8? Specify eighth argument - image-builder directory}"
 
 CI="${CI:-false}"
 CODEBUILD_CI="${CODEBUILD_CI:-false}"
+EKSA_USE_DEV_RELEASE="${EKSA_USE_DEV_RELEASE:-false}"
 DEV_RELEASE=false
-if [[ $CI == true || $CODEBUILD_CI == true ]]; then
+if [[ $CI == true || $CODEBUILD_CI == true || $EKSA_USE_DEV_RELEASE == true ]]; then
   DEV_RELEASE=true
 fi
 


### PR DESCRIPTION
Backport image-builder script enhancements to release-0.16 that would allow building images for older EKS-A releases from newer versions of image-builder.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
