### PR TITLE
supports s3 path prefixes in bucket variable

### DIFF
--- a/build/lib/fetch_binaries.sh
+++ b/build/lib/fetch_binaries.sh
@@ -59,10 +59,6 @@ else
     SHA_URL="$(build::common::echo_and_run build::common::get_latest_eksa_asset_url_sha256 $ARTIFACTS_BUCKET $REPO_OWNER/$REPO $ARCH $LATEST_TAG $RELEASE_BRANCH)"
 fi
 
-if [ "$CODEBUILD_CI" = "true" ]; then
-    build::common::echo_and_run build::common::wait_for_tarball $URL
-fi
-
 DOWNLOAD_DIR=$(mktemp -d)
 trap "rm -rf $DOWNLOAD_DIR" EXIT
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When building privately or in the case of staging bundle build, wed like to be able to push to and pull from a clean folder on s3. This will allow us to ensure that when we build the entire stack we are building all the deps as needed and not potentially pulling older builds.

The way this is setup is to support supplying a path/prefix in ARTIFACTS_BUCKET. for ex

`export ARTIFACTS_BUCKET=s3://my-bucket/staging/release/1`

Another option would be to introduce a new var, ARTIFACTS_BUCKET_PREFIX.  This approach may be slightly more clear, but there are a number of places wed have to handle this in the code today.  If we really wanted to have a second var we could something like:

```
export ARTIFACTS_BUCKET=s3://my-bucket
export ARTIFACTS_BUCKET_PREFIX=/staging/build/1
```

Then in Common.mk do:

`ARTIFACTS_BUCKET+=$(ARTIFACTS_BUCKET_PREFIX)`

This approach has the benefit of 2 vars but to all the existing code, ARTIFACTS_BUCKET has the full path that it needs.

The utilmate plan here is to change the bundle pipeline to generate a new, unique, s3 prefix/folder so that all the builds in that pipeline push and pull from that folder, instead of the `latest` folder.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
