### PR TITLE
adds retries and timeout to packer image-builder

### DIFF
--- a/projects/kubernetes-sigs/image-builder/buildspecs/ami.yml
+++ b/projects/kubernetes-sigs/image-builder/buildspecs/ami.yml
@@ -9,11 +9,6 @@ env:
     GOPATH: "/home/imagebuilder/go"
 
 phases:
-  install:
-    run-as: root
-    commands:
-      - chmod 755 /usr/lib/python3.9/site-packages
-      - chown -R imagebuilder:imagebuilder /home/imagebuilder/.packer.d
   pre_build:
     commands:
       - git config --global credential.helper '!aws codecommit credential-helper $@'

--- a/projects/kubernetes-sigs/image-builder/buildspecs/ova.yml
+++ b/projects/kubernetes-sigs/image-builder/buildspecs/ova.yml
@@ -15,11 +15,6 @@ env:
     VSPHERE_CONNECTION_DATA: "vsphere_ci_beta_connection:vsphere_connection_data"
 
 phases:
-  install:
-    run-as: root
-    commands:
-      - chmod 755 /usr/lib/python3.9/site-packages
-      - chown -R imagebuilder:imagebuilder /home/imagebuilder/.packer.d
   pre_build:
     commands:
       - git config --global credential.helper '!aws codecommit credential-helper $@'

--- a/projects/kubernetes-sigs/image-builder/patches/0001-Add-goss-validations-for-EKS-D-artifacts.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0001-Add-goss-validations-for-EKS-D-artifacts.patch
@@ -1,7 +1,7 @@
 From 77387af616bd52c47525a2c5c86e430d3e4577e4 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 18:36:56 -0800
-Subject: [PATCH 01/25] Add goss validations for EKS-D artifacts
+Subject: [PATCH 01/26] Add goss validations for EKS-D artifacts
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0002-Output-vsphere-builds-to-content-library-instead-of-.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0002-Output-vsphere-builds-to-content-library-instead-of-.patch
@@ -1,7 +1,7 @@
 From c1cf6093ad760214200f68f5f826c7d1c8b4f73f Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:00:12 -0800
-Subject: [PATCH 02/25] Output vsphere builds to content library instead of
+Subject: [PATCH 02/26] Output vsphere builds to content library instead of
  exports
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0003-Create-etc-pki-tls-certs-dir-as-part-of-image-builds.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0003-Create-etc-pki-tls-certs-dir-as-part-of-image-builds.patch
@@ -1,7 +1,7 @@
 From f4ba98d94350e21f0b589a61ab1a1b35e74333b3 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:05:13 -0800
-Subject: [PATCH 03/25] Create /etc/pki/tls/certs dir as part of image-builds
+Subject: [PATCH 03/26] Create /etc/pki/tls/certs dir as part of image-builds
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0004-Add-etcdadm-and-etcd.tar.gz-to-image-for-unstacked-e.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0004-Add-etcdadm-and-etcd.tar.gz-to-image-for-unstacked-e.patch
@@ -1,7 +1,7 @@
 From 6067b53b55e9d381ebd1be1ccc235ce40579ca9c Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:12:53 -0800
-Subject: [PATCH 04/25] Add etcdadm and etcd.tar.gz to image for unstacked etcd
+Subject: [PATCH 04/26] Add etcdadm and etcd.tar.gz to image for unstacked etcd
  support
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0005-Additional-EKS-A-specific-goss-validations.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0005-Additional-EKS-A-specific-goss-validations.patch
@@ -1,7 +1,7 @@
 From 73436f46bf8fd6f0251a55c4dd0a2b3b9b691188 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:26:09 -0800
-Subject: [PATCH 05/25] Additional EKS-A specific goss validations
+Subject: [PATCH 05/26] Additional EKS-A specific goss validations
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0006-Tweak-Product-info-in-OVF.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0006-Tweak-Product-info-in-OVF.patch
@@ -1,7 +1,7 @@
 From dc5a1d7f5501600e662e509cc21369968698c0dc Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:29:16 -0800
-Subject: [PATCH 06/25] Tweak Product info in OVF
+Subject: [PATCH 06/26] Tweak Product info in OVF
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0007-Support-crictl-validation-from-input-checksum.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0007-Support-crictl-validation-from-input-checksum.patch
@@ -1,7 +1,7 @@
 From 649791272ebeeb070f58d4eb096c188507c5c4c7 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Fri, 2 Sep 2022 14:32:21 -0700
