### PR TITLE
better handle no golang version when cleaning up go cache directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ MAKEFLAGS+=--no-builtin-rules --warn-undefined-variables --no-print-directory
 BASE_DIRECTORY:=$(abspath .)
 BUILD_LIB=${BASE_DIRECTORY}/build/lib
 SHELL_TRACE?=false
-DEFAULT_SHELL:=$(if $(filter true,$(SHELL_TRACE)),$(BUILD_LIB)/make_shell.sh trace,bash)
+DEFAULT_SHELL:=$(if $(filter true,$(SHELL_TRACE)),$(BUILD_LIB)/make_shell.sh trace true,bash)
 SHELL:=$(DEFAULT_SHELL)
 .SHELLFLAGS:=-eu -o pipefail -c
 

--- a/build/lib/generate_help_body.sh
+++ b/build/lib/generate_help_body.sh
@@ -130,6 +130,7 @@ fi
 
 CLEAN_TARGETS="${NL}${NL}##@ Clean Targets"
 CLEAN_TARGETS+="${NL}clean: ## Removes source and _output directory"
+CLEAN_TARGETS+="${NL}clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders"
 if [[ "$REPO_NO_CLONE" != "true" ]]; then
     CLEAN_TARGETS+="${NL}clean-repo: ## Removes source directory"
 fi

--- a/build/lib/make_shell.sh
+++ b/build/lib/make_shell.sh
@@ -13,13 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# args: <trace|log|docker> <-c|-eu -o pipefail -c>
+# args: <trace|log|docker> <true|false> <-c|-eu -o pipefail -c>
 
 ACTION="$1"
-if [ "$ACTION" = "trace" ]; then
+TRACE="$2"
+if [ "$TRACE" = "true" ]; then
     >&2 echo "Shell trace: $@"
+
+    if [ -n "${LOGGING_TARGET:-}" ]; then
+        >&2 echo "LOGGING_TARGET set to: ${LOGGING_TARGET}"
+    fi
+    
+    if [ -n "${RUN_IN_DOCKER_ARGS:-}" ]; then
+        >&2 echo "RUN_IN_DOCKER_ARGS set to: ${RUN_IN_DOCKER_ARGS}"
+    fi
 fi
 
+shift
 shift
 
 # remove action and shellflags up to the -c

--- a/projects/apache/cloudstack-cloudmonkey/Help.mk
+++ b/projects/apache/cloudstack-cloudmonkey/Help.mk
@@ -51,6 +51,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/aquasecurity/harbor-scanner-trivy/Help.mk
+++ b/projects/aquasecurity/harbor-scanner-trivy/Help.mk
@@ -52,6 +52,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/aquasecurity/trivy/Help.mk
+++ b/projects/aquasecurity/trivy/Help.mk
@@ -52,6 +52,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/aws-containers/hello-eks-anywhere/Help.mk
+++ b/projects/aws-containers/hello-eks-anywhere/Help.mk
@@ -34,6 +34,7 @@ run-in-docker/validate-checksums: ## Run `validate-checksums` in docker builder 
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/aws-observability/aws-otel-collector/Help.mk
+++ b/projects/aws-observability/aws-otel-collector/Help.mk
@@ -28,6 +28,7 @@ run-in-docker/validate-checksums: ## Run `validate-checksums` in docker builder 
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/aws/bottlerocket-bootstrap/Help.mk
+++ b/projects/aws/bottlerocket-bootstrap/Help.mk
@@ -63,6 +63,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 
 ##@ Helpers
 help: ## Display this help

--- a/projects/aws/cluster-api-provider-aws-snow/Help.mk
+++ b/projects/aws/cluster-api-provider-aws-snow/Help.mk
@@ -35,6 +35,7 @@ upload-artifacts: # Upload tarballs and other artifacts from ARTIFACTS_PATH to S
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/aws/eks-a-admin-image/Help.mk
+++ b/projects/aws/eks-a-admin-image/Help.mk
@@ -20,6 +20,7 @@ run-in-docker/validate-checksums: ## Run `validate-checksums` in docker builder 
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 
 ##@ Helpers
 help: ## Display this help

--- a/projects/aws/eks-anywhere-build-tooling/Help.mk
+++ b/projects/aws/eks-anywhere-build-tooling/Help.mk
@@ -44,6 +44,7 @@ run-in-docker/validate-checksums: ## Run `validate-checksums` in docker builder 
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 
 ##@ Helpers
 help: ## Display this help

