### PR TITLE
Add patch for writefile action

### DIFF
--- a/projects/tinkerbell/hub/CHECKSUMS
+++ b/projects/tinkerbell/hub/CHECKSUMS
@@ -2,4 +2,4 @@
 e004f52237340707b753fd226c6c369931d9d6c1f966615d6475d4c2fd13dcf0  _output/bin/hub/linux-amd64/image2disk
 dcfec6b7c4fc2452defdaaec7a611fbe6cdf00e8e5dae86768447578849a4766  _output/bin/hub/linux-amd64/kexec
 cdf00127e3c815c792e3eb7e61fa858095a62afb98bda2714f92e463ca95f0cb  _output/bin/hub/linux-amd64/oci2disk
-9bbedaca313d22dd326665c84f308808bb73a593436d881b8929a887844b8ba6  _output/bin/hub/linux-amd64/writefile
+5d1d786bf1b4c7e658b01282ff9a4df6342903115a8660031e60be70c04b9cf7  _output/bin/hub/linux-amd64/writefile

--- a/projects/tinkerbell/hub/patches/0012-Allow-BOOTCONFIG_CONTENTS-and-CONTENTS-to-be-checked.patch
+++ b/projects/tinkerbell/hub/patches/0012-Allow-BOOTCONFIG_CONTENTS-and-CONTENTS-to-be-checked.patch
@@ -1,0 +1,31 @@
+From 1f42fd3edda7bd83a1b1770e6038c7c6d6de6ece Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Mon, 28 Aug 2023 11:05:36 -0600
+Subject: [PATCH] Allow BOOTCONFIG_CONTENTS and CONTENTS to be checked:
+
+Without this a Bottlerocket action that only
+specifies BOOTCONFIG_CONTENTS will fail.
+
+Signed-off-by: Prow Bot <prow@amazonaws.com>
+---
+ actions/writefile/v1/main.go | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/actions/writefile/v1/main.go b/actions/writefile/v1/main.go
+index bf9f4ac..d5f923c 100644
+--- a/actions/writefile/v1/main.go
++++ b/actions/writefile/v1/main.go
+@@ -259,8 +259,8 @@ func main() {
+ 		}
+ 	}
+ 
+-	if contents == "" {
+-		log.Fatal("No content. Either the CONTENTS env var was not set or a data retrieval action failed.")
++	if contents == "" && bootconfig == "" {
++		log.Fatal("No content. Either the CONTENTS or BOOTCONFIG_CONTENTS env vars were not set or a data retrieval action failed.")
+ 	}
+ 
+ 	// If bootconfig is set, contents will be empty and will serve as output initrd file provided
+-- 
+2.41.0
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add patch for writefile action to fix issue when `CONTENTS` is not set but `BOOTCONFIG_CONTENTS` is set.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