-Subject: [PATCH 07/25] Support crictl validation from input checksum
+Subject: [PATCH 07/26] Support crictl validation from input checksum
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0008-Exclude-kernel-and-cloud-init-from-yum-updates.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0008-Exclude-kernel-and-cloud-init-from-yum-updates.patch
@@ -1,7 +1,7 @@
 From 57394707343d15a11f5eaa95e7eecfac27532c1e Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 6 Dec 2022 15:42:02 -0600
-Subject: [PATCH 08/25] Exclude kernel and cloud-init from yum updates
+Subject: [PATCH 08/26] Exclude kernel and cloud-init from yum updates
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0009-Patch-cloud-init-systemd-unit-to-wait-for-network-ma.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0009-Patch-cloud-init-systemd-unit-to-wait-for-network-ma.patch
@@ -1,7 +1,7 @@
 From c5d465abe5c4990407b0bb1ae8a5f509dd0e55a1 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Mon, 9 Jan 2023 14:11:18 -0600
-Subject: [PATCH 09/25] Patch cloud-init systemd unit to wait for network
+Subject: [PATCH 09/26] Patch cloud-init systemd unit to wait for network
  manager online
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0010-Add-instance-metadata-options-to-Packer-config.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0010-Add-instance-metadata-options-to-Packer-config.patch
@@ -1,7 +1,7 @@
 From 3b894353bd052b36d4fc6afe61888ddd4eba67e2 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Feb 2023 01:39:15 -0800
-Subject: [PATCH 10/25] Add instance metadata options to Packer config
+Subject: [PATCH 10/26] Add instance metadata options to Packer config
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0011-Rename-Snow-node-image-to-reflect-appropriate-CAPI-p.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0011-Rename-Snow-node-image-to-reflect-appropriate-CAPI-p.patch
@@ -1,7 +1,7 @@
 From 174958df5393fe070de05dc38480195a835f14eb Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Fri, 10 Feb 2023 16:08:18 -0800
-Subject: [PATCH 11/25] Rename Snow node image to reflect appropriate CAPI
+Subject: [PATCH 11/26] Rename Snow node image to reflect appropriate CAPI
  provider
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0012-Add-EKS-A-specific-inline-Goss-vars-to-all-supported.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0012-Add-EKS-A-specific-inline-Goss-vars-to-all-supported.patch
@@ -1,7 +1,7 @@
 From 2d18d5c4c61cf2415e378a80675eca795de73db5 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Mar 2023 19:27:50 -0800
-Subject: [PATCH 12/25] Add EKS-A specific inline Goss vars to all supported
+Subject: [PATCH 12/26] Add EKS-A specific inline Goss vars to all supported
  providers
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0013-Use-tar.gz-extension-for-CNI-plugins-tarball.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0013-Use-tar.gz-extension-for-CNI-plugins-tarball.patch
@@ -1,7 +1,7 @@
 From d1e8e6db38ae280f966ccfca2cae39111ed34868 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 9 Mar 2023 16:05:22 -0800
-Subject: [PATCH 13/25] Use tar.gz extension for CNI plugins tarball
+Subject: [PATCH 13/26] Use tar.gz extension for CNI plugins tarball
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0014-uses-latest-ubuntu-22.04-iso.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0014-uses-latest-ubuntu-22.04-iso.patch
@@ -1,7 +1,7 @@
 From 5f40679680c03ba0e28613ab48bce4e329db3c79 Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Fri, 23 Jun 2023 10:50:08 -0500
-Subject: [PATCH 14/25] uses latest ubuntu 22.04 iso
+Subject: [PATCH 14/26] uses latest ubuntu 22.04 iso
 
 ---
  images/capi/packer/ova/ubuntu-2204-efi.json | 4 ++--

--- a/projects/kubernetes-sigs/image-builder/patches/0015-adds-support-for-raw-ubuntu-22.04-builds.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0015-adds-support-for-raw-ubuntu-22.04-builds.patch
@@ -1,7 +1,7 @@
 From 515ed374314c8bad6b49719666c6efbad64bb954 Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Fri, 16 Jun 2023 15:27:15 -0500