--- a/projects/aws/eks-anywhere-packages/Help.mk
+++ b/projects/aws/eks-anywhere-packages/Help.mk
@@ -82,6 +82,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/aws/eks-anywhere/Help.mk
+++ b/projects/aws/eks-anywhere/Help.mk
@@ -30,6 +30,7 @@ run-in-docker/validate-checksums: ## Run `validate-checksums` in docker builder 
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 
 ##@ Helpers
 help: ## Display this help

--- a/projects/aws/etcdadm-bootstrap-provider/Help.mk
+++ b/projects/aws/etcdadm-bootstrap-provider/Help.mk
@@ -57,6 +57,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/aws/etcdadm-controller/Help.mk
+++ b/projects/aws/etcdadm-controller/Help.mk
@@ -57,6 +57,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/aws/image-builder/Help.mk
+++ b/projects/aws/image-builder/Help.mk
@@ -47,6 +47,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 
 ##@ Helpers
 help: ## Display this help

--- a/projects/aws/rolesanywhere-credential-helper/Help.mk
+++ b/projects/aws/rolesanywhere-credential-helper/Help.mk
@@ -51,6 +51,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/brancz/kube-rbac-proxy/Help.mk
+++ b/projects/brancz/kube-rbac-proxy/Help.mk
@@ -52,6 +52,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/cert-manager/cert-manager/Help.mk
+++ b/projects/cert-manager/cert-manager/Help.mk
@@ -93,6 +93,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/cilium/cilium/Help.mk
+++ b/projects/cilium/cilium/Help.mk
@@ -29,6 +29,7 @@ upload-artifacts: # Upload tarballs and other artifacts from ARTIFACTS_PATH to S
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/containerd/containerd/Help.mk
+++ b/projects/containerd/containerd/Help.mk
@@ -75,6 +75,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/distribution/distribution/Help.mk
+++ b/projects/distribution/distribution/Help.mk
@@ -52,6 +52,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/emissary-ingress/emissary/Help.mk
+++ b/projects/emissary-ingress/emissary/Help.mk
@@ -82,6 +82,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/envoyproxy/envoy/Help.mk
+++ b/projects/envoyproxy/envoy/Help.mk
@@ -34,6 +34,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 
 ##@ Helpers
 help: ## Display this help

--- a/projects/fluxcd/flux2/Help.mk
+++ b/projects/fluxcd/flux2/Help.mk
@@ -61,6 +61,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/fluxcd/helm-controller/Help.mk
+++ b/projects/fluxcd/helm-controller/Help.mk
@@ -52,6 +52,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/fluxcd/kustomize-controller/Help.mk
+++ b/projects/fluxcd/kustomize-controller/Help.mk
@@ -52,6 +52,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/fluxcd/notification-controller/Help.mk
+++ b/projects/fluxcd/notification-controller/Help.mk
@@ -52,6 +52,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/fluxcd/source-controller/Help.mk
+++ b/projects/fluxcd/source-controller/Help.mk
@@ -52,6 +52,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/goharbor/harbor/Help.mk
+++ b/projects/goharbor/harbor/Help.mk
@@ -110,6 +110,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/helm/helm/Help.mk
+++ b/projects/helm/helm/Help.mk
@@ -52,6 +52,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/kube-vip/kube-vip/Help.mk
+++ b/projects/kube-vip/kube-vip/Help.mk
@@ -53,6 +53,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/kubernetes-sigs/cluster-api-provider-cloudstack/Help.mk
+++ b/projects/kubernetes-sigs/cluster-api-provider-cloudstack/Help.mk
@@ -57,6 +57,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/kubernetes-sigs/cluster-api-provider-vsphere/Help.mk
+++ b/projects/kubernetes-sigs/cluster-api-provider-vsphere/Help.mk
@@ -58,6 +58,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/kubernetes-sigs/cluster-api/Help.mk
+++ b/projects/kubernetes-sigs/cluster-api/Help.mk
@@ -89,6 +89,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/kubernetes-sigs/cri-tools/Help.mk
+++ b/projects/kubernetes-sigs/cri-tools/Help.mk
@@ -56,6 +56,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/kubernetes-sigs/etcdadm/Help.mk
+++ b/projects/kubernetes-sigs/etcdadm/Help.mk
@@ -52,6 +52,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/kubernetes-sigs/image-builder/Help.mk
+++ b/projects/kubernetes-sigs/image-builder/Help.mk
@@ -31,6 +31,7 @@ run-in-docker/validate-checksums: ## Run `validate-checksums` in docker builder 
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/kubernetes-sigs/kind/Help.mk
+++ b/projects/kubernetes-sigs/kind/Help.mk
@@ -80,6 +80,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 create-kind-cluster-amd64: ## Create local kind cluster using built amd64 image
 create-kind-cluster-arm64: ## Create local kind cluster using built arm64 image

