### PR TITLE
Add default buildspec definition to batch buildspecs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,14 +91,14 @@ generate-project-list: | ensure-locale
 .PHONY: generate-staging-buildspec
 generate-staging-buildspec: export BINARY_PLATFORMS=linux/amd64 linux/arm64
 generate-staging-buildspec: | ensure-locale
-	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "$(ALL_PROJECTS)" "$(BASE_DIRECTORY)/release/staging-build.yml"
-	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "$(ALL_PROJECTS)" "$(BASE_DIRECTORY)/release/checksums-build.yml" true EXCLUDE_FROM_CHECKSUMS_BUILDSPEC CHECKSUMS_BUILDSPECS false buildspecs/checksums-pr-buildspec.yml
-	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "aws_bottlerocket-bootstrap" "$(BASE_DIRECTORY)/projects/aws/bottlerocket-bootstrap/buildspecs/batch-build.yml" true
-	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "kubernetes_cloud-provider-vsphere" "$(BASE_DIRECTORY)/projects/kubernetes/cloud-provider-vsphere/buildspecs/batch-build.yml" true
-	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "kubernetes-sigs_kind" "$(BASE_DIRECTORY)/projects/kubernetes-sigs/kind/buildspecs/batch-build.yml" true
-	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "containerd_containerd" "$(BASE_DIRECTORY)/projects/containerd/containerd/buildspecs/batch-build.yml" true
-	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "opencontainers_runc" "$(BASE_DIRECTORY)/projects/opencontainers/runc/buildspecs/batch-build.yml" true
-	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "torvalds_linux" "$(BASE_DIRECTORY)/projects/torvalds/linux/buildspecs/batch-build.yml" true
+	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "$(ALL_PROJECTS)" "$(BASE_DIRECTORY)/release/staging-build.yml" "$(BASE_DIRECTORY)/buildspec.yml"
+	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "$(ALL_PROJECTS)" "$(BASE_DIRECTORY)/release/checksums-build.yml" "$(BASE_DIRECTORY)/buildspecs/checksums-buildspec.yml" true EXCLUDE_FROM_CHECKSUMS_BUILDSPEC CHECKSUMS_BUILDSPECS false buildspecs/checksums-pr-buildspec.yml
+	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "aws_bottlerocket-bootstrap" "$(BASE_DIRECTORY)/projects/aws/bottlerocket-bootstrap/buildspecs/batch-build.yml" "$(BASE_DIRECTORY)/buildspec.yml" true
+	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "kubernetes_cloud-provider-vsphere" "$(BASE_DIRECTORY)/projects/kubernetes/cloud-provider-vsphere/buildspecs/batch-build.yml" "$(BASE_DIRECTORY)/buildspec.yml" true
+	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "kubernetes-sigs_kind" "$(BASE_DIRECTORY)/projects/kubernetes-sigs/kind/buildspecs/batch-build.yml" "$(BASE_DIRECTORY)/buildspecs/images.yml" true
+	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "containerd_containerd" "$(BASE_DIRECTORY)/projects/containerd/containerd/buildspecs/batch-build.yml" "$(BASE_DIRECTORY)/buildspec.yml" true
+	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "opencontainers_runc" "$(BASE_DIRECTORY)/projects/opencontainers/runc/buildspecs/batch-build.yml" "$(BASE_DIRECTORY)/buildspec.yml" true
+	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "torvalds_linux" "$(BASE_DIRECTORY)/projects/torvalds/linux/buildspecs/batch-build.yml" "$(BASE_DIRECTORY)/buildspec.yml" true
 
 .PHONY: generate
 generate: generate-project-list generate-staging-buildspec

--- a/projects/aws/bottlerocket-bootstrap/buildspecs/batch-build.yml
+++ b/projects/aws/bottlerocket-bootstrap/buildspecs/batch-build.yml
@@ -18,37 +18,40 @@ batch:
   fast-fail: true
   build-graph:
     - identifier: aws_bottlerocket_bootstrap_1_24
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           RELEASE_BRANCH: 1-24
     - identifier: aws_bottlerocket_bootstrap_1_25
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           RELEASE_BRANCH: 1-25
     - identifier: aws_bottlerocket_bootstrap_1_26
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           RELEASE_BRANCH: 1-26
     - identifier: aws_bottlerocket_bootstrap_1_27
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           RELEASE_BRANCH: 1-27
     - identifier: aws_bottlerocket_bootstrap_1_28
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           RELEASE_BRANCH: 1-28
+version: 0.2
+phases:
+  pre_build:
+    commands:
+      - ./build/lib/setup.sh
+  build:
+    commands:
+      - if $(make check-project-path-exists) && make check-for-release-branch-skip -C $PROJECT_PATH; then make release -C $PROJECT_PATH; fi

