### PR TITLE
[Image Builder] Add download manifest command for airgapped builds

### DIFF
--- a/projects/aws/image-builder/builder/constants.go
+++ b/projects/aws/image-builder/builder/constants.go
@@ -28,6 +28,11 @@ const (
 	prodEksaReleaseManifestURL       string = "https://anywhere-assets.eks.amazonaws.com/releases/eks-a/manifest.yaml"
 	devEksaReleaseManifestURL        string = "https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/eks-a-release.yaml"
 	devBranchEksaReleaseManifestURL  string = "https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/%s/eks-a-release.yaml"
+	eksDistroProdDomain              string = "distro.eks.amazonaws.com"
+	eksDistroManifestFileNameFormat  string = "eks-d-%s.yaml"
+	eksAnywhereManifestFileName      string = "eks-a-manifest.yaml"
+	eksAnywhereBundlesFileNameFormat string = "eks-a-bundles-%s.yaml"
+	manifestsTarballName             string = "eks-a-manifests.tar"
 
 	// Environment variables
 	branchNameEnvVar                      string = "BRANCH_NAME"

--- a/projects/aws/image-builder/builder/manifests.go
+++ b/projects/aws/image-builder/builder/manifests.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
-	"sigs.k8s.io/yaml"
+	k8syaml "sigs.k8s.io/yaml"
 )
 
 // DownloadManifests connects to the internet, clones a fresh copy of eks-a-build-tooling repo
@@ -87,7 +87,7 @@ func downloadEKSAManifests(outputPath string) error {
 	}
 
 	releases := &releasev1.Release{}
