### PR TITLE
improves use of gnu variants on macosx

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -302,7 +302,7 @@ ADD_TRAILING_CHAR=$(if $(1),$(1)$(2),)
 # check if pass variable has length of 1
 IS_ONE_WORD=$(if $(filter 1,$(words $(1))),true,false)
 
-SED_CMD=$(shell if [ "$$(uname -s)" = "Darwin" ] && command -v gsed &> /dev/null; then echo gsed; else echo sed; fi)
+SED_CMD=$(shell source $(BUILD_LIB)/common.sh && build::common::gnu_variant_on_mac sed)
 
 ####################################################
 
@@ -842,7 +842,8 @@ release: $(RELEASE_TARGETS)
 # Iterate over release branch versions, avoiding branches explicitly marked as skipped
 .PHONY: %/release-branches/all
 %/release-branches/all:
-	@for version in $(SUPPORTED_K8S_VERSIONS) ; do \
+	@set -e; \
+	for version in $(SUPPORTED_K8S_VERSIONS) ; do \
 	    if ! [[ "$(SKIPPED_K8S_VERSIONS)" =~ $$version  ]]; then \
 			$(MAKE) $* $(if $(filter true,$(BINARIES_ARE_RELEASE_BRANCHED)),clean-output,) RELEASE_BRANCH=$$version; \
 		fi \

--- a/build/lib/create_release_checksums.sh
+++ b/build/lib/create_release_checksums.sh
@@ -17,19 +17,14 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_ROOT}/common.sh"
+
 ASSET_ROOT="$1"
 
-FIND=find
-if which gfind &>/dev/null; then
-    FIND=gfind
-elif which gnudate &>/dev/null; then
-    FIND=gnufind
-fi
+FIND=$(build::common::gnu_variant_on_mac find)
 
-REALPATH=realpath
-if which grealpath &>/dev/null; then
-    REALPATH=grealpath
-fi
+REALPATH=$(build::common::gnu_variant_on_mac realpath)
 
 SHA256SUM=$(dirname ${ASSET_ROOT})/SHA256SUM
 SHA512SUM=$(dirname ${ASSET_ROOT})/SHA512SUM

--- a/build/lib/generate_help_body.sh
+++ b/build/lib/generate_help_body.sh
@@ -41,10 +41,10 @@ FOOTER="########### END GENERATED ###########################"
 MAKEFILE=$PROJECT_ROOT/Makefile
 HELPFILE=$PROJECT_ROOT/Help.mk
 
-SED=sed
-if [ "$(uname -s)" = "Darwin" ]; then
-    SED=gsed
-fi
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_ROOT}/common.sh"
+
+SED=$(build::common::gnu_variant_on_mac sed)
 
 $SED -i "/$HEADER/,/$FOOTER/d" $MAKEFILE
 # remove trailing newlines

--- a/build/lib/helm_pull.sh
+++ b/build/lib/helm_pull.sh
@@ -18,10 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SED=sed
-if [ "$(uname -s)" = "Darwin" ]; then
-    SED=gsed
-fi
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_ROOT}/common.sh"
+
+SED=$(build::common::gnu_variant_on_mac sed)
 
 IMAGE_REGISTRY="${1?First argument is image registry}"
 HELM_REPO_URL="${2?Second arguement is update repo url}"

--- a/build/lib/helm_push.sh
+++ b/build/lib/helm_push.sh
@@ -18,10 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SED=sed
-if [ "$(uname -s)" = "Darwin" ]; then
-    SED=gsed
-fi
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_ROOT}/common.sh"
+
+SED=$(build::common::gnu_variant_on_mac sed)
 
 IMAGE_REGISTRY="${1?First argument is image registry}"
 HELM_DESTINATION_REPOSITORY="${2?Second argument is helm repository}"

--- a/build/lib/helm_replace.sh
+++ b/build/lib/helm_replace.sh
@@ -18,10 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SED=sed
-if [ "$(uname -s)" = "Darwin" ]; then
-    SED=gsed
-fi
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_ROOT}/common.sh"
+
+SED=$(build::common::gnu_variant_on_mac sed)
 
 HELM_DESTINATION_REPOSITORY="${1?First argument is helm destination repository}"
 OUTPUT_DIR="${2?Second arguement is output directory}"