-Subject: [PATCH 15/25] adds support for raw ubuntu 22.04 builds
+Subject: [PATCH 15/26] adds support for raw ubuntu 22.04 builds
 
 ---
  images/capi/Makefile                          |   6 +-

--- a/projects/kubernetes-sigs/image-builder/patches/0016-sets-OS_VERSION-for-goss-validation-on-raw-image-bui.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0016-sets-OS_VERSION-for-goss-validation-on-raw-image-bui.patch
@@ -1,7 +1,7 @@
 From e0d2002ce4c1a8a85f9f000af601bec976180402 Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Wed, 28 Jun 2023 12:42:22 -0500
-Subject: [PATCH 16/25] sets OS_VERSION for goss validation on raw image builds
+Subject: [PATCH 16/26] sets OS_VERSION for goss validation on raw image builds
 
 ---
  images/capi/packer/raw/packer.json              | 1 +

--- a/projects/kubernetes-sigs/image-builder/patches/0017-Disable-UDP-offload-service-for-Redhat-and-Ubuntu.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0017-Disable-UDP-offload-service-for-Redhat-and-Ubuntu.patch
@@ -1,7 +1,7 @@
 From 0c89186ab29acab4cb2a29bb1703659d2f024383 Mon Sep 17 00:00:00 2001
 From: Taylor Neyland <tneyla@amazon.com>
 Date: Wed, 19 Jul 2023 12:51:30 -0500
-Subject: [PATCH 17/25] Disable UDP offload service for Redhat and Ubuntu
+Subject: [PATCH 17/26] Disable UDP offload service for Redhat and Ubuntu
 
 ---
  .../system/disable-udp-offload-redhat.service  | 15 +++++++++++++++

--- a/projects/kubernetes-sigs/image-builder/patches/0018-Add-dracut-cmd-to-generate-initramfs-with-all-driver.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0018-Add-dracut-cmd-to-generate-initramfs-with-all-driver.patch
@@ -1,7 +1,7 @@
 From fbd4f5a4bc97e78a65ac5464927275c5ea2ead2f Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Wed, 6 Sep 2023 11:09:02 -0500
-Subject: [PATCH 18/25] Add dracut cmd to generate initramfs with all drivers
+Subject: [PATCH 18/26] Add dracut cmd to generate initramfs with all drivers
  for rhel raw
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0019-Add-proxy-register-with-satellite-and-pull-packages-.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0019-Add-proxy-register-with-satellite-and-pull-packages-.patch
@@ -1,7 +1,7 @@
 From 4e1086adafdb2b6b8462b0da2b18cc9b926e7ec0 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Fri, 11 Aug 2023 11:59:20 -0500
-Subject: [PATCH 19/25] Add proxy, register with satellite, and pull packages
+Subject: [PATCH 19/26] Add proxy, register with satellite, and pull packages
  from satellite support to redhat subscription manager
 
 When pulling from satellite the os version must be set using `rhsm_server_release_version`

--- a/projects/kubernetes-sigs/image-builder/patches/0020-Ubuntu-switch-to-offline-install-when-mirrors-are-un.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0020-Ubuntu-switch-to-offline-install-when-mirrors-are-un.patch
@@ -1,7 +1,7 @@
 From e5a649ccfc3d497a24c15db8db8c878daef2ddb4 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Mon, 18 Sep 2023 10:38:42 -0500
-Subject: [PATCH 20/25] Ubuntu switch to offline-install when mirrors are
+Subject: [PATCH 20/26] Ubuntu switch to offline-install when mirrors are
  unavailable
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0021-Default-Flatcar-version-to-avoid-pulling-from-intern.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0021-Default-Flatcar-version-to-avoid-pulling-from-intern.patch
@@ -1,7 +1,7 @@
 From f815a68696ad4269f4da042aa5fe0843f1636095 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Wed, 20 Sep 2023 10:33:44 -0500
-Subject: [PATCH 21/25] Default Flatcar version to avoid pulling from internet
+Subject: [PATCH 21/26] Default Flatcar version to avoid pulling from internet
  on every make
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0022-TEMP-skip-python-3.9-check-if-ansible-already-instal.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0022-TEMP-skip-python-3.9-check-if-ansible-already-instal.patch
@@ -1,7 +1,7 @@
 From 18d7a763c7f856e52c6080fffa23c32eac609e76 Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
 Date: Fri, 13 Oct 2023 13:11:34 -0500
