### PR TITLE
replaces base_directory with constant relative path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath .)
 BUILD_LIB=${BASE_DIRECTORY}/build/lib
 AWS_ACCOUNT_ID?=$(shell aws sts get-caller-identity --query Account --output text)
 AWS_REGION?=us-west-2

--- a/projects/apache/cloudstack-cloudmonkey/Makefile
+++ b/projects/apache/cloudstack-cloudmonkey/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=cloudstack-cloudmonkey

--- a/projects/aquasecurity/harbor-scanner-trivy/Makefile
+++ b/projects/aquasecurity/harbor-scanner-trivy/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=harbor-scanner-trivy

--- a/projects/aquasecurity/trivy/Makefile
+++ b/projects/aquasecurity/trivy/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=trivy

--- a/projects/aws-containers/hello-eks-anywhere/Makefile
+++ b/projects/aws-containers/hello-eks-anywhere/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=hello-eks-anywhere

--- a/projects/aws-observability/aws-otel-collector/Makefile
+++ b/projects/aws-observability/aws-otel-collector/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 HELM_GIT_TAG:=$(shell cat HELM_GIT_TAG)
  # Upstream images are used directly without re-building and re-tagging in build

--- a/projects/aws/cluster-api-provider-aws-snow/Makefile
+++ b/projects/aws/cluster-api-provider-aws-snow/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 
 REPO=cluster-api-provider-aws-snow

--- a/projects/aws/eks-a-admin-image/Makefile
+++ b/projects/aws/eks-a-admin-image/Makefile
@@ -1,6 +1,6 @@
 -include .env
 
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG=0.0.0-dev # This value does not matter but needs to be set
 
 SIMPLE_CREATE_BINARIES=false

--- a/projects/aws/eks-anywhere-build-tooling/Makefile
+++ b/projects/aws/eks-anywhere-build-tooling/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 
 REPO=eks-anywhere-build-tooling

--- a/projects/aws/eks-anywhere-packages/Makefile
+++ b/projects/aws/eks-anywhere-packages/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG?=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 

--- a/projects/aws/eks-anywhere/Makefile
+++ b/projects/aws/eks-anywhere/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 
 REPO=eks-anywhere

--- a/projects/aws/etcdadm-bootstrap-provider/Makefile
+++ b/projects/aws/etcdadm-bootstrap-provider/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=etcdadm-bootstrap-provider

--- a/projects/aws/etcdadm-controller/Makefile
+++ b/projects/aws/etcdadm-controller/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=etcdadm-controller

--- a/projects/aws/rolesanywhere-credential-helper/Makefile
+++ b/projects/aws/rolesanywhere-credential-helper/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=rolesanywhere-credential-helper

--- a/projects/brancz/kube-rbac-proxy/Makefile
+++ b/projects/brancz/kube-rbac-proxy/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=kube-rbac-proxy

--- a/projects/cilium/cilium/Makefile
+++ b/projects/cilium/cilium/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 CHART_TAG:=$(shell echo $(GIT_TAG) | sed 's/^v//')
 

--- a/projects/containerd/containerd/Makefile
+++ b/projects/containerd/containerd/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=containerd

--- a/projects/distribution/distribution/Makefile
+++ b/projects/distribution/distribution/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=distribution

--- a/projects/emissary-ingress/emissary/Makefile
+++ b/projects/emissary-ingress/emissary/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 APPMESH_VERSION:=$(shell cat APPMESH_VERSION)

--- a/projects/envoyproxy/envoy/Makefile
+++ b/projects/envoyproxy/envoy/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 
 ENVOY_IMAGE=public.ecr.aws/appmesh/aws-appmesh-envoy:$(GIT_TAG)

--- a/projects/fluxcd/flux2/Makefile
+++ b/projects/fluxcd/flux2/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=flux2

--- a/projects/fluxcd/helm-controller/Makefile
+++ b/projects/fluxcd/helm-controller/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=helm-controller

--- a/projects/fluxcd/kustomize-controller/Makefile
+++ b/projects/fluxcd/kustomize-controller/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=kustomize-controller

--- a/projects/fluxcd/notification-controller/Makefile
+++ b/projects/fluxcd/notification-controller/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=notification-controller

--- a/projects/fluxcd/source-controller/Makefile
+++ b/projects/fluxcd/source-controller/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=source-controller

--- a/projects/goharbor/harbor/Makefile
+++ b/projects/goharbor/harbor/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 

--- a/projects/helm/helm/Makefile
+++ b/projects/helm/helm/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=helm

--- a/projects/kube-vip/kube-vip/Makefile
+++ b/projects/kube-vip/kube-vip/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=kube-vip

--- a/projects/kubernetes-sigs/cluster-api-provider-cloudstack/Makefile
+++ b/projects/kubernetes-sigs/cluster-api-provider-cloudstack/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=cluster-api-provider-cloudstack

--- a/projects/kubernetes-sigs/cluster-api-provider-vsphere/Makefile
+++ b/projects/kubernetes-sigs/cluster-api-provider-vsphere/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=cluster-api-provider-vsphere