--- a/projects/aws/rolesanywhere-credential-helper/Makefile
+++ b/projects/aws/rolesanywhere-credential-helper/Makefile
@@ -12,7 +12,6 @@ HAS_S3_ARTIFACTS=true
 
 IMAGE_NAMES=
 
-
 include $(BASE_DIRECTORY)/Common.mk
 
 

--- a/projects/containerd/containerd/buildspecs/batch-build.yml
+++ b/projects/containerd/containerd/buildspecs/batch-build.yml
@@ -18,16 +18,22 @@ batch:
   fast-fail: true
   build-graph:
     - identifier: containerd_containerd_linux_amd64
-      buildspec: buildspec.yml
       env:
         type: LINUX_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           BINARY_PLATFORMS: linux/amd64
     - identifier: containerd_containerd_linux_arm64
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           BINARY_PLATFORMS: linux/arm64
+version: 0.2
+phases:
+  pre_build:
+    commands:
+      - ./build/lib/setup.sh
+  build:
+    commands:
+      - if $(make check-project-path-exists) && make check-for-release-branch-skip -C $PROJECT_PATH; then make release -C $PROJECT_PATH; fi

--- a/projects/kubernetes-sigs/kind/buildspecs/batch-build.yml
+++ b/projects/kubernetes-sigs/kind/buildspecs/batch-build.yml
@@ -23,37 +23,43 @@ batch:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
     - identifier: kubernetes_sigs_kind_1_24
-      buildspec: buildspecs/images.yml
       env:
         type: LINUX_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           RELEASE_BRANCH: 1-24
     - identifier: kubernetes_sigs_kind_1_25
-      buildspec: buildspecs/images.yml
       env:
         type: LINUX_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           RELEASE_BRANCH: 1-25
     - identifier: kubernetes_sigs_kind_1_26
-      buildspec: buildspecs/images.yml
       env:
         type: LINUX_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           RELEASE_BRANCH: 1-26
     - identifier: kubernetes_sigs_kind_1_27
-      buildspec: buildspecs/images.yml
       env:
         type: LINUX_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           RELEASE_BRANCH: 1-27
     - identifier: kubernetes_sigs_kind_1_28
-      buildspec: buildspecs/images.yml
       env:
         type: LINUX_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           RELEASE_BRANCH: 1-28
+version: 0.2
+env:
+  variables:
+    HAS_S3_ARTIFACTS: ""
+phases:
+  pre_build:
+    commands:
+      - ./build/lib/setup.sh
+  build:
+    commands:
+      - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi

--- a/projects/kubernetes/cloud-provider-aws/Makefile
+++ b/projects/kubernetes/cloud-provider-aws/Makefile
@@ -2,9 +2,6 @@ BASE_DIRECTORY:=$(abspath ../../../)
 GIT_TAG=$(shell cat ./$(RELEASE_BRANCH)/GIT_TAG)
 GOLANG_VERSION=$(shell cat ./$(RELEASE_BRANCH)/GOLANG_VERSION)
 
-EXCLUDE_FROM_STAGING_BUILDSPEC=true
-SKIP_ON_RELEASE_BRANCH=true
-
 REPO=cloud-provider-aws
 REPO_OWNER=kubernetes
 

--- a/projects/kubernetes/cloud-provider-vsphere/buildspecs/batch-build.yml
+++ b/projects/kubernetes/cloud-provider-vsphere/buildspecs/batch-build.yml
@@ -18,37 +18,40 @@ batch:
   fast-fail: true
   build-graph:
     - identifier: kubernetes_cloud_provider_vsphere_1_24
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           RELEASE_BRANCH: 1-24
     - identifier: kubernetes_cloud_provider_vsphere_1_25
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           RELEASE_BRANCH: 1-25
     - identifier: kubernetes_cloud_provider_vsphere_1_26
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           RELEASE_BRANCH: 1-26
     - identifier: kubernetes_cloud_provider_vsphere_1_27
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           RELEASE_BRANCH: 1-27
     - identifier: kubernetes_cloud_provider_vsphere_1_28
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           RELEASE_BRANCH: 1-28
+version: 0.2
+phases:
+  pre_build:
+    commands:
+      - ./build/lib/setup.sh
+  build:
+    commands:
+      - if $(make check-project-path-exists) && make check-for-release-branch-skip -C $PROJECT_PATH; then make release -C $PROJECT_PATH; fi