-Subject: [PATCH 22/25] TEMP: skip python 3.9 check if ansible already
+Subject: [PATCH 22/26] TEMP: skip python 3.9 check if ansible already
  installed
 
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0023-Nutanix-RHEL-support-for-AWS-image-builder.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0023-Nutanix-RHEL-support-for-AWS-image-builder.patch
@@ -1,7 +1,7 @@
 From c6c3d38b240d23520a69760ce740b8f479920e5a Mon Sep 17 00:00:00 2001
 From: Ilya Alekseyev <ilya.alekseyev@nutanix.com>
 Date: Wed, 11 Oct 2023 22:07:22 -0400
-Subject: [PATCH 23/25] Nutanix RHEL support for AWS image-builder
+Subject: [PATCH 23/26] Nutanix RHEL support for AWS image-builder
 
 ---
  images/capi/packer/nutanix/packer.json | 1 +

--- a/projects/kubernetes-sigs/image-builder/patches/0024-Fix-redhat-9-cloud-init-feature-flags-bug.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0024-Fix-redhat-9-cloud-init-feature-flags-bug.patch
@@ -1,7 +1,7 @@
 From ac7f6a843dc531ee813346ff66aa9b53164e3cb0 Mon Sep 17 00:00:00 2001
 From: Ilya Alekseyev <ilya.alekseyev@nutanix.com>
 Date: Thu, 12 Oct 2023 09:12:01 -0400
-Subject: [PATCH 24/25] Fix redhat 9 cloud-init feature flags bug
+Subject: [PATCH 24/26] Fix redhat 9 cloud-init feature flags bug
 
 ---
  images/capi/ansible/roles/providers/tasks/main.yml | 13 +++++++++++--

--- a/projects/kubernetes-sigs/image-builder/patches/0025-Fix-ensure-iptables-present-for-rhel.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0025-Fix-ensure-iptables-present-for-rhel.patch
@@ -1,7 +1,7 @@
 From 442ef46609a5ae6d518a5bef9d02568993e05994 Mon Sep 17 00:00:00 2001
 From: Ilya Alekseyev <ilya.alekseyev@nutanix.com>
 Date: Fri, 13 Oct 2023 12:20:42 -0400
-Subject: [PATCH 25/25] Fix ensure iptables present for rhel
+Subject: [PATCH 25/26] Fix ensure iptables present for rhel
 
 ---
  images/capi/ansible/roles/setup/tasks/redhat.yml | 14 ++++++++++++++

