### PR TITLE
minor image builder improvements

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -432,7 +432,7 @@ SKIP_CHECKSUM_VALIDATION?=false
 IN_DOCKER_TARGETS=all-attributions all-attributions-checksums all-checksums attribution attribution-checksums binaries checksums clean clean-go-cache
 PRUNE_BUILDCTL?=false
 GITHUB_TOKEN?=
-DEPENDENCY_TOOLS=buildctl helm jq skopeo tuftool yq
+DEPENDENCY_TOOLS=buildctl helm jq lz4 skopeo tuftool yq
 ####################################################
 
 #################### LOGGING #######################

--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -114,12 +114,12 @@ function build::common::upload_artifacts() {
     # Upload artifacts to s3 
     # 1. To proper path on s3 with buildId-githash
     # 2. Latest path to indicate the latest build, with --delete option to delete stale files in the dest path
-    build::common::echo_and_run aws s3 sync "$artifactspath" "$artifactsbucket"/"$projectpath"/"$buildidentifier"-"$githash"/artifacts --acl public-read
+    build::common::echo_and_run aws s3 sync "$artifactspath" "$artifactsbucket"/"$projectpath"/"$buildidentifier"-"$githash"/artifacts --acl public-read --no-progress
 
     if [ "$do_not_delete" = "true" ]; then
-      build::common::echo_and_run aws s3 sync "$artifactspath" "$artifactsbucket"/"$projectpath"/"$latesttag" --acl public-read
+      build::common::echo_and_run aws s3 sync "$artifactspath" "$artifactsbucket"/"$projectpath"/"$latesttag" --acl public-read --no-progress
     else
-      build::common::echo_and_run aws s3 sync "$artifactspath" "$artifactsbucket"/"$projectpath"/"$latesttag" --delete --acl public-read
+      build::common::echo_and_run aws s3 sync "$artifactspath" "$artifactsbucket"/"$projectpath"/"$latesttag" --delete --acl public-read --no-progress
     fi
   fi
 }
@@ -278,7 +278,7 @@ function build::common::use_go_version() {
   # Adding to the beginning of PATH to allow for builds on specific version if it exists
   export PATH=${gobinarypath}:$PATH
   export GOCACHE=$(go env GOCACHE)/$version
-}
+  }
 
 # Use a seperate build cache for each project/version to ensure there are no
 # shared bits which can mess up the final checksum calculation

--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -80,6 +80,10 @@ RAW_FORMAT_EXT=gz
 AMI_FORMAT_EXT=gz
 CLOUDSTACK_FORMAT_EXT=qcow2
 
+# there is no file produced during nutanix builds, defining to avoid
+# missing variable warning
+NUTANIX_FORMAT_EXT=
+
 # $1- image_format
 # $2 - image_os
 EXT_FROM_FORMAT=$(if $(and $(filter bottlerocket,$2),$(filter-out ova,$1)),img.,)$($(call TO_UPPER,$1)_FORMAT_EXT)
@@ -206,6 +210,22 @@ DEBUG?=0
 
 SKIP_ON_RELEASE_BRANCH=$(if $(filter bottlerocket,$(IMAGE_OS)),false,true)
 
+# our file builds/downloads are technically intermediate targets which would get deleted when
+# make finishes, this avoids that
+ALL_FINAL_FILE_PATHS=\
+	$(foreach format,$(IMAGE_FORMATS_AVAIL),\
+		$(foreach os,$(ALLOWED_$(call TO_UPPER,$(format))_OS),\
+			$(foreach ver,$(ALLOWED_$(call TO_UPPER,$(os))_VERSIONS),\
+				$(foreach firmware,$(if $(filter $(os)-$(format),$(ALLOWED_EFI_OS_FORMATS)),/ /efi/,/),\
+					$(ARTIFACTS_PATH)/$(os)/$(ver)/$(format)$(firmware)$(os).$(call EXT_FROM_FORMAT,$(format),$(os))\
+				)\
+			)\
+		)\
+	)
+
+SPECIAL_TARGET_SECONDARY=$(strip $(ALL_FINAL_FILE_PATHS))
+
+
 include $(BASE_DIRECTORY)/Common.mk
 
 
@@ -242,7 +262,7 @@ $(ARTIFACTS_PATH)/bottlerocket/% upload-bottlerocket-%: IMAGE_OS=bottlerocket
 $(ARTIFACTS_PATH)/bottlerocket/%: IMAGE_OS_VERSION=$(word 1,$(subst /, ,$(*D)))
 $(ARTIFACTS_PATH)/bottlerocket/%: IMAGE_FORMAT=$(word 2,$(subst /, ,$(*D)))
 $(ARTIFACTS_PATH)/bottlerocket/%: export BOTTLEROCKET_ROOT_JSON_PATH=$(BOTTLEROCKET_DOWNLOAD_PATH)/root.json
-$(ARTIFACTS_PATH)/bottlerocket/%: | ensure-yq ensure-tuftool
+$(ARTIFACTS_PATH)/bottlerocket/%: | ensure-yq ensure-tuftool ensure-lz4
 	@echo -e $(call TARGET_START_LOG)
 	mkdir -p $(@D) $(BOTTLEROCKET_DOWNLOAD_PATH)
 	# This configuration supports local installations and checksum validations of root.json file


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- stop showing s3 upload progress. for image uploading it overloads the logs and its unnecessary
- extract the br raw image requires lz4
- avoid removing the downloaded files because they are intermediate targets. the fix is a bit ugly and this is a pretty minor case, it really only comes up when running locally multiple times, but feels like a low risk to avoid some "strange" behavior that I have to re-remember every time.
- improve the host interface for the packer host IP detection

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