--- a/projects/opencontainers/runc/buildspecs/batch-build.yml
+++ b/projects/opencontainers/runc/buildspecs/batch-build.yml
@@ -18,16 +18,22 @@ batch:
   fast-fail: true
   build-graph:
     - identifier: opencontainers_runc_linux_amd64
-      buildspec: buildspec.yml
       env:
         type: LINUX_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           BINARY_PLATFORMS: linux/amd64
     - identifier: opencontainers_runc_linux_arm64
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           BINARY_PLATFORMS: linux/arm64
+version: 0.2
+phases:
+  pre_build:
+    commands:
+      - ./build/lib/setup.sh
+  build:
+    commands:
+      - if $(make check-project-path-exists) && make check-for-release-branch-skip -C $PROJECT_PATH; then make release -C $PROJECT_PATH; fi

--- a/projects/torvalds/linux/buildspecs/batch-build.yml
+++ b/projects/torvalds/linux/buildspecs/batch-build.yml
@@ -18,16 +18,22 @@ batch:
   fast-fail: true
   build-graph:
     - identifier: torvalds_linux_linux_amd64
-      buildspec: buildspec.yml
       env:
         type: LINUX_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           BINARY_PLATFORMS: linux/amd64
     - identifier: torvalds_linux_linux_arm64
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           BINARY_PLATFORMS: linux/arm64
+version: 0.2
+phases:
+  pre_build:
+    commands:
+      - ./build/lib/setup.sh
+  build:
+    commands:
+      - if $(make check-project-path-exists) && make check-for-release-branch-skip -C $PROJECT_PATH; then make release -C $PROJECT_PATH; fi

