### PR TITLE
gives a better error message when downloading dependencies fails

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -839,9 +839,10 @@ helm/build: $(if $(wildcard $(PROJECT_ROOT)/helm/patches),$(HELM_GIT_PATCH_TARGE
 helm/push: helm/build | ensure-helm $$(ENABLE_LOGGING)
 	@$(BUILD_LIB)/helm_push.sh $(IMAGE_REPO) $(HELM_DESTINATION_REPOSITORY) $(HELM_TAG) $(GIT_TAG) $(OUTPUT_DIR) $(LATEST)
 
-## Fetch Binary Targets
+#@ Fetch Binary Targets
 .PHONY: handle-dependencies 
-handle-dependencies: $(call PROJECT_DEPENDENCIES_TARGETS)
+handle-dependencies: # Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+handle-dependencies: $(PROJECT_DEPENDENCIES_TARGETS)
 
 $(BINARY_DEPS_DIR)/linux-%: | $$(ENABLE_LOGGING)
 	@$(BUILD_LIB)/fetch_binaries.sh $(BINARY_DEPS_DIR) $* $(ARTIFACTS_BUCKET) $(LATEST) $(RELEASE_BRANCH)

--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -344,7 +344,11 @@ function build::common::get_latest_eksa_asset_url() {
   elif build::common::echo_and_run aws s3api head-object --bucket $(basename $artifact_bucket) --key $fallback_latest_uri &> /dev/null; then
     aws s3 presign $artifact_bucket/$fallback_latest_uri
   else
-    echo "No artifact availabe!"
+    >&2 echo "******* No artifact availabe! *******"
+    >&2 echo "${s3_url_prefix}/${fallback_latest_uri} does not exists!"
+    >&2 echo "Please double check the value of \$ARTIFACTS_BUCKET."
+    >&2 echo "${git_tag} of ${project} may not be the current latest version, verify you have the latest code from main to be sure."
+    >&2 echo "*************************************"
     exit 1
   fi
 }

--- a/build/lib/fetch_binaries.sh
+++ b/build/lib/fetch_binaries.sh
@@ -44,12 +44,6 @@ if [[ -n "$RELEASE_BRANCH_OVERRIDE" ]]; then
     OUTPUT_DIR_FILE+=/$RELEASE_BRANCH_OVERRIDE
 fi
 
-if [[ $REPO == *.tar.gz ]]; then
-    mkdir -p $(dirname $OUTPUT_DIR_FILE)
-else
-    mkdir -p $OUTPUT_DIR_FILE
-fi
-
 if [[ $PRODUCT = 'eksd' ]]; then
     if [[ $REPO_OWNER = 'kubernetes' ]]; then
         TARBALL="kubernetes-$REPO-linux-$ARCH.tar.gz"
@@ -76,7 +70,13 @@ FILENAME_AND_POSSIBLE_QUERY=${URL##*/}
 
 build::common::echo_and_run wget -q --retry-connrefused "$URL" -O $DOWNLOAD_DIR/${FILENAME_AND_POSSIBLE_QUERY%%[?#]*}
 build::common::echo_and_run wget -q --retry-connrefused "$SHA_URL" -O $DOWNLOAD_DIR/${FILENAME_AND_POSSIBLE_QUERY%%[?#]*}.sha256
- (cd $DOWNLOAD_DIR && sha256sum -c *.sha256)
+(cd $DOWNLOAD_DIR && sha256sum -c *.sha256)
+
+if [[ $REPO == *.tar.gz ]]; then
+    mkdir -p $(dirname $OUTPUT_DIR_FILE)
+else
+    mkdir -p $OUTPUT_DIR_FILE
+fi
 
 if [[ $REPO == *.tar.gz ]]; then
     build::common::echo_and_run mv $DOWNLOAD_DIR/*.tar.gz $OUTPUT_DIR_FILE

--- a/projects/apache/cloudstack-cloudmonkey/Help.mk
+++ b/projects/apache/cloudstack-cloudmonkey/Help.mk
@@ -54,6 +54,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/aquasecurity/harbor-scanner-trivy/Help.mk
+++ b/projects/aquasecurity/harbor-scanner-trivy/Help.mk
@@ -55,6 +55,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/aquasecurity/trivy/Help.mk
+++ b/projects/aquasecurity/trivy/Help.mk
@@ -55,6 +55,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/aws-containers/hello-eks-anywhere/Help.mk
+++ b/projects/aws-containers/hello-eks-anywhere/Help.mk
@@ -37,6 +37,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/aws-observability/aws-otel-collector/Help.mk
+++ b/projects/aws-observability/aws-otel-collector/Help.mk
@@ -31,6 +31,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/aws/bottlerocket-bootstrap/Help.mk
+++ b/projects/aws/bottlerocket-bootstrap/Help.mk
@@ -65,6 +65,9 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/aws/cluster-api-provider-aws-snow/Help.mk
+++ b/projects/aws/cluster-api-provider-aws-snow/Help.mk
@@ -38,6 +38,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/aws/eks-a-admin-image/Help.mk
+++ b/projects/aws/eks-a-admin-image/Help.mk
@@ -22,6 +22,9 @@ run-in-docker/validate-checksums: ## Run `validate-checksums` in docker builder 
 clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/aws/eks-anywhere-build-tooling/Help.mk
+++ b/projects/aws/eks-anywhere-build-tooling/Help.mk
@@ -46,6 +46,9 @@ run-in-docker/validate-checksums: ## Run `validate-checksums` in docker builder 
 clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/aws/eks-anywhere-packages/Help.mk
+++ b/projects/aws/eks-anywhere-packages/Help.mk
@@ -85,6 +85,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/aws/eks-anywhere/Help.mk
+++ b/projects/aws/eks-anywhere/Help.mk
@@ -32,6 +32,9 @@ run-in-docker/validate-checksums: ## Run `validate-checksums` in docker builder 
 clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/aws/etcdadm-bootstrap-provider/Help.mk
+++ b/projects/aws/etcdadm-bootstrap-provider/Help.mk
@@ -60,6 +60,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/aws/etcdadm-controller/Help.mk
+++ b/projects/aws/etcdadm-controller/Help.mk
@@ -60,6 +60,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/aws/image-builder/Help.mk
+++ b/projects/aws/image-builder/Help.mk
@@ -49,6 +49,9 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/aws/rolesanywhere-credential-helper/Help.mk
+++ b/projects/aws/rolesanywhere-credential-helper/Help.mk
@@ -54,6 +54,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/brancz/kube-rbac-proxy/Help.mk
+++ b/projects/brancz/kube-rbac-proxy/Help.mk
@@ -55,6 +55,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/cert-manager/cert-manager/Help.mk
+++ b/projects/cert-manager/cert-manager/Help.mk
@@ -96,6 +96,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/cilium/cilium/Help.mk
+++ b/projects/cilium/cilium/Help.mk
@@ -32,6 +32,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/containerd/containerd/Help.mk
+++ b/projects/containerd/containerd/Help.mk
@@ -78,6 +78,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/distribution/distribution/Help.mk
+++ b/projects/distribution/distribution/Help.mk
@@ -55,6 +55,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/emissary-ingress/emissary/Help.mk
+++ b/projects/emissary-ingress/emissary/Help.mk
@@ -85,6 +85,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/envoyproxy/envoy/Help.mk
+++ b/projects/envoyproxy/envoy/Help.mk
@@ -36,6 +36,9 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/fluxcd/flux2/Help.mk
+++ b/projects/fluxcd/flux2/Help.mk
@@ -64,6 +64,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/fluxcd/helm-controller/Help.mk
+++ b/projects/fluxcd/helm-controller/Help.mk
@@ -55,6 +55,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/fluxcd/kustomize-controller/Help.mk
+++ b/projects/fluxcd/kustomize-controller/Help.mk
@@ -55,6 +55,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/fluxcd/notification-controller/Help.mk
+++ b/projects/fluxcd/notification-controller/Help.mk
@@ -55,6 +55,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/fluxcd/source-controller/Help.mk
+++ b/projects/fluxcd/source-controller/Help.mk
@@ -55,6 +55,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/goharbor/harbor/Help.mk
+++ b/projects/goharbor/harbor/Help.mk
@@ -113,6 +113,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/helm/helm/Help.mk
+++ b/projects/helm/helm/Help.mk
@@ -55,6 +55,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/kube-vip/kube-vip/Help.mk
+++ b/projects/kube-vip/kube-vip/Help.mk
@@ -56,6 +56,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/kubernetes-sigs/cluster-api-provider-cloudstack/Help.mk
+++ b/projects/kubernetes-sigs/cluster-api-provider-cloudstack/Help.mk
@@ -60,6 +60,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/kubernetes-sigs/cluster-api-provider-vsphere/Help.mk
+++ b/projects/kubernetes-sigs/cluster-api-provider-vsphere/Help.mk
@@ -61,6 +61,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/kubernetes-sigs/cluster-api/Help.mk
+++ b/projects/kubernetes-sigs/cluster-api/Help.mk
@@ -92,6 +92,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/kubernetes-sigs/cri-tools/Help.mk
+++ b/projects/kubernetes-sigs/cri-tools/Help.mk
@@ -59,6 +59,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/kubernetes-sigs/etcdadm/Help.mk
+++ b/projects/kubernetes-sigs/etcdadm/Help.mk
@@ -55,6 +55,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/kubernetes-sigs/image-builder/Help.mk
+++ b/projects/kubernetes-sigs/image-builder/Help.mk
@@ -34,6 +34,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/kubernetes-sigs/kind/Help.mk
+++ b/projects/kubernetes-sigs/kind/Help.mk
@@ -85,6 +85,9 @@ clean-repo: ## Removes source directory
 create-kind-cluster-amd64: ## Create local kind cluster using built amd64 image
 create-kind-cluster-arm64: ## Create local kind cluster using built arm64 image
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/kubernetes-sigs/metrics-server/Help.mk
+++ b/projects/kubernetes-sigs/metrics-server/Help.mk
@@ -31,6 +31,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/kubernetes/autoscaler/Help.mk
+++ b/projects/kubernetes/autoscaler/Help.mk
@@ -60,6 +60,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/kubernetes/cloud-provider-aws/Help.mk
+++ b/projects/kubernetes/cloud-provider-aws/Help.mk
@@ -54,6 +54,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/kubernetes/cloud-provider-vsphere/Help.mk
+++ b/projects/kubernetes/cloud-provider-vsphere/Help.mk
@@ -55,6 +55,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/metallb/metallb/Help.mk
+++ b/projects/metallb/metallb/Help.mk
@@ -66,6 +66,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/nutanix-cloud-native/cluster-api-provider-nutanix/Help.mk
+++ b/projects/nutanix-cloud-native/cluster-api-provider-nutanix/Help.mk
@@ -60,6 +60,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/opencontainers/runc/Help.mk
+++ b/projects/opencontainers/runc/Help.mk
@@ -54,6 +54,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/prometheus/node_exporter/Help.mk
+++ b/projects/prometheus/node_exporter/Help.mk
@@ -56,6 +56,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/prometheus/prometheus/Help.mk
+++ b/projects/prometheus/prometheus/Help.mk
@@ -64,6 +64,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/rancher/local-path-provisioner/Help.mk
+++ b/projects/rancher/local-path-provisioner/Help.mk
@@ -55,6 +55,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/redis/redis/Help.mk
+++ b/projects/redis/redis/Help.mk
@@ -28,6 +28,9 @@ run-in-docker/validate-checksums: ## Run `validate-checksums` in docker builder 
 clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/replicatedhq/troubleshoot/Help.mk
+++ b/projects/replicatedhq/troubleshoot/Help.mk
@@ -55,6 +55,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/tinkerbell/boots/Help.mk
+++ b/projects/tinkerbell/boots/Help.mk
@@ -55,6 +55,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/tinkerbell/cluster-api-provider-tinkerbell/Help.mk
+++ b/projects/tinkerbell/cluster-api-provider-tinkerbell/Help.mk
@@ -60,6 +60,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/tinkerbell/hegel/Help.mk
+++ b/projects/tinkerbell/hegel/Help.mk
@@ -55,6 +55,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/tinkerbell/hook/Help.mk
+++ b/projects/tinkerbell/hook/Help.mk
@@ -71,6 +71,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/tinkerbell/hub/Help.mk
+++ b/projects/tinkerbell/hub/Help.mk
@@ -94,6 +94,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/tinkerbell/rufio/Help.mk
+++ b/projects/tinkerbell/rufio/Help.mk
@@ -60,6 +60,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/tinkerbell/tink/Help.mk
+++ b/projects/tinkerbell/tink/Help.mk
@@ -75,6 +75,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/tinkerbell/tinkerbell-chart/Help.mk
+++ b/projects/tinkerbell/tinkerbell-chart/Help.mk
@@ -34,6 +34,9 @@ all-attributions-checksums: ## Update attribution and checksums files for all RE
 clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/torvalds/linux/Help.mk
+++ b/projects/torvalds/linux/Help.mk
@@ -42,6 +42,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion

--- a/projects/vmware/govmomi/Help.mk
+++ b/projects/vmware/govmomi/Help.mk
@@ -54,6 +54,9 @@ clean: ## Removes source and _output directory
 clean-go-cache: ## Removes the GOMODCACHE AND GOCACHE folders
 clean-repo: ## Removes source directory
 
+##@Fetch Binary Targets
+handle-dependencies: ## Download and extract TARs for each dependency listed in PROJECT_DEPENDENCIES
+
 ##@ Helpers
 help: ## Display this help
 add-generated-help-block: ## Add or update generated help block to document project make file and support shell auto completion


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When downloading deps fails its pretty silent. This adds a better error message to guide the dev.  Also improved the rerunable of the targets by delaying when the extract folder is created so that if download fails and you rerun, it will try again versus thinking it was already done due to the folder existing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
