### PR TITLE
Fix readonly variable for bundles url override

### DIFF
--- a/build/lib/eksa_releases.sh
+++ b/build/lib/eksa_releases.sh
@@ -41,7 +41,7 @@ function build::eksa_releases::load_bundle_manifest() {
     if [ $dev_release = true ] && [ -n "$EKSA_RELEASE_VERSION" ]; then
       eksa_release_version="$eksa_release_version+build.*"
     fi
-    local -r bundle_manifest_url=$(echo "$release_manifest" | yq e ".spec.releases[] | select(.version == \"$eksa_release_version\") .bundleManifestUrl" -)
+    local bundle_manifest_url=$(echo "$release_manifest" | yq e ".spec.releases[] | select(.version == \"$eksa_release_version\") .bundleManifestUrl" -)
     # EKSA_BUNDLE_MANIFEST_URL is set only when image-builder CLI is running in airgapped mode.
     # This will be set to a filepath that has the downloaded or pre-baked bundles file
     EKSA_BUNDLE_MANIFEST_URL="${EKSA_BUNDLE_MANIFEST_URL:-}"


### PR DESCRIPTION
*Description of changes:*
Setting `EKSA_BUNDLE_MANIFEST_URL` environment variable overrides url found by parsing eks-a release manifest. Removing readonly flag from the variable in order set the override manifest url.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