--- a/release/checksums-build.yml
+++ b/release/checksums-build.yml
@@ -18,7 +18,6 @@ batch:
   fast-fail: false
   build-graph:
     - identifier: apache_cloudstack_cloudmonkey
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -26,7 +25,6 @@ batch:
           PROJECT_PATH: projects/apache/cloudstack-cloudmonkey
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/apache.cloudstack-cloudmonkey
     - identifier: aquasecurity_harbor_scanner_trivy
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -34,7 +32,6 @@ batch:
           PROJECT_PATH: projects/aquasecurity/harbor-scanner-trivy
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aquasecurity.harbor-scanner-trivy
     - identifier: aquasecurity_trivy
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
@@ -42,21 +39,18 @@ batch:
           PROJECT_PATH: projects/aquasecurity/trivy
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aquasecurity.trivy
     - identifier: aws_bottlerocket_bootstrap
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           PROJECT_PATH: projects/aws/bottlerocket-bootstrap
     - identifier: aws_eks_anywhere
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           PROJECT_PATH: projects/aws/eks-anywhere
     - identifier: aws_eks_anywhere_packages
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
@@ -64,7 +58,6 @@ batch:
           PROJECT_PATH: projects/aws/eks-anywhere-packages
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-packages
     - identifier: aws_etcdadm_bootstrap_provider
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -72,7 +65,6 @@ batch:
           PROJECT_PATH: projects/aws/etcdadm-bootstrap-provider
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.etcdadm-bootstrap-provider
     - identifier: aws_etcdadm_controller
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -80,14 +72,12 @@ batch:
           PROJECT_PATH: projects/aws/etcdadm-controller
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.etcdadm-controller
     - identifier: aws_image_builder
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           PROJECT_PATH: projects/aws/image-builder
     - identifier: aws_rolesanywhere_credential_helper
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -95,7 +85,6 @@ batch:
           PROJECT_PATH: projects/aws/rolesanywhere-credential-helper
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.rolesanywhere-credential-helper
     - identifier: aws_containers_hello_eks_anywhere
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -103,7 +92,6 @@ batch:
           PROJECT_PATH: projects/aws-containers/hello-eks-anywhere
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws-containers.hello-eks-anywhere
     - identifier: aws_observability_aws_otel_collector
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -111,7 +99,6 @@ batch:
           PROJECT_PATH: projects/aws-observability/aws-otel-collector
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws-observability.aws-otel-collector
     - identifier: brancz_kube_rbac_proxy
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -119,7 +106,6 @@ batch:
           PROJECT_PATH: projects/brancz/kube-rbac-proxy
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/brancz.kube-rbac-proxy
     - identifier: cert_manager_cert_manager
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
@@ -127,7 +113,6 @@ batch:
           PROJECT_PATH: projects/cert-manager/cert-manager
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/cert-manager.cert-manager
     - identifier: containerd_containerd_linux_amd64
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: LINUX_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -136,7 +121,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/containerd.containerd
           BINARY_PLATFORMS: linux/amd64
     - identifier: containerd_containerd_linux_arm64
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -145,7 +129,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/containerd.containerd
           BINARY_PLATFORMS: linux/arm64
     - identifier: distribution_distribution
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -153,7 +136,6 @@ batch:
           PROJECT_PATH: projects/distribution/distribution
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/distribution.distribution
     - identifier: emissary_ingress_emissary
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -161,14 +143,12 @@ batch:
           PROJECT_PATH: projects/emissary-ingress/emissary
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/emissary-ingress.emissary
     - identifier: envoyproxy_envoy
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           PROJECT_PATH: projects/envoyproxy/envoy
     - identifier: fluxcd_flux2
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -176,7 +156,6 @@ batch:
           PROJECT_PATH: projects/fluxcd/flux2
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/fluxcd.flux2
     - identifier: fluxcd_helm_controller
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -184,7 +163,6 @@ batch:
           PROJECT_PATH: projects/fluxcd/helm-controller
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/fluxcd.helm-controller
     - identifier: fluxcd_kustomize_controller
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -192,7 +170,6 @@ batch:
           PROJECT_PATH: projects/fluxcd/kustomize-controller
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/fluxcd.kustomize-controller
     - identifier: fluxcd_notification_controller
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -200,7 +177,6 @@ batch:
           PROJECT_PATH: projects/fluxcd/notification-controller
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/fluxcd.notification-controller
     - identifier: fluxcd_source_controller
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -208,7 +184,6 @@ batch:
           PROJECT_PATH: projects/fluxcd/source-controller
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/fluxcd.source-controller
     - identifier: goharbor_harbor
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
@@ -216,7 +191,6 @@ batch:
           PROJECT_PATH: projects/goharbor/harbor
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/goharbor.harbor
     - identifier: helm_helm
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -224,7 +198,6 @@ batch:
           PROJECT_PATH: projects/helm/helm
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/helm.helm
     - identifier: kube_vip_kube_vip
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -232,7 +205,6 @@ batch:
           PROJECT_PATH: projects/kube-vip/kube-vip
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kube-vip.kube-vip
     - identifier: kubernetes_autoscaler_1_24
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
@@ -241,7 +213,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.autoscaler
           RELEASE_BRANCH: 1-24
     - identifier: kubernetes_autoscaler_1_25
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
@@ -250,7 +221,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.autoscaler
           RELEASE_BRANCH: 1-25
     - identifier: kubernetes_autoscaler_1_26
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
@@ -259,7 +229,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.autoscaler
           RELEASE_BRANCH: 1-26
     - identifier: kubernetes_autoscaler_1_27
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
@@ -268,7 +237,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.autoscaler
           RELEASE_BRANCH: 1-27
     - identifier: kubernetes_autoscaler_1_28
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
@@ -277,7 +245,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.autoscaler
           RELEASE_BRANCH: 1-28
     - identifier: kubernetes_cloud_provider_aws_1_24
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -286,7 +253,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.cloud-provider-aws
           RELEASE_BRANCH: 1-24
     - identifier: kubernetes_cloud_provider_aws_1_25
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -295,7 +261,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.cloud-provider-aws
           RELEASE_BRANCH: 1-25
     - identifier: kubernetes_cloud_provider_aws_1_26
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -304,7 +269,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.cloud-provider-aws
           RELEASE_BRANCH: 1-26
     - identifier: kubernetes_cloud_provider_aws_1_27
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -313,7 +277,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.cloud-provider-aws
           RELEASE_BRANCH: 1-27
     - identifier: kubernetes_cloud_provider_aws_1_28
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -322,7 +285,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.cloud-provider-aws
           RELEASE_BRANCH: 1-28
     - identifier: kubernetes_cloud_provider_vsphere_1_24
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -331,7 +293,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.cloud-provider-vsphere
           RELEASE_BRANCH: 1-24
     - identifier: kubernetes_cloud_provider_vsphere_1_25
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -340,7 +301,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.cloud-provider-vsphere
           RELEASE_BRANCH: 1-25
     - identifier: kubernetes_cloud_provider_vsphere_1_26
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -349,7 +309,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.cloud-provider-vsphere
           RELEASE_BRANCH: 1-26
     - identifier: kubernetes_cloud_provider_vsphere_1_27
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -358,7 +317,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.cloud-provider-vsphere
           RELEASE_BRANCH: 1-27
     - identifier: kubernetes_cloud_provider_vsphere_1_28
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -367,7 +325,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.cloud-provider-vsphere
           RELEASE_BRANCH: 1-28
     - identifier: kubernetes_sigs_cluster_api
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
@@ -375,7 +332,6 @@ batch:
           PROJECT_PATH: projects/kubernetes-sigs/cluster-api
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.cluster-api
     - identifier: kubernetes_sigs_cluster_api_provider_cloudstack
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -383,7 +339,6 @@ batch:
           PROJECT_PATH: projects/kubernetes-sigs/cluster-api-provider-cloudstack
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.cluster-api-provider-cloudstack
     - identifier: kubernetes_sigs_cluster_api_provider_vsphere
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -391,7 +346,6 @@ batch:
           PROJECT_PATH: projects/kubernetes-sigs/cluster-api-provider-vsphere
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.cluster-api-provider-vsphere
     - identifier: kubernetes_sigs_cri_tools
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -399,7 +353,6 @@ batch:
           PROJECT_PATH: projects/kubernetes-sigs/cri-tools
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.cri-tools
     - identifier: kubernetes_sigs_etcdadm
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -407,7 +360,6 @@ batch:
           PROJECT_PATH: projects/kubernetes-sigs/etcdadm
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.etcdadm
     - identifier: kubernetes_sigs_kind
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -415,7 +367,6 @@ batch:
           PROJECT_PATH: projects/kubernetes-sigs/kind
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
     - identifier: metallb_metallb
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -423,7 +374,6 @@ batch:
           PROJECT_PATH: projects/metallb/metallb
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/metallb.metallb
     - identifier: nutanix_cloud_native_cluster_api_provider_nutanix
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -431,7 +381,6 @@ batch:
           PROJECT_PATH: projects/nutanix-cloud-native/cluster-api-provider-nutanix
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/nutanix-cloud-native.cluster-api-provider-nutanix
     - identifier: opencontainers_runc_linux_amd64
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: LINUX_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -440,7 +389,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/opencontainers.runc
           BINARY_PLATFORMS: linux/amd64
     - identifier: opencontainers_runc_linux_arm64
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -449,7 +397,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/opencontainers.runc
           BINARY_PLATFORMS: linux/arm64
     - identifier: prometheus_node_exporter
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -457,7 +404,6 @@ batch:
           PROJECT_PATH: projects/prometheus/node_exporter
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/prometheus.node_exporter
     - identifier: prometheus_prometheus
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
@@ -465,7 +411,6 @@ batch:
           PROJECT_PATH: projects/prometheus/prometheus
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/prometheus.prometheus
     - identifier: rancher_local_path_provisioner
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -473,14 +418,12 @@ batch:
           PROJECT_PATH: projects/rancher/local-path-provisioner
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/rancher.local-path-provisioner
     - identifier: redis_redis
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           PROJECT_PATH: projects/redis/redis
     - identifier: replicatedhq_troubleshoot
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -488,7 +431,6 @@ batch:
           PROJECT_PATH: projects/replicatedhq/troubleshoot
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/replicatedhq.troubleshoot
     - identifier: tinkerbell_boots
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -496,7 +438,6 @@ batch:
           PROJECT_PATH: projects/tinkerbell/boots
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/tinkerbell.boots
     - identifier: tinkerbell_cluster_api_provider_tinkerbell
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -504,7 +445,6 @@ batch:
           PROJECT_PATH: projects/tinkerbell/cluster-api-provider-tinkerbell
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/tinkerbell.cluster-api-provider-tinkerbell
     - identifier: tinkerbell_hegel
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -512,7 +452,6 @@ batch:
           PROJECT_PATH: projects/tinkerbell/hegel
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/tinkerbell.hegel
     - identifier: tinkerbell_hook
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -520,7 +459,6 @@ batch:
           PROJECT_PATH: projects/tinkerbell/hook
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/tinkerbell.hook
     - identifier: tinkerbell_hub
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -528,7 +466,6 @@ batch:
           PROJECT_PATH: projects/tinkerbell/hub
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/tinkerbell.hub
     - identifier: tinkerbell_rufio
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -536,7 +473,6 @@ batch:
           PROJECT_PATH: projects/tinkerbell/rufio
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/tinkerbell.rufio
     - identifier: tinkerbell_tink
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -544,14 +480,12 @@ batch:
           PROJECT_PATH: projects/tinkerbell/tink
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/tinkerbell.tink
     - identifier: tinkerbell_tinkerbell_chart
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           PROJECT_PATH: projects/tinkerbell/tinkerbell-chart
     - identifier: vmware_govmomi
