### PR TITLE
Support for Air-gapped Image building

### DIFF
--- a/projects/aws/image-builder/builder/constants.go
+++ b/projects/aws/image-builder/builder/constants.go
@@ -29,10 +29,12 @@ const (
 	devEksaReleaseManifestURL        string = "https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/eks-a-release.yaml"
 	devBranchEksaReleaseManifestURL  string = "https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/%s/eks-a-release.yaml"
 	eksDistroProdDomain              string = "distro.eks.amazonaws.com"
+	eksAnywhereAssetsProdDomain      string = "anywhere-assets.eks.amazonaws.com"
 	eksDistroManifestFileNameFormat  string = "eks-d-%s.yaml"
 	eksAnywhereManifestFileName      string = "eks-a-manifest.yaml"
 	eksAnywhereBundlesFileNameFormat string = "eks-a-bundles-%s.yaml"
 	manifestsTarballName             string = "eks-a-manifests.tar"
+	manifestsDirName                 string = "eks-a-d-manifests"
 
 	// Environment variables
 	branchNameEnvVar                      string = "BRANCH_NAME"
@@ -41,6 +43,8 @@ const (
 	releaseBranchEnvVar                   string = "RELEASE_BRANCH"
 	eksAReleaseVersionEnvVar              string = "EKSA_RELEASE_VERSION"
 	eksAReleaseManifestURLEnvVar          string = "EKSA_RELEASE_MANIFEST_URL"
+	eksABundlesURLEnvVar                  string = "EKSA_BUNDLE_MANIFEST_URL"
+	eksDManifestURLEnvVar                 string = "EKSD_MANIFEST_URL"
 	packerAdditionalFilesConfigFileEnvVar string = "PACKER_ADDITIONAL_FILES_VAR_FILES"
 	rhelUsernameEnvVar                    string = "RHSM_USERNAME"
 	rhelPasswordEnvVar                    string = "RHSM_PASSWORD"
@@ -50,6 +54,7 @@ const (
 	packerTypeVarFilesEnvVar              string = "PACKER_TYPE_VAR_FILES"
 	packerNutanixVarFilesEnvVar           string = "PACKER_NUTANIX_VAR_FILES"
 	eksaUseDevReleaseEnvVar               string = "EKSA_USE_DEV_RELEASE"
+	cloneUrlEnvVar                        string = "CLONE_URL"
 
 	// Miscellaneous
 	mainBranch            string = "main"

--- a/projects/aws/image-builder/builder/manifests.go
+++ b/projects/aws/image-builder/builder/manifests.go
@@ -1,10 +1,13 @@
 package builder
 
 import (
+	"archive/tar"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 	k8syaml "sigs.k8s.io/yaml"
@@ -20,7 +23,7 @@ func (b *BuildOptions) DownloadManifests() error {
 	}
 
 	buildToolingRepoPath := getBuildToolingPath(cwd)
-	_, err = prepBuildToolingRepo(buildToolingRepoPath, "", b.Force)
+	_, err = b.prepBuildToolingRepo(buildToolingRepoPath)
 	if err != nil {
 		return err
 	}
@@ -58,6 +61,11 @@ func downloadEKSDManifests(outputPath string) error {
 		return err
 	}
 
+	// Create output directory path
+	if err = os.MkdirAll(outputPath, 0755); err != nil {
+		return err
+	}
+
 	for branch, number := range eksDReleaseBranchesWithNumber {
 		manifestUrl := fmt.Sprintf("https://%s/kubernetes-%s/kubernetes-%s-eks-%s.yaml", eksDistroProdDomain, branch, branch, number)
 		manifestFileName := fmt.Sprintf(eksDistroManifestFileNameFormat, branch)
@@ -73,7 +81,16 @@ func downloadEKSDManifests(outputPath string) error {
 
 func downloadEKSAManifests(outputPath string) error {
 	// Download Release manifest
-	releaseManifestUrl := getEksAReleasesManifestURL()
+	releaseManifestUrl, err := getEksAReleasesManifestURL(false)
+	if err != nil {
+		return err
+	}
+
+	// Create output directory path
+	if err = os.MkdirAll(outputPath, 0755); err != nil {
+		return err
+	}
+
 	releaseManifestPath := filepath.Join(outputPath, eksAnywhereManifestFileName)
 	log.Printf("Downloading eks-a release manifest")
 	if err := downloadFile(releaseManifestPath, releaseManifestUrl); err != nil {
@@ -96,6 +113,111 @@ func downloadEKSAManifests(outputPath string) error {
 		log.Printf("Downloading eks-a bundles manifest for eks-a version: %s", r.Version)
 		if err = downloadFile(bundleFilePath, r.BundleManifestUrl); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// extractTarball extracts the provided tarball onto the path
+func extractTarball(tarball, path string) error {
+	tarFile, err := os.Open(tarball)
+	if err != nil {
+		return err
+	}
+	defer tarFile.Close()
+
+	// Create a new directory to extract the tarball into.
+	if err = os.RemoveAll(path); err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(path, 0755)
+	if err != nil {
+		return err
+	}
+
+	// Create a tar reader for the tarball.
+	tarReader := tar.NewReader(tarFile)
+
+	// Iterate over the tarball's entries.
+	for {
+		// Get the next header from the tarball.
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			// We've reached the end of the tarball.
+			break
+		}
+		if err != nil {
+			return err
+		}
+
+		// Create a new file for the tar entry.
+		outFile, err := os.Create(filepath.Join(path, header.Name))
+		if err != nil {
+			return err
+		}
+		defer outFile.Close()
+
+		// Copy the tar entry's contents to the new file.
+		_, err = io.Copy(outFile, tarReader)
+		if err != nil {
+			return err
+		}
+
+		outFile.Chmod(os.FileMode(header.Mode))
+	}
+
+	return nil
+}
+
+func extractAndPrepManifestTarball(tarballFile, privateEksDServerDomain, privateEksAServerDomain string) error {
+	log.Println("Manifest tarball provided, extracting to directory")
+	manifestDir, err := getManifestRoot()
+	if err != nil {
+		return fmt.Errorf("Error retrieving manifest root")
+	}
+	if err = extractTarball(tarballFile, manifestDir); err != nil {
+		return fmt.Errorf("Error extracting tarball: %v", err)
+	}
+
+	// Replacing eks-a bundles manifest hostname
+	// These endpoints are used for artifacts like containerd, crictl & etcdadm
+	// Find all eks-a bundles manifest and replace hostname
+	files, err := os.ReadDir(manifestDir)
+	if err != nil {
+		return err
+	}
+	for _, file := range files {
+		if !file.IsDir() {
+			// Find EKS-D Manifests and replace prod distro domain with private server's
+			absFilePath := filepath.Join(manifestDir, file.Name())
+			eksDManifestFilePattern := strings.ReplaceAll(eksDistroManifestFileNameFormat, "%s", "*")
+			eksDMatch, err := filepath.Match(eksDManifestFilePattern, file.Name())
+			if err != nil {
+				return err
+			}
+
+			if eksDMatch {
+				log.Printf("Replacing EKS-D domain name in file: %s\n", file.Name())
+				if err = replaceStringInFile(absFilePath, fmt.Sprintf("https://%s", eksDistroProdDomain), privateEksDServerDomain); err != nil {
+					return err
+				}
+			}
+
+			// Find EKS-A Bundles Manifests and replace prod anywhere domain with private server's
+			eksABundlesManifestFilePattern := strings.ReplaceAll(eksAnywhereBundlesFileNameFormat, "%s", "*")
+			eksAMatch, err := filepath.Match(eksABundlesManifestFilePattern, file.Name())
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("File: %s, Match: %s, Pattern: %s\n", file.Name(), eksAMatch, eksABundlesManifestFilePattern)
+			if eksAMatch {
+				log.Printf("Replacing EKS-A domain name in file: %s\n", file.Name())
+				if err = replaceStringInFile(absFilePath, fmt.Sprintf("https://%s", eksAnywhereAssetsProdDomain), privateEksAServerDomain); err != nil {
+					return err
+				}
+			}
 		}
 	}
 	return nil

--- a/projects/aws/image-builder/builder/types.go
+++ b/projects/aws/image-builder/builder/types.go
@@ -47,6 +47,8 @@ type BuildOptions struct {
 	FilesConfig        *AdditionalFilesConfig
 	ReleaseChannel     string
 	Force              bool
+	AirGapped          bool
+	ManifestTarball    string
 	Firmware           string
 	EKSAReleaseVersion string
 }
@@ -73,6 +75,7 @@ type VsphereConfig struct {
 	ProxyConfig
 	ExtraPackagesConfig
 	ExtraOverridesConfig
+	AirGappedConfig
 }
 
 type BaremetalConfig struct {
@@ -82,6 +85,7 @@ type BaremetalConfig struct {
 	ProxyConfig
 	ExtraPackagesConfig
 	ExtraOverridesConfig
+	AirGappedConfig
 }
 
 type CloudstackConfig struct {
@@ -91,6 +95,7 @@ type CloudstackConfig struct {
 	ProxyConfig
 	ExtraPackagesConfig
 	ExtraOverridesConfig
+	AirGappedConfig
 }
 
 type IsoConfig struct {
@@ -121,6 +126,7 @@ type NutanixConfig struct {
 	ProxyConfig
 	ExtraPackagesConfig
 	ExtraOverridesConfig
+	AirGappedConfig
 }
 
 type AMIConfig struct {
@@ -170,4 +176,11 @@ type ExtraOverridesConfig struct {
 	NodeCustomRolesPost      string `json:"node_custom_roles_post,omitempty"`
 	DisablePublicRepos       string `json:"disable_public_repos,omitempty"`
 	ReenablePublicRepos      string `json:"reenable_public_repos,omitempty"`
+}
+
+type AirGappedConfig struct {
+	EksABuildToolingRepoUrl    string `json:"eksa_build_tooling_repo_url,omitempty"`
+	ImageBuilderRepoUrl        string `json:"image_builder_repo_url,omitempty"`
+	PrivateServerEksDDomainUrl string `json:"private_artifacts_eksd_fqdn,omitempty"`
+	PrivateServerEksADomainUrl string `json:"private_artifacts_eksa_fqdn,omitempty"`
 }


### PR DESCRIPTION
*Description of changes:*
Support for air gapped image building. This change includes image builder cli changes to build an airgapped OS.
- Extracts the manifest tarball generated with internet availability
- Replaces the domains in the extracted manifests pointing to the internal artifact endpoints
- Ensures airgapped packer vars are set 
    - extra_repos
    - iso_url
    - iso_checksum
    - iso_checksum_type
    - disable_public_repos
- Sets the right env var to point to the extracted manifests for EKS-D release bundle for provided release channel

Changes are actively being tested.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