--- a/projects/kubernetes-sigs/metrics-server/Help.mk
+++ b/projects/kubernetes-sigs/metrics-server/Help.mk
@@ -28,6 +28,7 @@ run-in-docker/validate-checksums: ## Run `validate-checksums` in docker builder 
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/kubernetes/autoscaler/Help.mk
+++ b/projects/kubernetes/autoscaler/Help.mk
@@ -57,6 +57,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/kubernetes/cloud-provider-aws/Help.mk
+++ b/projects/kubernetes/cloud-provider-aws/Help.mk
@@ -51,6 +51,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/kubernetes/cloud-provider-vsphere/Help.mk
+++ b/projects/kubernetes/cloud-provider-vsphere/Help.mk
@@ -52,6 +52,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/metallb/metallb/Help.mk
+++ b/projects/metallb/metallb/Help.mk
@@ -63,6 +63,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/nutanix-cloud-native/cluster-api-provider-nutanix/Help.mk
+++ b/projects/nutanix-cloud-native/cluster-api-provider-nutanix/Help.mk
@@ -57,6 +57,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/opencontainers/runc/Help.mk
+++ b/projects/opencontainers/runc/Help.mk
@@ -51,6 +51,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/prometheus/node_exporter/Help.mk
+++ b/projects/prometheus/node_exporter/Help.mk
@@ -53,6 +53,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/prometheus/prometheus/Help.mk
+++ b/projects/prometheus/prometheus/Help.mk
@@ -61,6 +61,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/rancher/local-path-provisioner/Help.mk
+++ b/projects/rancher/local-path-provisioner/Help.mk
@@ -52,6 +52,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/redis/redis/Help.mk
+++ b/projects/redis/redis/Help.mk
@@ -26,6 +26,7 @@ run-in-docker/validate-checksums: ## Run `validate-checksums` in docker builder 
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 
 ##@ Helpers
 help: ## Display this help

--- a/projects/replicatedhq/troubleshoot/Help.mk
+++ b/projects/replicatedhq/troubleshoot/Help.mk
@@ -52,6 +52,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/tinkerbell/boots/Help.mk
+++ b/projects/tinkerbell/boots/Help.mk
@@ -52,6 +52,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/Help.mk
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/Help.mk
@@ -57,6 +57,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/tinkerbell/hegel/Help.mk
+++ b/projects/tinkerbell/hegel/Help.mk
@@ -52,6 +52,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/tinkerbell/hook/Help.mk
+++ b/projects/tinkerbell/hook/Help.mk
@@ -68,6 +68,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/tinkerbell/hub/Help.mk
+++ b/projects/tinkerbell/hub/Help.mk
@@ -91,6 +91,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/tinkerbell/rufio/Help.mk
+++ b/projects/tinkerbell/rufio/Help.mk
@@ -57,6 +57,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/tinkerbell/tink/Help.mk
+++ b/projects/tinkerbell/tink/Help.mk
@@ -72,6 +72,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/tinkerbell/tinkerbell-chart/Help.mk
+++ b/projects/tinkerbell/tinkerbell-chart/Help.mk
@@ -32,6 +32,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 
 ##@ Helpers
 help: ## Display this help

--- a/projects/torvalds/linux/Help.mk
+++ b/projects/torvalds/linux/Help.mk
@@ -39,6 +39,7 @@ upload-artifacts: # Upload tarballs and other artifacts from ARTIFACTS_PATH to S
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers

--- a/projects/vmware/govmomi/Help.mk
+++ b/projects/vmware/govmomi/Help.mk
@@ -51,6 +51,7 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 
 ##@ Clean Targets
 clean: ## Removes source and _output directory
+clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
 ##@ Helpers


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The nightly attribution generation has been failing since my docker changes.  I had changed the use_go_version function to return early if the supplied go_version was empty. Before it would have just defaulted to the default go version in the container.  Since it never gets set, the GOCACHE folder was being set to `/root/.cache/go-build` instead of `/root/.cache/go-build/{GO_VERSION}`.  This not a big deal since that project isnt doing any building anyway.  

The problem comes when in prow we mount` /root/.cache/go-build` so when clean-go-cache tried to delete it, it cant because its not really a folder. This changes that code to check for a go_version before trying to delete those go folders.

Since i was in here, i also tweaked the way the trace shell works so it can be used when targets override to use logging or docker.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
