### PR TITLE
Install Ubuntu offline when mirrors are unreachable

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0022-Ubuntu-switch-to-offline-install-when-mirrors-are-un.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0022-Ubuntu-switch-to-offline-install-when-mirrors-are-un.patch
@@ -1,0 +1,40 @@
+From e49e4c268f4f9c4e71b68492bbb4665b5a49c729 Mon Sep 17 00:00:00 2001
+From: Vignesh Goutham Ganesh <vgg@amazon.com>
+Date: Mon, 18 Sep 2023 10:38:42 -0500
+Subject: [PATCH] Ubuntu switch to offline-install when mirrors are unavailable
+
+Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
+---
+ images/capi/packer/raw/linux/ubuntu/http/22.04.efi/user-data | 2 ++
+ images/capi/packer/raw/linux/ubuntu/http/22.04/user-data     | 2 ++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/images/capi/packer/raw/linux/ubuntu/http/22.04.efi/user-data b/images/capi/packer/raw/linux/ubuntu/http/22.04.efi/user-data
+index 8b699a18a..d14d0fa49 100644
+--- a/images/capi/packer/raw/linux/ubuntu/http/22.04.efi/user-data
++++ b/images/capi/packer/raw/linux/ubuntu/http/22.04.efi/user-data
+@@ -79,6 +79,8 @@ autoinstall:
+       device: format-0
+       type: mount
+       id: mount-0
++  apt:
++    fallback: offline-install
+   updates: "all"
+   ssh:
+     install-server: true
+diff --git a/images/capi/packer/raw/linux/ubuntu/http/22.04/user-data b/images/capi/packer/raw/linux/ubuntu/http/22.04/user-data
+index e2838e3c4..a5ed32346 100644
+--- a/images/capi/packer/raw/linux/ubuntu/http/22.04/user-data
++++ b/images/capi/packer/raw/linux/ubuntu/http/22.04/user-data
+@@ -58,6 +58,8 @@ autoinstall:
+         id: mount-0
+         device: format-0
+         path: /
++  apt:
++    fallback: offline-install
+   updates: 'all'
+   ssh:
+     install-server: true
+-- 
+2.39.2 (Apple Git-143)
+


### PR DESCRIPTION
*Description of changes:*
Image builder tries Ubuntu mirrors when installing the OS from ISO onto vm. This change prevents failing the install when mirrors are unreachable, and proceeds to install only from the ISO.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
