### PR TITLE
do not lock containerd version

### DIFF
--- a/projects/kubernetes-sigs/kind/CHECKSUMS
+++ b/projects/kubernetes-sigs/kind/CHECKSUMS
@@ -1,4 +1,5 @@
-a7d38d55a8806c9fa05da22f5393227b3726b983cea45b20fb068255062ec0a0  _output/bin/kind/linux-amd64/kind
-0ae5db801675aea333ea015968e158ed3f0acf603c783cde1c8dc7cad58e9de9  _output/bin/kind/linux-amd64/kindnetd
-3588a409a89793435a9a25d8cd61b93f6b116288ca5e964d09039230dc61ede6  _output/bin/kind/linux-arm64/kind
-8f8f1e0def40e0d7c5a05a97a13b43f82a5a9133bfebfe6c30733f1767677d5e  _output/bin/kind/linux-arm64/kindnetd
+d937d5fc56e33d6f43f1847fa9d3f27fe4ee545238fd5906aaeb7309f66042db  _output/bin/kind/linux-amd64/kind
+2c7ba783282034c923d38d3c1dfd715f0c13fe3402e554be45d99c69a017ba84  _output/bin/kind/linux-amd64/kindnetd
+8bb27c07715177dd1a9c20243954c4f35c9757fb1e71e803d52c158111f82360  _output/bin/kind/linux-arm64/kind
+873a2c98337c841811caad9ca819b0856e9d57d67a9d617ce2b2d1cd6bee5dd9  _output/bin/kind/linux-arm64/kindnetd
+

--- a/projects/kubernetes-sigs/kind/patches/0005-TEMP-lock-containerd-and-runc-version.patch
+++ b/projects/kubernetes-sigs/kind/patches/0005-TEMP-lock-containerd-and-runc-version.patch
@@ -16,7 +16,7 @@ index 0ab8ab87..2a86d2e5 100644
      && systemctl mask getty@tty1.service
      
 +RUN echo "force runc and containerd version ... " \
-+    && DEBIAN_FRONTEND=noninteractive clean-install containerd-1.6.19-1.amzn2023.0.1 runc-1.1.5-1.amzn2023.0.1
++    && DEBIAN_FRONTEND=noninteractive clean-install runc-1.1.5-1.amzn2023.0.1
  
  RUN echo "Enabling services ... " \
      && systemctl enable kubelet.service \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Follow up to https://github.com/aws/eks-anywhere-build-tooling/pull/2406

Tested this on Al2 and the newer containerd version does not seem to be a problem.  This makes sense because the issue we looks very much like the runc 1.1.6/1.1.7 misc controller issue seen in kind/kubernetes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