-      buildspec: buildspecs/checksums-buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -630,3 +564,17 @@ batch:
         - tinkerbell_tink
         - tinkerbell_tinkerbell_chart
         - vmware_govmomi
+version: 0.2
+env:
+  secrets-manager:
+    GITHUB_TOKEN: github-eks-distro-pr-bot:github-token
+phases:
+  pre_build:
+    commands:
+      - ./build/lib/setup.sh
+  build:
+    commands:
+      - echo "CHECKSUMS -text merge=union" > .gitattributes
+      - if $(make check-project-path-exists); then make attribution checksums -C $PROJECT_PATH; fi
+      - build/lib/update_go_versions.sh
+      - build/update-attribution-files/create_pr.sh true

--- a/release/staging-build.yml
+++ b/release/staging-build.yml
@@ -18,7 +18,6 @@ batch:
   fast-fail: true
   build-graph:
     - identifier: apache_cloudstack_cloudmonkey
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -26,7 +25,6 @@ batch:
           PROJECT_PATH: projects/apache/cloudstack-cloudmonkey
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/apache.cloudstack-cloudmonkey
     - identifier: aws_bottlerocket_bootstrap_1_24
-      buildspec: buildspec.yml
       depend-on:
         - kubernetes_sigs_etcdadm
       env:
