### PR TITLE
URL overrides for bundles and EKS-D manifest for air gapped Image builder

### DIFF
--- a/build/lib/eksa_releases.sh
+++ b/build/lib/eksa_releases.sh
@@ -44,6 +44,7 @@ function build::eksa_releases::load_bundle_manifest() {
     local -r bundle_manifest_url=$(echo "$release_manifest" | yq e ".spec.releases[] | select(.version == \"$eksa_release_version\") .bundleManifestUrl" -)
     # EKSA_BUNDLE_MANIFEST_URL is set only when image-builder CLI is running in airgapped mode.
     # This will be set to a filepath that has the downloaded or pre-baked bundles file
+    EKSA_BUNDLE_MANIFEST_URL="${EKSA_BUNDLE_MANIFEST_URL:-}"
     if [ -n "$EKSA_BUNDLE_MANIFEST_URL" ]; then
       bundle_manifest_url="$EKSA_BUNDLE_MANIFEST_URL"
     fi

--- a/build/lib/eksd_releases.sh
+++ b/build/lib/eksd_releases.sh
@@ -41,6 +41,7 @@ function build::eksd_releases::get_release_yaml_url() {
     local -r release_branch=$1
     # EKSD_MANIFEST_URL is set only when image-builder CLI is running in airgapped mode.
     # This will be set to a filepath that has the downloaded or pre-baked eks-d manifest file
+    EKSD_MANIFEST_URL="${EKSD_MANIFEST_URL:-}"
     if [ -n "$EKSD_MANIFEST_URL" ]; then
         echo "${EKSD_MANIFEST_URL}"
     else


### PR DESCRIPTION
Description of changes:*
Image builder when running in air gapped mode, will set an override for EKS-D manifest and EKS-A bundles manifest that will house artifacts pointing to the internal artifacts server. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