--- a/projects/kubernetes-sigs/image-builder/patches/0026-adds-retries-and-timeout-to-packer-image-builder.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0026-adds-retries-and-timeout-to-packer-image-builder.patch
@@ -1,0 +1,203 @@
+From 0ec8f5d039faa50ebaaaaa3e4738bc2be5c219ae Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Mon, 21 Aug 2023 18:40:07 -0500
+Subject: [PATCH 26/26]  adds retries and timeout to packer image-builder
+
+---
+ images/capi/packer/ami/packer.json        |  2 ++
+ images/capi/packer/ova/packer-common.json |  3 ++-
+ images/capi/packer/ova/packer-node.json   | 22 ++++++++++++++++------
+ images/capi/packer/qemu/packer.json       |  7 ++++++-
+ images/capi/packer/raw/packer.json        |  7 ++++++-
+ 5 files changed, 32 insertions(+), 9 deletions(-)
+
+diff --git a/images/capi/packer/ami/packer.json b/images/capi/packer/ami/packer.json
+index cab705721..ce7e1e4fd 100644
+--- a/images/capi/packer/ami/packer.json
++++ b/images/capi/packer/ami/packer.json
+@@ -105,7 +105,9 @@
+         "--scp-extra-args",
+         "{{user `ansible_scp_extra_args`}}"
+       ],
++      "max_retries": 5,
+       "playbook_file": "./ansible/node.yml",
++      "timeout": "30m",
+       "type": "ansible"
+     },
+     {
+diff --git a/images/capi/packer/ova/packer-common.json b/images/capi/packer/ova/packer-common.json
+index 9505b4245..eabb600fd 100644
+--- a/images/capi/packer/ova/packer-common.json
++++ b/images/capi/packer/ova/packer-common.json
+@@ -22,8 +22,9 @@
+   "remote_type": "",
+   "remote_username": "",
+   "skip_compaction": "false",
++  "ssh_handshake_attempts": "100",
+   "ssh_password": "builder",
+-  "ssh_timeout": "60m",
++  "ssh_timeout": "20m",
+   "ssh_username": "builder",
+   "vmx_version": "15",
+   "vnc_bind_address": "127.0.0.1",
+diff --git a/images/capi/packer/ova/packer-node.json b/images/capi/packer/ova/packer-node.json
+index 0567fcd56..b1b0f9a4d 100644
+--- a/images/capi/packer/ova/packer-node.json
++++ b/images/capi/packer/ova/packer-node.json
+@@ -18,8 +18,9 @@
+       "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'userdel -f -r {{user `ssh_username`}} && rm -f /etc/sudoers.d/{{user `ssh_username` }} && {{user `shutdown_command`}}'",
+       "skip_compaction": "{{user `skip_compaction`}}",
+       "source_path": "{{ user `source_path`}}",
++      "ssh_handshake_attempts": "100",
+       "ssh_password": "{{user `ssh_password`}}",
+-      "ssh_timeout": "4h",
++      "ssh_timeout": "20m",
+       "ssh_username": "{{user `ssh_username`}}",
+       "type": "vmware-vmx",
+       "vm_name": "{{user `build_version`}}",
+@@ -67,8 +68,9 @@
+       "remote_username": "{{user `remote_username`}}",
+       "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c '{{user `shutdown_command`}}'",
+       "skip_compaction": "{{user `skip_compaction`}}",
++      "ssh_handshake_attempts": "100",
+       "ssh_password": "{{user `ssh_password`}}",
+-      "ssh_timeout": "4h",
++      "ssh_timeout": "20m",
+       "ssh_username": "{{user `ssh_username`}}",
+       "type": "vmware-iso",
+       "version": "{{user `vmx_version`}}",
+@@ -115,8 +117,9 @@
+       "remote_username": "{{user `remote_username`}}",
+       "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'userdel -f -r {{user `ssh_username`}} && rm -f /etc/sudoers.d/{{user `ssh_username` }} && {{user `shutdown_command`}}'",
+       "skip_compaction": "{{user `skip_compaction`}}",
++      "ssh_handshake_attempts": "100",
+       "ssh_password": "{{user `ssh_password`}}",
+-      "ssh_timeout": "4h",
++      "ssh_timeout": "20m",
+       "ssh_username": "{{user `ssh_username`}}",
+       "type": "vmware-iso",
+       "version": "{{user `vmx_version`}}",
+@@ -174,8 +177,9 @@
+       "resource_pool": "{{user `resource_pool`}}",
+       "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c '{{user `shutdown_command`}}'",
+       "ssh_clear_authorized_keys": "false",
++      "ssh_handshake_attempts": "100",
+       "ssh_password": "{{user `ssh_password`}}",
+-      "ssh_timeout": "4h",
++      "ssh_timeout": "20m",
+       "ssh_username": "{{user `ssh_username`}}",
+       "storage": [
+         {
+@@ -238,7 +242,8 @@
+       "resource_pool": "{{user `resource_pool`}}",
+       "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'userdel -f -r {{user `ssh_username`}} && rm -f /etc/sudoers.d/{{user `ssh_username` }} && {{user `shutdown_command`}}'",
+       "ssh_password": "{{user `ssh_password`}}",
+-      "ssh_timeout": "4h",
++      "ssh_handshake_attempts": "100",
++      "ssh_timeout": "20m",
+       "ssh_username": "{{user `ssh_username`}}",
+       "storage": [
+         {
+@@ -280,7 +285,8 @@
+       "resource_pool": "{{user `resource_pool`}}",
+       "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'userdel -f -r {{user `ssh_username`}} && rm -f /etc/sudoers.d/{{user `ssh_username` }} && {{user `shutdown_command`}}'",
+       "ssh_password": "{{user `ssh_password`}}",
+-      "ssh_timeout": "4h",
++      "ssh_handshake_attempts": "100",
++      "ssh_timeout": "20m",
+       "ssh_username": "{{user `ssh_username`}}",
+       "template": "{{user `template`}}",
+       "type": "vsphere-clone",
+@@ -390,7 +396,9 @@
+         "--scp-extra-args",
+         "{{user `ansible_scp_extra_args`}}"
+       ],
++      "max_retries": 5,
+       "playbook_file": "./ansible/firstboot.yml",
++      "timeout": "30m",
+       "type": "ansible",
+       "user": "{{user `ssh_username`}}"
+     },
+@@ -423,7 +431,9 @@
+         "--scp-extra-args",
+         "{{user `ansible_scp_extra_args`}}"
+       ],
++      "max_retries": 5,
+       "playbook_file": "./ansible/node.yml",
++      "timeout": "5m",
+       "type": "ansible",
+       "user": "{{user `ssh_username`}}"
+     },
+diff --git a/images/capi/packer/qemu/packer.json b/images/capi/packer/qemu/packer.json
+index dd93fc8da..599fd5f6d 100644
+--- a/images/capi/packer/qemu/packer.json
++++ b/images/capi/packer/qemu/packer.json
+@@ -24,8 +24,9 @@
+       "output_directory": "{{user `output_directory`}}",
+       "qemu_binary": "{{user `qemu_binary`}}",
+       "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'usermod -L {{user `ssh_username`}} && {{user `shutdown_command`}}'",
++      "ssh_handshake_attempts": "100",
+       "ssh_password": "{{user `ssh_password`}}",
+-      "ssh_timeout": "2h",
++      "ssh_timeout": "20m",
+       "ssh_username": "{{user `ssh_username`}}",
+       "type": "qemu",
+       "vm_name": "{{user `vm_name`}}"
+@@ -84,7 +85,9 @@
+         "--scp-extra-args",
+         "{{user `ansible_scp_extra_args`}}"
+       ],
++      "max_retries": 5,
+       "playbook_file": "./ansible/firstboot.yml",
++      "timeout": "30m",
+       "type": "ansible",
+       "user": "builder"
+     },
+@@ -111,7 +114,9 @@
+         "--scp-extra-args",
+         "{{user `ansible_scp_extra_args`}}"
+       ],
++      "max_retries": 5,
+       "playbook_file": "./ansible/node.yml",
++      "timeout": "30m",
+       "type": "ansible",
+       "user": "builder"
+     },
+diff --git a/images/capi/packer/raw/packer.json b/images/capi/packer/raw/packer.json
+index 83aa6b4fb..5e983fa59 100644
+--- a/images/capi/packer/raw/packer.json
++++ b/images/capi/packer/raw/packer.json
+@@ -24,8 +24,9 @@
+       "output_directory": "{{user `output_directory`}}",
+       "qemu_binary": "{{user `qemu_binary`}}",
+       "shutdown_command": "echo '{{user `ssh_password`}}' | sudo -S -E sh -c 'usermod -L {{user `ssh_username`}} && {{user `shutdown_command`}}'",
++      "ssh_handshake_attempts": "100",
+       "ssh_password": "{{user `ssh_password`}}",
+-      "ssh_timeout": "2h",
++      "ssh_timeout": "20m",
+       "ssh_username": "{{user `ssh_username`}}",
+       "type": "qemu",
+       "vm_name": "{{user `vm_name`}}"
+@@ -71,7 +72,9 @@
+         "--scp-extra-args",
+         "{{user `ansible_scp_extra_args`}}"
+       ],
++      "max_retries": 5,
+       "playbook_file": "./ansible/firstboot.yml",
++      "timeout": "30m",
+       "type": "ansible",
+       "user": "builder"
+     },
+@@ -97,7 +100,9 @@
+         "--scp-extra-args",
+         "{{user `ansible_scp_extra_args`}}"
+       ],
++      "max_retries": 5,
+       "playbook_file": "./ansible/node.yml",
++      "timeout": "30m",
+       "type": "ansible",
+       "user": "builder"
+     },
+-- 
+2.42.0
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This adds retries to initial ansible tasks as well as changes the ssh_timeout, which we do see run forever sometimes, to 20 mins which matches the nutanix config.  I *think* this may (automatically?) retry in the cases where we see timeouts and failures today. It may just make the failure quicker, in which case we can add a followup PR to add retries.  

Want to try this first and see what happens.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