--- a/projects/kubernetes-sigs/cluster-api/Makefile
+++ b/projects/kubernetes-sigs/cluster-api/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=cluster-api

--- a/projects/kubernetes-sigs/cri-tools/Makefile
+++ b/projects/kubernetes-sigs/cri-tools/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=cri-tools

--- a/projects/kubernetes-sigs/etcdadm/Makefile
+++ b/projects/kubernetes-sigs/etcdadm/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=etcdadm

--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 MAKE_ROOT=$(BASE_DIRECTORY)/projects/kubernetes-sigs/image-builder
 GIT_TAG:=$(shell cat GIT_TAG)
 

--- a/projects/kubernetes-sigs/kind/Makefile
+++ b/projects/kubernetes-sigs/kind/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=kind

--- a/projects/kubernetes-sigs/metrics-server/Makefile
+++ b/projects/kubernetes-sigs/metrics-server/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG=$(shell source $(BUILD_LIB)/common.sh && build::eksd_releases::get_eksd_component_asset_image_tag metrics-server metrics-server-image $(RELEASE_BRANCH))
 HELM_GIT_TAG:=$(shell cat $(RELEASE_BRANCH)/HELM_GIT_TAG)
  # Upstream images are used directly without re-building and re-tagging in build

--- a/projects/kubernetes/autoscaler/Makefile
+++ b/projects/kubernetes/autoscaler/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG=$(shell cat ./$(RELEASE_BRANCH)/GIT_TAG)
 GOLANG_VERSION:=$(shell cat ./$(RELEASE_BRANCH)/GOLANG_VERSION)
 

--- a/projects/kubernetes/cloud-provider-aws/Makefile
+++ b/projects/kubernetes/cloud-provider-aws/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG=$(shell cat ./$(RELEASE_BRANCH)/GIT_TAG)
 GOLANG_VERSION:=$(shell cat ./$(RELEASE_BRANCH)/GOLANG_VERSION)
 

--- a/projects/kubernetes/cloud-provider-vsphere/Makefile
+++ b/projects/kubernetes/cloud-provider-vsphere/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG=$(shell cat ./$(RELEASE_BRANCH)/GIT_TAG)
 GOLANG_VERSION:=$(shell cat ./$(RELEASE_BRANCH)/GOLANG_VERSION)
 

--- a/projects/metallb/metallb/Makefile
+++ b/projects/metallb/metallb/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=metallb

--- a/projects/nutanix-cloud-native/cluster-api-provider-nutanix/Makefile
+++ b/projects/nutanix-cloud-native/cluster-api-provider-nutanix/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=cluster-api-provider-nutanix

--- a/projects/opencontainers/runc/Makefile
+++ b/projects/opencontainers/runc/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=runc

--- a/projects/prometheus/node_exporter/Makefile
+++ b/projects/prometheus/node_exporter/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=node_exporter

--- a/projects/prometheus/prometheus/Makefile
+++ b/projects/prometheus/prometheus/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 HELM_GIT_TAG:=$(shell cat HELM_GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)

--- a/projects/rancher/local-path-provisioner/Makefile
+++ b/projects/rancher/local-path-provisioner/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=local-path-provisioner

--- a/projects/redis/redis/Makefile
+++ b/projects/redis/redis/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 
 REPO=redis

--- a/projects/replicatedhq/troubleshoot/Makefile
+++ b/projects/replicatedhq/troubleshoot/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=troubleshoot

--- a/projects/tinkerbell/boots/Makefile
+++ b/projects/tinkerbell/boots/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=boots

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/Makefile
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=cluster-api-provider-tinkerbell

--- a/projects/tinkerbell/hegel/Makefile
+++ b/projects/tinkerbell/hegel/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=hegel

--- a/projects/tinkerbell/hook/Makefile
+++ b/projects/tinkerbell/hook/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 LINUX_KERNEL_VERSION:=$(shell cat LINUX_KERNEL_VERSION)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)

--- a/projects/tinkerbell/hub/Makefile
+++ b/projects/tinkerbell/hub/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=hub

--- a/projects/tinkerbell/rufio/Makefile
+++ b/projects/tinkerbell/rufio/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=rufio

--- a/projects/tinkerbell/tink/Makefile
+++ b/projects/tinkerbell/tink/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=tink

--- a/projects/tinkerbell/tinkerbell-chart/Makefile
+++ b/projects/tinkerbell/tinkerbell-chart/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 
 REPO_OWNER=tinkerbell

--- a/projects/torvalds/linux/Makefile
+++ b/projects/torvalds/linux/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 
 REPO=linux

--- a/projects/vmware/govmomi/Makefile
+++ b/projects/vmware/govmomi/Makefile
@@ -1,4 +1,4 @@
-BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG:=$(shell cat GIT_TAG)
 GOLANG_VERSION:=$(shell cat GOLANG_VERSION)
 REPO=govmomi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In the interest of removing unnecessary shell calls, instead of using git to get the repo root, we know all projects are 3 levels in from the root, we rely on this in other places.  I dont think there is any reason we cant rely on this on here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
