### PR TITLE
Default Flatcar version to avoid polling internet on all make commands

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0023-Default-Flatcar-version-to-avoid-pulling-from-intern.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0023-Default-Flatcar-version-to-avoid-pulling-from-intern.patch
@@ -1,0 +1,27 @@
+From d4c2ccc4ffd732f5f702f8eec58d6222c7336cfb Mon Sep 17 00:00:00 2001
+From: Vignesh Goutham Ganesh <vgg@amazon.com>
+Date: Wed, 20 Sep 2023 10:33:44 -0500
+Subject: [PATCH] Default Flatcar version to avoid pulling from internet on
+ every make
+
+Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
+---
+ images/capi/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/images/capi/Makefile b/images/capi/Makefile
+index 4f90365aa..16b020fe2 100644
+--- a/images/capi/Makefile
++++ b/images/capi/Makefile
+@@ -307,7 +307,7 @@ WINDOWS_VERSIONS		:=	windows-2019 windows-2004 windows-2022
+ 
+ # Set Flatcar Container Linux channel and version if not supplied
+ FLATCAR_CHANNEL ?= stable
+-FLATCAR_VERSION ?= current
++FLATCAR_VERSION ?= 3510.2.7
+ ifeq ($(FLATCAR_VERSION),current)
+ override FLATCAR_VERSION := $(shell hack/image-grok-latest-flatcar-version.sh $(FLATCAR_CHANNEL))
+ endif
+-- 
+2.39.2 (Apple Git-143)
+


### PR DESCRIPTION
*Description of changes:*
On every image-builder make command, make pulls the manifest json to determine the latest Flatcar version. This is an issue when trying to run airgapped builds. This change defaults the version to the current latest.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
