### PR TITLE
Add packages ECR to credHelpers list

### DIFF
--- a/config/docker-ecr-config.json
+++ b/config/docker-ecr-config.json
@@ -5,6 +5,7 @@
         "751815209827.dkr.ecr.us-east-1.amazonaws.com": "ecr-login",
         "857151390494.dkr.ecr.us-west-2.amazonaws.com": "ecr-login",
         "382577505035.dkr.ecr.us-west-2.amazonaws.com": "ecr-login",
+        "067575901363.dkr.ecr.us-west-2.amazonaws.com": "ecr-login",
         "public.ecr.aws": "ecr-login"
     }
 }


### PR DESCRIPTION
Add packages ECR to `credHelpers` list for `amazon-ecr-credential-helper` to use for authentication to ECR.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
