### PR TITLE
support pushing/pulling from private s3

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -425,6 +425,7 @@ FAKE_ARM_IMAGES_FOR_VALIDATION?=false
 IMAGE_FORMAT?=
 IMAGE_OS?=
 UPLOAD_DO_NOT_DELETE?=false
+UPLOAD_CREATE_PUBLIC_ACL?=true
 ####################################################
 
 #################### OTHER #########################
@@ -667,7 +668,7 @@ endif
 
 .PHONY: upload-artifacts
 upload-artifacts: s3-artifacts upload-output-to-prow-artifacts-s3-artifacts | $$(ENABLE_LOGGING)
-	@$(BUILD_LIB)/upload_artifacts.sh $(ARTIFACTS_PATH) $(ARTIFACTS_BUCKET) $(ARTIFACTS_UPLOAD_PATH) $(BUILD_IDENTIFIER) $(GIT_HASH) $(LATEST) $(UPLOAD_DRY_RUN) $(UPLOAD_DO_NOT_DELETE)
+	@$(BUILD_LIB)/upload_artifacts.sh $(ARTIFACTS_PATH) $(ARTIFACTS_BUCKET) $(ARTIFACTS_UPLOAD_PATH) $(BUILD_IDENTIFIER) $(GIT_HASH) $(LATEST) $(UPLOAD_DRY_RUN) $(UPLOAD_DO_NOT_DELETE) $(UPLOAD_CREATE_PUBLIC_ACL)
 
 .PHONY: s3-artifacts
 s3-artifacts: tarballs

--- a/build/lib/upload_artifacts.sh
+++ b/build/lib/upload_artifacts.sh
@@ -26,8 +26,9 @@ GIT_HASH="${5?Specify fifth argument - git hash of the tar builds}"
 LATEST_TAG="${6?Specify sixth argument - folder name corresponding to latest build}"
 UPLOAD_DRY_RUN="${7?Specify seventh argument - Dry run upload}"
 UPLOAD_DO_NOT_DELETE="${8?Specify eighth argument - Do not delete extra files in s3 bucket on upload}"
+CREATE_PUBLIC_ACL="${9?Specify ninth argument - Set public acl for upload files}"
 
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 source "${SCRIPT_ROOT}/common.sh"
 
-build::common::upload_artifacts $SRC_TAR_PATH $ARTIFACTS_BUCKET $PROJECT_PATH $BUILD_IDENTIFIER $GIT_HASH $LATEST_TAG $UPLOAD_DRY_RUN $UPLOAD_DO_NOT_DELETE
+build::common::upload_artifacts $SRC_TAR_PATH $ARTIFACTS_BUCKET $PROJECT_PATH $BUILD_IDENTIFIER $GIT_HASH $LATEST_TAG $UPLOAD_DRY_RUN $UPLOAD_DO_NOT_DELETE $CREATE_PUBLIC_ACL

--- a/projects/kubernetes-sigs/kind/build/base-image-build-args.sh
+++ b/projects/kubernetes-sigs/kind/build/base-image-build-args.sh
@@ -42,10 +42,10 @@ CNI_PLUGINS_ARM64_URL=$(build::eksd_releases::get_eksd_component_url "cni-plugin
 CNI_PLUGINS_AMD64_SHA256SUM=$(build::eksd_releases::get_eksd_component_sha "cni-plugins" $EKSD_RELEASE_BRANCH amd64)
 CNI_PLUGINS_ARM64_SHA256SUM=$(build::eksd_releases::get_eksd_component_sha "cni-plugins" $EKSD_RELEASE_BRANCH arm64)
 
-CRICTL_AMD64_URL=$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET 'kubernetes-sigs/cri-tools' amd64 $LATEST_TAG)
-CRICTL_ARM64_URL=$(build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET 'kubernetes-sigs/cri-tools' arm64 $LATEST_TAG)
-CRICTL_AMD64_SHA256SUM_URL=$CRICTL_AMD64_URL.sha256
-CRICTL_ARM64_SHA256SUM_URL=$CRICTL_ARM64_URL.sha256
+CRICTL_AMD64_URL=$(build::common::echo_and_run build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET 'kubernetes-sigs/cri-tools' amd64 $LATEST_TAG $EKSD_RELEASE_BRANCH)
+CRICTL_ARM64_URL=$(build::common::echo_and_run build::common::get_latest_eksa_asset_url $ARTIFACTS_BUCKET 'kubernetes-sigs/cri-tools' arm64 $LATEST_TAG $EKSD_RELEASE_BRANCH)
+CRICTL_AMD64_SHA256SUM_URL=$(build::common::echo_and_run build::common::get_latest_eksa_asset_url_sha256 $ARTIFACTS_BUCKET 'kubernetes-sigs/cri-tools' amd64 $LATEST_TAG $EKSD_RELEASE_BRANCH)
+CRICTL_ARM64_SHA256SUM_URL=$(build::common::echo_and_run build::common::get_latest_eksa_asset_url_sha256 $ARTIFACTS_BUCKET 'kubernetes-sigs/cri-tools' arm64 $LATEST_TAG $EKSD_RELEASE_BRANCH)
 
 mkdir -p $(dirname $OUTPUT_FILE)
 cat <<EOF >> $OUTPUT_FILE
@@ -57,8 +57,8 @@ CNI_PLUGINS_AMD64_URL=$CNI_PLUGINS_AMD64_URL
 CNI_PLUGINS_ARM64_URL=$CNI_PLUGINS_ARM64_URL
 CNI_PLUGINS_AMD64_SHA256SUM=$CNI_PLUGINS_AMD64_SHA256SUM
 CNI_PLUGINS_ARM64_SHA256SUM=$CNI_PLUGINS_ARM64_SHA256SUM
-CRICTL_AMD64_SHA256SUM_URL=$CRICTL_AMD64_SHA256SUM_URL
-CRICTL_ARM64_SHA256SUM_URL=$CRICTL_ARM64_SHA256SUM_URL
-CRICTL_AMD64_URL=$CRICTL_AMD64_URL
-CRICTL_ARM64_URL=$CRICTL_ARM64_URL
+CRICTL_AMD64_SHA256SUM_URL="$CRICTL_AMD64_SHA256SUM_URL"
+CRICTL_ARM64_SHA256SUM_URL="$CRICTL_ARM64_SHA256SUM_URL"
+CRICTL_AMD64_URL="$CRICTL_AMD64_URL"
+CRICTL_ARM64_URL="$CRICTL_ARM64_URL"
 EOF


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We do not need to use this for anything right during our build process, but we may eventually want to enable building in CI without marking all build artifacts public.

I was using this to test building the entire stack in my aws account pointed at a private s3 bucket. I was able to build the entire stack this way without needing to pull anything from the build account bucket.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
