### PR TITLE
cherrypick: Adds pre/post boot and node roles (#2474)

### DIFF
--- a/projects/aws/image-builder/builder/types.go
+++ b/projects/aws/image-builder/builder/types.go
@@ -70,6 +70,7 @@ type VsphereConfig struct {
 	IsoConfig
 	RhelConfig
 	ExtraPackagesConfig
+	ExtraOverridesConfig
 }
 
 type BaremetalConfig struct {
@@ -77,6 +78,7 @@ type BaremetalConfig struct {
 	IsoConfig
 	RhelConfig
 	ExtraPackagesConfig
+	ExtraOverridesConfig
 }
 
 type CloudstackConfig struct {
@@ -84,6 +86,7 @@ type CloudstackConfig struct {
 	IsoConfig
 	RhelConfig
 	ExtraPackagesConfig
+	ExtraOverridesConfig
 }
 
 type IsoConfig struct {
@@ -108,6 +111,7 @@ type NutanixConfig struct {
 	NutanixPassword   string `json:"nutanix_password"`
 	NutanixSubnetName string `json:"nutanix_subnet_name"`
 	ExtraPackagesConfig
+	ExtraOverridesConfig
 }
 
 type AMIConfig struct {
@@ -123,10 +127,20 @@ type AMIConfig struct {
 	VolumeType          string `json:"volume_type"`
 
 	ExtraPackagesConfig
+	ExtraOverridesConfig
 }
 
 type ExtraPackagesConfig struct {
 	ExtraDebs  string `json:"extra_debs,omitempty"`
 	ExtraRepos string `json:"extra_repos,omitempty"`
 	ExtraRpms  string `json:"extra_rpms,omitempty"`
+}
+
+type ExtraOverridesConfig struct {
+	FirstbootCustomRolesPre  string `json:"firstboot_custom_roles_pre,omitempty"`
+	FirstbootCustomRolesPost string `json:"firstboot_custom_roles_post,omitempty"`
+	NodeCustomRolesPre       string `json:"node_custom_roles_pre,omitempty"`
+	NodeCustomRolesPost      string `json:"node_custom_roles_post,omitempty"`
+	DisablePublicRepos       string `json:"disable_public_repos,omitempty"`
+	ReenablePublicRepos      string `json:"reenable_public_repos,omitempty"`
 }


### PR DESCRIPTION
As per https://github.com/kubernetes-sigs/image-builder/issues/894 issue upstream project opened to use custom Ansible roles pre/post boot of the node and also pre/post node provisioning.

This opens doors to customize image built for custom requirements, for example if deployment needs to happen in offline environment that has no access to the internet and would require to update system with required changes to look for packages on internal proxies instead.

Also allows to provide extra updates to the system before Kubernetes is installed along with extra tweaks after.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