-	if err = yaml.Unmarshal(releaseManifestData, releases); err != nil {
+	if err = k8syaml.Unmarshal(releaseManifestData, releases); err != nil {
 		return err
 	}
 	for _, r := range releases.Spec.Releases {

--- a/projects/aws/image-builder/builder/manifests.go
+++ b/projects/aws/image-builder/builder/manifests.go
@@ -1,0 +1,102 @@
+package builder
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
+	"sigs.k8s.io/yaml"
+)
+
+// DownloadManifests connects to the internet, clones a fresh copy of eks-a-build-tooling repo
+// and pulls EKS-A and EKS-D artifacts for all supported releases and creates an archive.
+func (b *BuildOptions) DownloadManifests() error {
+	// Clone build tooling from the latest release branch
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("Error retrieving current working directory: %v", err)
+	}
+
+	buildToolingRepoPath := getBuildToolingPath(cwd)
+	_, err = prepBuildToolingRepo(buildToolingRepoPath, "", b.Force)
+	if err != nil {
+		return err
+	}
+
+	// Download eks-d manifests
+	manifestsPath := filepath.Join(cwd, "manifests")
+	if err = downloadEKSDManifests(manifestsPath); err != nil {
+		return err
+	}
+
+	// Download eks-a manifests
+	if err = downloadEKSAManifests(manifestsPath); err != nil {
+		return err
+	}
+
+	// Create tarball of the downloaded manifests
+	log.Println("Creating tarball of downloaded manifests")
+	if err = createTarball(manifestsTarballName, manifestsPath); err != nil {
+		return err
+	}
+	log.Printf("Manifest tarball %s was successfully created", manifestsTarballName)
+
+	// Clean up manifests directory
+	if err = os.RemoveAll(manifestsPath); err != nil {
+		return err
+	}
+	cleanup(buildToolingRepoPath)
+	return nil
+}
+
+func downloadEKSDManifests(outputPath string) error {
+	// Get all eksDReleases with their release numbers
+	eksDReleaseBranchesWithNumber, err := getEksDReleaseBranchesWithNumber()
+	if err != nil {
+		return err
+	}
+
+	for branch, number := range eksDReleaseBranchesWithNumber {
+		manifestUrl := fmt.Sprintf("https://%s/kubernetes-%s/kubernetes-%s-eks-%s.yaml", eksDistroProdDomain, branch, branch, number)
+		manifestFileName := fmt.Sprintf(eksDistroManifestFileNameFormat, branch)
+		manifestFilePath := filepath.Join(outputPath, manifestFileName)
+		log.Printf("Downloading eks-d manifest for release branch %s, release number %s", branch, number)
+		if err := downloadFile(manifestFilePath, manifestUrl); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func downloadEKSAManifests(outputPath string) error {
+	// Download Release manifest
+	releaseManifestUrl := getEksAReleasesManifestURL()
+	releaseManifestPath := filepath.Join(outputPath, eksAnywhereManifestFileName)
+	log.Printf("Downloading eks-a release manifest")
+	if err := downloadFile(releaseManifestPath, releaseManifestUrl); err != nil {
+		return err
+	}
+
+	// Download all the bundles from release manifest
+	releaseManifestData, err := os.ReadFile(releaseManifestPath)
+	if err != nil {
+		return err
+	}
+
+	releases := &releasev1.Release{}
+	if err = yaml.Unmarshal(releaseManifestData, releases); err != nil {
+		return err
+	}
+	for _, r := range releases.Spec.Releases {
+		bundleName := fmt.Sprintf(eksAnywhereBundlesFileNameFormat, r.Version)
+		bundleFilePath := filepath.Join(outputPath, bundleName)
+		log.Printf("Downloading eks-a bundles manifest for eks-a version: %s", r.Version)
+		if err = downloadFile(bundleFilePath, r.BundleManifestUrl); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/projects/aws/image-builder/builder/utils.go
+++ b/projects/aws/image-builder/builder/utils.go
@@ -15,7 +15,8 @@ import (
 	"time"
 
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
-	"sigs.k8s.io/yaml"
+	"github.com/ghodss/yaml"
+	k8syaml "sigs.k8s.io/yaml"
 )
 
 type EksDReleases struct {
@@ -209,7 +210,7 @@ func getGitCommitFromBundle(eksaReleaseVersion string) (string, string, error) {
 	}
 
 	releases := &releasev1.Release{}
-	if err = yaml.Unmarshal(releasesManifestContents, releases); err != nil {
+	if err = k8syaml.Unmarshal(releasesManifestContents, releases); err != nil {
 		return "", "", fmt.Errorf("failed to unmarshal release manifest from [%s]: %v", eksAReleasesManifestURL, err)
 	}
 
@@ -260,7 +261,7 @@ func getGitCommitFromBundle(eksaReleaseVersion string) (string, string, error) {
 	}
 
 	bundles := &releasev1.Bundles{}
-	if err = yaml.Unmarshal(bundleManifestContents, bundles); err != nil {
+	if err = k8syaml.Unmarshal(bundleManifestContents, bundles); err != nil {
 		return "", "", fmt.Errorf("failed to unmarshal bundles manifest from [%s]: %v", bundleManifestUrl, err)
 	}
 

--- a/projects/aws/image-builder/cmd/download.go
+++ b/projects/aws/image-builder/cmd/download.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var downloadCmd = &cobra.Command{
+	Use:   "download",
+	Short: "Downloads artifacts for airgapped builds",
+	Long:  "Downloads manifests and other artifacts used to build EKS-A Node images in airgapped environment",
+}
+
+func init() {
+	rootCmd.AddCommand(downloadCmd)
+}

--- a/projects/aws/image-builder/cmd/downloadmanifests.go
+++ b/projects/aws/image-builder/cmd/downloadmanifests.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+)
+
+var downloadManifestsCmd = &cobra.Command{
+	Use:   "manifests",
+	Short: "Downloads manifests for airgapped builds",
+	Long:  "Downloads EKS-D and EKS-A manifests used to build EKS-A Node images in airgapped environment",
+	Run: func(cmd *cobra.Command, args []string) {
+		err := bo.DownloadManifests()
+		if err != nil {
+			log.Fatalf("Error downloading manifests: %v", err)
+		}
+	},
+}
+
+func init() {
+	downloadCmd.AddCommand(downloadManifestsCmd)
+	downloadManifestsCmd.Flags().BoolVar(&bo.Force, "force", false, "Force flag to clean up leftover files from previous execution")
+}


### PR DESCRIPTION
*Description of changes:*
Adds a download manifest command that will pull down all the latest eks-d manifests as well as the eks-a release manifest and all the bundles manifest. Command will create a tarball from all the manifests and finally cleanup.

```
image-builder download manifest
```

Last few lines of output
```
2023/10/09 18:58:01 Downloading eks-a bundles manifest for eks-a version: v0.16.4
2023/10/09 18:58:01 Downloading eks-a bundles manifest for eks-a version: v0.16.5
2023/10/09 18:58:01 Downloading eks-a bundles manifest for eks-a version: v0.17.0
2023/10/09 18:58:01 Downloading eks-a bundles manifest for eks-a version: v0.17.1
2023/10/09 18:58:01 Downloading eks-a bundles manifest for eks-a version: v0.17.2
2023/10/09 18:58:02 Downloading eks-a bundles manifest for eks-a version: v0.17.3
2023/10/09 18:58:02 Creating tarball of downloaded manifests
2023/10/09 18:58:02 Manifest tarball eks-a-manifests.tar was successfully created
2023/10/09 18:58:02 Cleaning up cache build files
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
