### PR TITLE
Export Nutanix images to disk

### DIFF
--- a/projects/aws/image-builder/builder/builder.go
+++ b/projects/aws/image-builder/builder/builder.go
@@ -268,6 +268,11 @@ func (b *BuildOptions) BuildImage() {
 		}
 
 		log.Printf("Image Build Successful\n Please find the image uploaded under Nutanix Image Service with name %s\n", b.NutanixConfig.ImageName)
+		if b.NutanixConfig.ImageExport == "true" {
+			outputImageGlobPattern = "*.img"
+			outputArtifactPath = filepath.Join(cwd, fmt.Sprintf("%s-%s-kube-%s.img", b.Os, b.OsVersion, b.ReleaseChannel))
+			log.Printf("Also please find the exported image at %s\n", outputArtifactPath)
+		}
 	} else if b.Hypervisor == CloudStack {
 		if b.AirGapped {
 			airGapEnvVars, err := getAirGapCmdEnvVars(b.CloudstackConfig.ImageBuilderRepoUrl, detectedEksaVersion, b.ReleaseChannel)

--- a/projects/aws/image-builder/builder/types.go
+++ b/projects/aws/image-builder/builder/types.go
@@ -115,6 +115,7 @@ type NutanixConfig struct {
 	ClusterName       string `json:"nutanix_cluster_name"`
 	ImageName         string `json:"image_name"`
 	ImageUrl          string `json:"image_url,omitempty"`
+	ImageExport       string `json:"image_export,omitempty"`
 	SourceImageName   string `json:"source_image_name,omitempty"`
 	NutanixEndpoint   string `json:"nutanix_endpoint"`
 	NutanixInsecure   string `json:"nutanix_insecure"`


### PR DESCRIPTION
Export Nutanix images to disk so they can be used in a different Prism Central environment or distributed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
