### PR TITLE
Add kube version and os version info in the output file

### DIFF
--- a/projects/aws/image-builder/builder/builder.go
+++ b/projects/aws/image-builder/builder/builder.go
@@ -130,7 +130,7 @@ func (b *BuildOptions) BuildImage() {
 		}
 
 		outputImageGlobPattern = "output/*.ova"
-		outputArtifactPath = filepath.Join(cwd, fmt.Sprintf("%s.ova", b.Os))
+		outputArtifactPath = filepath.Join(cwd, fmt.Sprintf("%s-%s-kube-%s.ova", b.Os, b.OsVersion, b.ReleaseChannel))
 
 		log.Printf("Image Build Successful\n Please find the output artifact at %s\n", outputArtifactPath)
 	} else if b.Hypervisor == Baremetal {
@@ -176,7 +176,7 @@ func (b *BuildOptions) BuildImage() {
 		}
 
 		outputImageGlobPattern = "output/*.gz"
-		outputArtifactPath = filepath.Join(cwd, fmt.Sprintf("%s.gz", b.Os))
+		outputArtifactPath = filepath.Join(cwd, fmt.Sprintf("%s-%s-kube-%s.gz", b.Os, b.OsVersion, b.ReleaseChannel))
 
 		log.Printf("Image Build Successful\n Please find the output artifact at %s\n", outputArtifactPath)
 	} else if b.Hypervisor == Nutanix {
@@ -271,7 +271,7 @@ func (b *BuildOptions) BuildImage() {
 			log.Fatalf("Error executing image-builder for raw hypervisor: %v", err)
 		}
 
-		outputArtifactPath = filepath.Join(cwd, fmt.Sprintf("%s.qcow2", b.Os))
+		outputArtifactPath = filepath.Join(cwd, fmt.Sprintf("%s-%s-kube-%s.qcow2", b.Os, b.OsVersion, b.ReleaseChannel))
 
 		log.Printf("Image Build Successful\n Please find the output artifact at %s\n", outputArtifactPath)
 	} else if b.Hypervisor == AMI {


### PR DESCRIPTION
*Issue #, if available:*
From EKSA version - 0.18, template specified in the spec is expected to contain the corresponding K8s version as a pre-flight validation. For a smooth transition, this change patches the image-builder to add Kube version and the os release information in the output file.  

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