@@ -36,7 +34,6 @@ batch:
           PROJECT_PATH: projects/aws/bottlerocket-bootstrap
           RELEASE_BRANCH: 1-24
     - identifier: aws_bottlerocket_bootstrap_1_25
-      buildspec: buildspec.yml
       depend-on:
         - kubernetes_sigs_etcdadm
       env:
@@ -46,7 +43,6 @@ batch:
           PROJECT_PATH: projects/aws/bottlerocket-bootstrap
           RELEASE_BRANCH: 1-25
     - identifier: aws_bottlerocket_bootstrap_1_26
-      buildspec: buildspec.yml
       depend-on:
         - kubernetes_sigs_etcdadm
       env:
@@ -56,7 +52,6 @@ batch:
           PROJECT_PATH: projects/aws/bottlerocket-bootstrap
           RELEASE_BRANCH: 1-26
     - identifier: aws_bottlerocket_bootstrap_1_27
-      buildspec: buildspec.yml
       depend-on:
         - kubernetes_sigs_etcdadm
       env:
@@ -66,7 +61,6 @@ batch:
           PROJECT_PATH: projects/aws/bottlerocket-bootstrap
           RELEASE_BRANCH: 1-27
     - identifier: aws_bottlerocket_bootstrap_1_28
-      buildspec: buildspec.yml
       depend-on:
         - kubernetes_sigs_etcdadm
       env:
@@ -76,7 +70,6 @@ batch:
           PROJECT_PATH: projects/aws/bottlerocket-bootstrap
           RELEASE_BRANCH: 1-28
     - identifier: aws_cluster_api_provider_aws_snow
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -84,14 +77,12 @@ batch:
           PROJECT_PATH: projects/aws/cluster-api-provider-aws-snow
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.cluster-api-provider-aws-snow
     - identifier: aws_eks_anywhere
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           PROJECT_PATH: projects/aws/eks-anywhere
     - identifier: aws_eks_anywhere_build_tooling
-      buildspec: buildspec.yml
       depend-on:
         - fluxcd_flux2
         - kubernetes_sigs_cluster_api
@@ -106,7 +97,6 @@ batch:
         variables:
           PROJECT_PATH: projects/aws/eks-anywhere-build-tooling
     - identifier: aws_eks_anywhere_packages
-      buildspec: buildspec.yml
       depend-on:
         - aws_rolesanywhere_credential_helper
         - kubernetes_cloud_provider_aws_1_25
@@ -118,7 +108,6 @@ batch:
           PROJECT_PATH: projects/aws/eks-anywhere-packages
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-packages
     - identifier: aws_etcdadm_bootstrap_provider
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -126,7 +115,6 @@ batch:
           PROJECT_PATH: projects/aws/etcdadm-bootstrap-provider
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.etcdadm-bootstrap-provider
     - identifier: aws_etcdadm_controller
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -134,14 +122,12 @@ batch:
           PROJECT_PATH: projects/aws/etcdadm-controller
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.etcdadm-controller
     - identifier: aws_image_builder
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           PROJECT_PATH: projects/aws/image-builder
     - identifier: aws_rolesanywhere_credential_helper
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -149,7 +135,6 @@ batch:
           PROJECT_PATH: projects/aws/rolesanywhere-credential-helper
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.rolesanywhere-credential-helper
     - identifier: brancz_kube_rbac_proxy
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -157,7 +142,6 @@ batch:
           PROJECT_PATH: projects/brancz/kube-rbac-proxy
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/brancz.kube-rbac-proxy
     - identifier: cert_manager_cert_manager
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
@@ -165,7 +149,6 @@ batch:
           PROJECT_PATH: projects/cert-manager/cert-manager
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/cert-manager.cert-manager
     - identifier: cilium_cilium
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -173,7 +156,6 @@ batch:
           PROJECT_PATH: projects/cilium/cilium
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/cilium.cilium
     - identifier: containerd_containerd_linux_amd64
