### PR TITLE
fixex help generation for kind project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,11 +133,11 @@ build-all-warning:
 	@echo "*** this will likely fail and either way run for a really long time ***"
 
 #########################################################################
-
+# to make running on mac/linux or amd/arm consistent exporting certain vars to overwrite default
 .PHONY: add-generated-help-block-project-%
 add-generated-help-block-project-%:
 	$(eval PROJECT_PATH=$(call PROJECT_PATH_MAP,$*))
-	$(MAKE) add-generated-help-block -C $(PROJECT_PATH) RELEASE_BRANCH=1-26
+	$(MAKE) add-generated-help-block -C $(PROJECT_PATH) RELEASE_BRANCH=1-26 BUILDER_PLATFORM_ARCH=amd64 
 
 .PHONY: add-generated-help-block
 add-generated-help-block: $(addprefix add-generated-help-block-project-, $(ALL_PROJECTS))

--- a/projects/aws/image-builder/Makefile
+++ b/projects/aws/image-builder/Makefile
@@ -60,6 +60,7 @@ clean: clean-extra
 unit-test:
 	go test ./...
 
+
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block
 # This is added to help document dynamic targets and support shell autocompletion

--- a/projects/fluxcd/flux2/Makefile
+++ b/projects/fluxcd/flux2/Makefile
@@ -35,6 +35,7 @@ $(FIX_LICENSES_SHA1CD): | $(GO_MOD_DOWNLOAD_TARGETS)
 # Copying in manually for now until the dep is updated upstream
 	wget -q --retry-connrefused -O $@ https://raw.githubusercontent.com/pjbgf/sha1cd/main/LICENSE
 
+
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block
 # This is added to help document dynamic targets and support shell autocompletion

--- a/projects/goharbor/harbor/Makefile
+++ b/projects/goharbor/harbor/Makefile
@@ -153,6 +153,7 @@ combine-images: IMAGE_BUILD_ARGS=IMAGE
 combine-images: DOCKERFILE_FOLDER=./docker/linux/combine
 combine-images: images
 
+
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block
 # This is added to help document dynamic targets and support shell autocompletion

--- a/projects/kubernetes-sigs/cluster-api/Makefile
+++ b/projects/kubernetes-sigs/cluster-api/Makefile
@@ -69,6 +69,7 @@ $(FIX_LICENSES_TEST_KIND_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
 # We use capi license instead
 	cp $(REPO)/LICENSE $@
 
+
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block
 # This is added to help document dynamic targets and support shell autocompletion

--- a/projects/kubernetes-sigs/kind/Makefile
+++ b/projects/kubernetes-sigs/kind/Makefile
@@ -65,7 +65,7 @@ BUILDSPEC_2_VARS_VALUES=SUPPORTED_K8S_VERSIONS
 include $(BASE_DIRECTORY)/Common.mk
 
 # Do not need to import if running clean or any var-value-% targets
-ifneq ($(and $(RELEASE_BRANCH),$(filter-out clean,$(MAKECMDGOALS_WITHOUT_VAR_VALUE))),)
+ifneq ($(and $(RELEASE_BRANCH),$(filter-out clean help-list add-generated-help-block,$(MAKECMDGOALS_WITHOUT_VAR_VALUE))),)
 -include $(KIND_BASE_IMAGE_BUILD_ARGS)
 -include $(KIND_NODE_IMAGE_BUILD_ARGS)
 endif

--- a/projects/kubernetes/autoscaler/Makefile
+++ b/projects/kubernetes/autoscaler/Makefile
@@ -49,6 +49,7 @@ $(FIX_LICENSES): | $(GO_MOD_DOWNLOAD_TARGETS)
 #go-licenses requires a LICENSE file in each folder with the go.mod
 	cp $(REPO)/LICENSE $@
 
+
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block
 # This is added to help document dynamic targets and support shell autocompletion


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There was a weird issue last night generating the kind help due the logging around one of the targets. Im not 100% sure why this isnt consistent, but this should clean it up.

Last night's PR: https://github.com/aws/eks-anywhere-build-tooling/pull/2622

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