--- a/build/lib/readme_check.sh
+++ b/build/lib/readme_check.sh
@@ -18,11 +18,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_ROOT}/common.sh"
+
 RETURN=0
-SED=sed
-if [ "$(uname -s)" = "Darwin" ]; then
-    SED=gsed
-fi
+SED=$(build::common::gnu_variant_on_mac sed)
 
 for GIT_TAG_FILE in projects/*/*/GIT_TAG
 do

--- a/build/lib/update_checksums.sh
+++ b/build/lib/update_checksums.sh
@@ -17,10 +17,14 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_ROOT}/common.sh"
+
 MAKE_ROOT="$1"
 PROJECT_ROOT="$2"
 OUTPUT_BIN_DIR="$3"
 
+REALPATH=$(build::common::gnu_variant_on_mac realpath)
 
 if [ ! -d ${OUTPUT_BIN_DIR} ] ;  then
     echo "${OUTPUT_BIN_DIR} not present! Run 'make binaries'"
@@ -31,7 +35,7 @@ CHECKSUMS_FILE=$PROJECT_ROOT/CHECKSUMS
 
 rm -f $CHECKSUMS_FILE
 for file in $(find ${OUTPUT_BIN_DIR} -type f | sort); do
-    filepath=$(realpath --relative-base=$MAKE_ROOT $file)
+    filepath=$($REALPATH --relative-base=$MAKE_ROOT $file)
     sha256sum $filepath >> $CHECKSUMS_FILE
 done
 

--- a/build/lib/validate_artifacts.sh
+++ b/build/lib/validate_artifacts.sh
@@ -37,10 +37,7 @@ if [ -n "$IMAGE_FORMAT" ]; then
   fi
 fi
 
-REALPATH=realpath
-if which grealpath &>/dev/null; then
-    REALPATH=grealpath
-fi
+REALPATH=$(build::common::gnu_variant_on_mac realpath)
 
 ACTUAL_FILES=$(mktemp)
 find "$ARTIFACTS_FOLDER" \

--- a/build/lib/version.sh
+++ b/build/lib/version.sh
@@ -14,6 +14,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_ROOT}/common.sh"
+
 version::get_version_vars() {
     local -r repo=$1
     GIT_RELEASE_TAG=$(git -C $repo describe --match 'v[0-9]*.[0-9]*.[0-9]**' --abbrev=0 --tags)
@@ -58,12 +61,7 @@ version::ldflags() {
             "-X '${package_prefix}.${key}=${val}'"
         )
     }
-    DATE=date
-    if which gdate &>/dev/null; then
-        DATE=gdate
-    elif which gnudate &>/dev/null; then
-        DATE=gnudate
-    fi
+    DATE=$(build::common::gnu_variant_on_mac date)
     
     # buildDate is not actual buildDate to avoid it breaking reproducible checksums
     # instead it is the date of the last commit, either the upstream TAG commit or the latest patch applied

--- a/projects/prometheus/prometheus/build/cp_npm_licenses.sh
+++ b/projects/prometheus/prometheus/build/cp_npm_licenses.sh
@@ -17,10 +17,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-TAR=tar
-if [ "$(uname -s)" = "Darwin" ]; then
-    TAR=gtar
-fi
+MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+source "${MAKE_ROOT}/../../../build/lib/common.sh"
+
+TAR=$(build::common::gnu_variant_on_mac tar)
 
 rm -f "prometheus/npm_licenses.tar.bz2"
 find prometheus/web/ui/node_modules -iname "license*" | $TAR cfj "prometheus/npm_licenses.tar.bz2" --transform 's/^/npm_licenses\//' --files-from=-


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We had a common "pattern" for certain tools, such as sed + tar +date, where on mac we would try and find the gnu build, which is installable via brew.  This introduces a helper and refactors our usage of this pattern so its consistent throughout our scripts.

This will also make it a bit more easier to track which brew formulas someone should install if building locally. I plan to update the building-locally doc in a future PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
