### PR TITLE
Make Python site-packages folder readable to non-root users

### DIFF
--- a/projects/kubernetes-sigs/image-builder/buildspecs/ami.yml
+++ b/projects/kubernetes-sigs/image-builder/buildspecs/ami.yml
@@ -12,6 +12,7 @@ phases:
   install:
     run-as: root
     commands:
+      - chmod 755 /usr/lib/python3.9/site-packages
       - chown -R imagebuilder:imagebuilder /home/imagebuilder/.packer.d
   pre_build:
     commands:

--- a/projects/kubernetes-sigs/image-builder/buildspecs/ova.yml
+++ b/projects/kubernetes-sigs/image-builder/buildspecs/ova.yml
@@ -18,6 +18,7 @@ phases:
   install:
     run-as: root
     commands:
+      - chmod 755 /usr/lib/python3.9/site-packages
       - chown -R imagebuilder:imagebuilder /home/imagebuilder/.packer.d
   pre_build:
     commands:


### PR DESCRIPTION
Make Python site-packages folder readable to non-root users so that AMI and OVA builds that run within CodeBuild as `imagebuilder` user can access these packages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