-      buildspec: buildspec.yml
       depend-on:
         - opencontainers_runc_linux_amd64
         - opencontainers_runc_linux_arm64
@@ -185,7 +167,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/containerd.containerd
           BINARY_PLATFORMS: linux/amd64
     - identifier: containerd_containerd_linux_arm64
-      buildspec: buildspec.yml
       depend-on:
         - opencontainers_runc_linux_amd64
         - opencontainers_runc_linux_arm64
@@ -197,7 +178,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/containerd.containerd
           BINARY_PLATFORMS: linux/arm64
     - identifier: distribution_distribution
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -205,14 +185,12 @@ batch:
           PROJECT_PATH: projects/distribution/distribution
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/distribution.distribution
     - identifier: envoyproxy_envoy
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           PROJECT_PATH: projects/envoyproxy/envoy
     - identifier: fluxcd_flux2
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -220,7 +198,6 @@ batch:
           PROJECT_PATH: projects/fluxcd/flux2
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/fluxcd.flux2
     - identifier: fluxcd_helm_controller
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -228,7 +205,6 @@ batch:
           PROJECT_PATH: projects/fluxcd/helm-controller
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/fluxcd.helm-controller
     - identifier: fluxcd_kustomize_controller
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -236,7 +212,6 @@ batch:
           PROJECT_PATH: projects/fluxcd/kustomize-controller
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/fluxcd.kustomize-controller
     - identifier: fluxcd_notification_controller
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -244,7 +219,6 @@ batch:
           PROJECT_PATH: projects/fluxcd/notification-controller
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/fluxcd.notification-controller
     - identifier: fluxcd_source_controller
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -252,7 +226,6 @@ batch:
           PROJECT_PATH: projects/fluxcd/source-controller
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/fluxcd.source-controller
     - identifier: helm_helm
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -260,15 +233,53 @@ batch:
           PROJECT_PATH: projects/helm/helm
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/helm.helm
     - identifier: kube_vip_kube_vip
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           PROJECT_PATH: projects/kube-vip/kube-vip
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kube-vip.kube-vip
+    - identifier: kubernetes_cloud_provider_aws_1_24
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          PROJECT_PATH: projects/kubernetes/cloud-provider-aws
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.cloud-provider-aws
+          RELEASE_BRANCH: 1-24
+    - identifier: kubernetes_cloud_provider_aws_1_25
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          PROJECT_PATH: projects/kubernetes/cloud-provider-aws
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.cloud-provider-aws
+          RELEASE_BRANCH: 1-25
+    - identifier: kubernetes_cloud_provider_aws_1_26
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          PROJECT_PATH: projects/kubernetes/cloud-provider-aws
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.cloud-provider-aws
+          RELEASE_BRANCH: 1-26
+    - identifier: kubernetes_cloud_provider_aws_1_27
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          PROJECT_PATH: projects/kubernetes/cloud-provider-aws
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.cloud-provider-aws
+          RELEASE_BRANCH: 1-27
+    - identifier: kubernetes_cloud_provider_aws_1_28
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          PROJECT_PATH: projects/kubernetes/cloud-provider-aws
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.cloud-provider-aws
+          RELEASE_BRANCH: 1-28
     - identifier: kubernetes_cloud_provider_vsphere_1_24
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -277,7 +288,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.cloud-provider-vsphere
           RELEASE_BRANCH: 1-24
     - identifier: kubernetes_cloud_provider_vsphere_1_25
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -286,7 +296,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.cloud-provider-vsphere
           RELEASE_BRANCH: 1-25
     - identifier: kubernetes_cloud_provider_vsphere_1_26
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -295,7 +304,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.cloud-provider-vsphere
           RELEASE_BRANCH: 1-26
     - identifier: kubernetes_cloud_provider_vsphere_1_27
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -304,7 +312,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.cloud-provider-vsphere
           RELEASE_BRANCH: 1-27
     - identifier: kubernetes_cloud_provider_vsphere_1_28
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -313,7 +320,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes.cloud-provider-vsphere
           RELEASE_BRANCH: 1-28
     - identifier: kubernetes_sigs_cluster_api
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
@@ -321,7 +327,6 @@ batch:
           PROJECT_PATH: projects/kubernetes-sigs/cluster-api
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.cluster-api
     - identifier: kubernetes_sigs_cluster_api_provider_cloudstack
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -329,7 +334,6 @@ batch:
           PROJECT_PATH: projects/kubernetes-sigs/cluster-api-provider-cloudstack
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.cluster-api-provider-cloudstack
     - identifier: kubernetes_sigs_cluster_api_provider_vsphere
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -337,7 +341,6 @@ batch:
           PROJECT_PATH: projects/kubernetes-sigs/cluster-api-provider-vsphere
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.cluster-api-provider-vsphere
     - identifier: kubernetes_sigs_cri_tools
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -345,7 +348,6 @@ batch:
           PROJECT_PATH: projects/kubernetes-sigs/cri-tools
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.cri-tools
     - identifier: kubernetes_sigs_etcdadm
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -576,7 +578,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
           RELEASE_BRANCH: 1-28
     - identifier: nutanix_cloud_native_cluster_api_provider_nutanix
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -584,7 +585,6 @@ batch:
           PROJECT_PATH: projects/nutanix-cloud-native/cluster-api-provider-nutanix
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/nutanix-cloud-native.cluster-api-provider-nutanix
     - identifier: opencontainers_runc_linux_amd64
