### PR TITLE
Add dracut cmd to generate initramfs with drivers for RHEL raw builds

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0020-Add-dracut-cmd-to-generate-initramfs-with-all-driver.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0020-Add-dracut-cmd-to-generate-initramfs-with-all-driver.patch
@@ -1,0 +1,42 @@
+From 67abe004ac8cec4e9434f29356e327d5b4d86803 Mon Sep 17 00:00:00 2001
+From: Vignesh Goutham Ganesh <vgg@amazon.com>
+Date: Wed, 6 Sep 2023 11:09:02 -0500
+Subject: [PATCH] Add dracut cmd to generate initramfs with all drivers for
+ rhel raw
+
+Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
+---
+ images/capi/ansible/roles/providers/tasks/raw.yml | 4 ++++
+ images/capi/packer/raw/raw-rhel-8.json            | 1 +
+ 2 files changed, 5 insertions(+)
+
+diff --git a/images/capi/ansible/roles/providers/tasks/raw.yml b/images/capi/ansible/roles/providers/tasks/raw.yml
+index d52a270ef..0a7211379 100644
+--- a/images/capi/ansible/roles/providers/tasks/raw.yml
++++ b/images/capi/ansible/roles/providers/tasks/raw.yml
+@@ -35,6 +35,10 @@
+     - cloud-utils-growpart
+   when: ansible_os_family == "RedHat"
+ 
++- name: Run dracut cmd to regenerate initramfs with all drivers - needed when converting to different hypervisor templates
++  shell: dracut --force --no-hostonly
++  when: ansible_os_family == "RedHat"
++
+ #- name: Unlock password
+ #  replace:
+ #    path: /etc/cloud/cloud.cfg
+diff --git a/images/capi/packer/raw/raw-rhel-8.json b/images/capi/packer/raw/raw-rhel-8.json
+index 54a7c0d80..e1f1735c7 100644
+--- a/images/capi/packer/raw/raw-rhel-8.json
++++ b/images/capi/packer/raw/raw-rhel-8.json
+@@ -2,6 +2,7 @@
+   "boot_command_prefix": "<tab> text inst.ks=",
+   "boot_command_suffix": "/8/ks.cfg<enter><wait>",
+   "build_name": "rhel-8",
++  "build_target": "raw",
+   "distro_name": "rhel",
+   "distro_version": "8",
+   "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8",
+-- 
+2.39.2 (Apple Git-143)
+


### PR DESCRIPTION
*Issue* #2462 

*Description of changes:*
Raw builds are run on KVM vms. RHEL 8.x ships with dracut that builds initramfs with default host-only mode set to true. This causes the initramfs to only include drivers that are required to run kvm infrastructure. When the disks are exported and booted on a metal server, the OS fails to boot up due to this missing drivers.

This change runs dracut with --no-hostonly to rebuild initramfs to include all drivers

This PR also fixes another issue that bubbled up during testing the dracut changes. The build_type was not set to raw in the rhel json file, causing providers role to run qemu tasks as opposed to raw tasks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
