### PR TITLE
bumps ssh timeout to 40m for raw and qemu image builds

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0026-adds-retries-and-timeout-to-packer-image-builder.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0026-adds-retries-and-timeout-to-packer-image-builder.patch
@@ -139,7 +139,7 @@ index dd93fc8da..599fd5f6d 100644
 +      "ssh_handshake_attempts": "100",
        "ssh_password": "{{user `ssh_password`}}",
 -      "ssh_timeout": "2h",
-+      "ssh_timeout": "20m",
++      "ssh_timeout": "40m",
        "ssh_username": "{{user `ssh_username`}}",
        "type": "qemu",
        "vm_name": "{{user `vm_name`}}"
@@ -174,7 +174,7 @@ index 83aa6b4fb..5e983fa59 100644
 +      "ssh_handshake_attempts": "100",
        "ssh_password": "{{user `ssh_password`}}",
 -      "ssh_timeout": "2h",
-+      "ssh_timeout": "20m",
++      "ssh_timeout": "40m",
        "ssh_username": "{{user `ssh_username`}}",
        "type": "qemu",
        "vm_name": "{{user `vm_name`}}"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
