### PR TITLE
Fix output image glob pattern for CloudStack image builds

### DIFF
--- a/projects/aws/image-builder/builder/builder.go
+++ b/projects/aws/image-builder/builder/builder.go
@@ -236,7 +236,7 @@ func (b *BuildOptions) BuildImage() {
 		var outputImageGlobPattern string
 		switch b.Os {
 		case RedHat:
-			outputImageGlobPattern = "output/rhel-*/rhel-*"
+			outputImageGlobPattern = "output/rhel-*"
 			buildCommand = fmt.Sprintf("make -C %s local-build-cloudstack-redhat-%s", imageBuilderProjectPath, b.OsVersion)
 			commandEnvVars = append(commandEnvVars,
 				fmt.Sprintf("%s=%s", rhelUsernameEnvVar, b.CloudstackConfig.RhelUsername),
@@ -260,6 +260,8 @@ func (b *BuildOptions) BuildImage() {
 		}
 
 		outputArtifactPath = filepath.Join(cwd, fmt.Sprintf("%s.qcow2", b.Os))
+
+		log.Printf("Image Build Successful\n Please find the output artifact at %s\n", outputArtifactPath)
 	} else if b.Hypervisor == AMI {
 		amiConfigFile := filepath.Join(imageBuilderProjectPath, packerAMIConfigFile)
 


### PR DESCRIPTION
Fix output image glob pattern for CloudStack image builds.

### Example build output
```
==> Builds finished. The artifacts of successful builds are:

--> qemu: VM files in directory: ./output/rhel-8-kube-v1.28.1
--> qemu: VM files in directory: ./output/rhel-8-kube-v1.28.1
--> qemu: VM files in directory: ./output/rhel-8-kube-v1.28.1
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
