### PR TITLE
Adds pre/post boot and node roles

### DIFF
--- a/projects/aws/image-builder/builder/types.go
+++ b/projects/aws/image-builder/builder/types.go
@@ -71,6 +71,7 @@ type VsphereConfig struct {
 	RhelConfig
 	ProxyConfig
 	ExtraPackagesConfig
+	ExtraOverridesConfig
 }
 
 type BaremetalConfig struct {
@@ -79,6 +80,7 @@ type BaremetalConfig struct {
 	RhelConfig
 	ProxyConfig
 	ExtraPackagesConfig
+	ExtraOverridesConfig
 }
 
 type CloudstackConfig struct {
@@ -87,6 +89,7 @@ type CloudstackConfig struct {
 	RhelConfig
 	ProxyConfig
 	ExtraPackagesConfig
+	ExtraOverridesConfig
 }
 
 type IsoConfig struct {
@@ -114,6 +117,7 @@ type NutanixConfig struct {
 	NutanixSubnetName string `json:"nutanix_subnet_name"`
 	ProxyConfig
 	ExtraPackagesConfig
+	ExtraOverridesConfig
 }
 
 type AMIConfig struct {
@@ -130,6 +134,7 @@ type AMIConfig struct {
 
 	ProxyConfig
 	ExtraPackagesConfig
+	ExtraOverridesConfig
 }
 
 type ExtraPackagesConfig struct {
@@ -153,4 +158,13 @@ type RhsmConfig struct {
 	ServerReleaseVersion string `json:"rhsm_server_release_version,omitempty"`
 	ActivationKey        string `json:"rhsm_activation_key,omitempty"`
 	OrgId                string `json:"rhsm_org_id,omitempty"`
+}
+
+type ExtraOverridesConfig struct {
+	FirstbootCustomRolesPre  string `json:"firstboot_custom_roles_pre,omitempty"`
+	FirstbootCustomRolesPost string `json:"firstboot_custom_roles_post,omitempty"`
+	NodeCustomRolesPre       string `json:"node_custom_roles_pre,omitempty"`
+	NodeCustomRolesPost      string `json:"node_custom_roles_post,omitempty"`
+	DisablePublicRepos       string `json:"disable_public_repos,omitempty"`
+	ReenablePublicRepos      string `json:"reenable_public_repos,omitempty"`
 }


### PR DESCRIPTION
*Issues addressed:*

* #2301 
* #2372

*Description of changes:*
As per https://github.com/kubernetes-sigs/image-builder/issues/894 issue upstream project opened to use custom Ansible roles pre/post boot of the node and also pre/post node provisioning.

This opens doors to customize image built for custom requirements, for example if deployment needs to happen in offline environment that has no access to the internet and would require to update system with required changes to look for packages on internal proxies instead.

Also allows to provide extra updates to the system before Kubernetes is installed along with extra tweaks after.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