-      buildspec: buildspec.yml
       env:
         type: LINUX_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -593,7 +593,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/opencontainers.runc
           BINARY_PLATFORMS: linux/amd64
     - identifier: opencontainers_runc_linux_arm64
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -602,7 +601,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/opencontainers.runc
           BINARY_PLATFORMS: linux/arm64
     - identifier: rancher_local_path_provisioner
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -610,14 +608,12 @@ batch:
           PROJECT_PATH: projects/rancher/local-path-provisioner
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/rancher.local-path-provisioner
     - identifier: redis_redis
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           PROJECT_PATH: projects/redis/redis
     - identifier: replicatedhq_troubleshoot
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -625,7 +621,6 @@ batch:
           PROJECT_PATH: projects/replicatedhq/troubleshoot
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/replicatedhq.troubleshoot
     - identifier: tinkerbell_boots
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -633,7 +628,6 @@ batch:
           PROJECT_PATH: projects/tinkerbell/boots
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/tinkerbell.boots
     - identifier: tinkerbell_cluster_api_provider_tinkerbell
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -641,7 +635,6 @@ batch:
           PROJECT_PATH: projects/tinkerbell/cluster-api-provider-tinkerbell
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/tinkerbell.cluster-api-provider-tinkerbell
     - identifier: tinkerbell_hegel
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -649,7 +642,6 @@ batch:
           PROJECT_PATH: projects/tinkerbell/hegel
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/tinkerbell.hegel
     - identifier: tinkerbell_hook
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -657,7 +649,6 @@ batch:
           PROJECT_PATH: projects/tinkerbell/hook
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/tinkerbell.hook
     - identifier: tinkerbell_hub
-      buildspec: buildspec.yml
       depend-on:
         - torvalds_linux
       env:
@@ -667,7 +658,6 @@ batch:
           PROJECT_PATH: projects/tinkerbell/hub
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/tinkerbell.hub
     - identifier: tinkerbell_rufio
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -675,7 +665,6 @@ batch:
           PROJECT_PATH: projects/tinkerbell/rufio
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/tinkerbell.rufio
     - identifier: tinkerbell_tink
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -683,14 +672,12 @@ batch:
           PROJECT_PATH: projects/tinkerbell/tink
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/tinkerbell.tink
     - identifier: tinkerbell_tinkerbell_chart
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           PROJECT_PATH: projects/tinkerbell/tinkerbell-chart
     - identifier: torvalds_linux_linux_amd64
-      buildspec: buildspec.yml
       env:
         type: LINUX_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -699,7 +686,6 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/torvalds.linux
           BINARY_PLATFORMS: linux/amd64
     - identifier: torvalds_linux_linux_arm64
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
@@ -708,10 +694,17 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/torvalds.linux
           BINARY_PLATFORMS: linux/arm64
     - identifier: vmware_govmomi
-      buildspec: buildspec.yml
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           PROJECT_PATH: projects/vmware/govmomi
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/vmware.govmomi
+version: 0.2
+phases:
+  pre_build:
+    commands:
+      - ./build/lib/setup.sh
+  build:
+    commands:
+      - if $(make check-project-path-exists) && make check-for-release-branch-skip -C $PROJECT_PATH; then make release -C $PROJECT_PATH; fi


### PR DESCRIPTION
The `buildspec` field in each build task of the batch build definition is an optional parameter, and if not provided, the current buildspec file is used to determine the phases, commands, etc. This PR adds the default buildspec definition in each batch buildspec so that we don't need to specify it again and again. The change is especially noticeable in the staging and checksums buildspecs which have 60+ build tasks each referencing the same buildspec file. Instead we can add the default phases/commands in the batch buildspec itself.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
