### PR TITLE
adds check for qemu and updates docs a bit

### DIFF
--- a/docs/development/building-locally.md
+++ b/docs/development/building-locally.md
@@ -7,36 +7,25 @@ This is to ensure checksums and attributions match what is generated in our CI a
 To force running targets on the host: `export FORCE_GO_BUILD_ON_HOST=true`.
 
 
-## Pre-requisites for building on MacOS host
-* Docker Desktop - https://docs.docker.com/desktop/install/mac-install/
-* Common utils required - `brew install jq yq`
-* Bash 4.2+ is required - `breq install bash`
-* A number of targets which run on the host require the gnu variants of common tools
-	such as `date` `find` `sed` `stat` `tar` - `brew install coreutils findutils gnu-sed gnu-tar`
-* Building container images requires `buildctl` - `brew buildkit`
-* Building helm charts requires `helm` and `skopeo`
-	* https://helm.sh/docs/intro/install/ - `curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash`
-	* https://github.com/containers/skopeo - `brew install skopeo`
-* To make pushing to ECR easier: `brew install docker-credential-helper-ecr`
-
 ## Pre-requisites for building on Linux (AL2/AL23) host
 * Docker
 	* `sudo yum install -y docker && sudo usermod -a -G docker ec2-user && id ec2-user && newgrp docker`
 	* `sudo systemctl enable docker.service && sudo systemctl start docker.service`
 * Common utils required 
-	* `sudo yum -y install jq git-core make lz4`
+	* `sudo yum -y install bc jq git-core make lz4`
 * `yq` is required by a number of targets
 	* `sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_$([ "x86_64" = "$(uname -m)" ] && echo amd64 || echo arm64) && sudo chmod +x /usr/local/bin/yq`
 * Building helm charts requires `helm` and `skopeo`
 	* https://helm.sh/docs/intro/install/ - `curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash`
 	* https://github.com/containers/skopeo - There is no binary release of skopeo for linux see [installing](https://github.com/containers/skopeo/blob/main/install.md) or
 		copy from builder-base image to host: `CONTAINER_ID=$(docker run -d -i public.ecr.aws/eks-distro-build-tooling/builder-base:standard-latest.al2 bash) && sudo docker cp $CONTAINER_ID:/usr/bin/skopeo /usr/local/bin && docker rm -vf $CONTAINER_ID`
-* Building container images for different architectures will require `qemu`
-	* `docker run --privileged --rm public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0 --install aarch64,amd64`
-* To ensure string sorting matches our build pipelines - `export LANG=C.UTF-8`
 * To make pushing to ECR easier: `sudo yum install amazon-ecr-credential-helper -y`
 * (Skip for AL23) Upgrade to aws cli v2: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
-* Building image-builder
+* To ensure string sorting matches our build pipelines - `export LANG=C.UTF-8`
+* Building CGO or other projects which require cross platform builds will `qemu`
+	* **NOTE:** This will need to be ran after each reboot
+	* `docker run --privileged --rm public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0 --install aarch64,amd64`
+* (rare) Building image-builder
 	* `tuftool` to download Bottlerocket images - https://github.com/awslabs/tough - There is no binary release of tuftool for linux see [Readme](https://github.com/awslabs/tough/blob/develop/tuftool/README.md) or
 		copy from builder-base image to host: `CONTAINER_ID=$(docker run -d -i public.ecr.aws/eks-distro-build-tooling/builder-base:standard-latest.al2 bash) && sudo docker cp $CONTAINER_ID:/usr/bin/tuftool /usr/local/bin && docker rm -vf $CONTAINER_ID`
 	* (Skip for AL23) python 3.9 is required for the version of ansible required. AL2 does not ship a python 3.9 package so the easiest way to install it is building it with pyenv:
@@ -46,29 +35,47 @@ To force running targets on the host: `export FORCE_GO_BUILD_ON_HOST=true`.
 		* `pyenv install 3.9 && pyenv global 3.9`
 
 
+## Pre-requisites for building on MacOS host
+* Docker Desktop - https://docs.docker.com/desktop/install/mac-install/
+* Common utils required - `brew install jq yq`
+* Bash 4.2+ is required - `brew install bash`
+* A number of targets which run on the host require the gnu variants of common tools
+	such as `date` `find` `sed` `stat` `tar` - `brew install coreutils findutils gnu-sed gnu-tar`
+* Building helm charts requires `helm` and `skopeo`
+	* https://helm.sh/docs/intro/install/ - `curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash`
+	* https://github.com/containers/skopeo - `brew install skopeo`
+* To make pushing to ECR easier: `brew install docker-credential-helper-ecr`
+* aws cli v2: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
+* (rare) Building image-builder
+	* `tuftool` to download Bottlerocket images - https://github.com/awslabs/tough
+	* python 3.9 is required for the version of ansible required.
+		* `brew install python@3.9`
+
 ## Typical build targets
 
 Each project folder contains a Makefile with the following build targets.
 
-* `binaries` - clones repo, checks out git tag and builds binaries.
-* `local-images` - builds container images and writes to `/tmp/{project}.tar`.
-* `images` - builds container images apnd pushes to configured registry. For a few projects (coredns, etcd, kubernetes) local oci tars are also built
-	to be uploaded to s3.
-* `gather-licenses` - copies licenses from all project dependencies and puts in `_output/LICENSES` to be included in tarballs and container images.
-* `attribution` - regenerate the ATTRIBUTION.txt file, golang versions are important here so make sure you have the same versions as the builder-base.
-	There is a periodic job which runs every day to keep these up to date, builds will not fail due to these not being 100% accurate.
-* `checksums` - update CHECKSUMS file based on currently built binaries.  Builds should be reproducible across Mac and Linux hosts.
-	This should be run when bumping GIT_TAG, changing patches or changing build flags, otherwise should not be changed. 
+* `checkout-repo` - clones project repo, checkouts GIT_TAG and patches if `patches` directory exists for current project.
+* (Runs in Docker) `binaries` - builds binaries for current project.
+* (Runs in Docker) `gather-licenses` - copies licenses from all project dependencies and puts in `_output/LICENSES` to be included in tarballs and container images.
+* (Runs in Docker) `attribution` - regenerate the ATTRIBUTION.txt file.
+* `checksums` - update CHECKSUMS file based on currently built binaries. This should be run when bumping GIT_TAG, changing patches or changing build flags, otherwise should not be changed.
 	Builds will fail if these do not match, but the correct checksums will be outputted to make updating easier.
-* `build` - run via prow presubmit, clones repo, build binary(s), gather licenses, build container images, build tarballs and generate attribution file.
+* `local-images` - builds container images, for the current host architecture, and exports to `/tmp/{project}.tar`.
+* `images` - builds container images, for both `linux/amd64` and `linux/arm64` and pushes to configured (`IMAGE_REPO`) registry.
+* `build` - run via presubmit, clones repo, build binary(s), gather licenses, build container images, build tarballs and generate attribution file.
 	Uses `local-images` to build images which does not push to a registry.
-* `release` - run via prow postsubmit, same as `build` except runs `images` to push to a remote registry and to push tars/binaries
-	to s3.
-
+* `release` - run via postsubmit, same as `build` except runs `images` to push to a remote registry and to push tars/binaries to s3.
+* `clean` - removes source and _output directory.
+* `clean-repo` - removes source directory.
+* `clean-go-cache` - removes the `GOMODCACHE` AND `GOCACHE` folders.
 
 ## Pre-requisites for building container images
 
 * There are two options for building container images
+	* (Experimental) `docker buildx` can be used which may be easier to setup since docker now ships with the buildx plugin.
+	docker buildx also uses buildkit behind the scenes so it should result in creating an image which is the same as using `buildctl` directly as prow does.
+		* You need to create a builder using either the `docker-container` or `remote` driver. For example: `docker buildx create --name multiarch --driver docker-container --use`
 	* `buildctl` can be used instead of docker to match our prow builds.  Running `local-images` targets 
 	will export images to a tar, but if running `images` targets which push images, a registry is required.  By default,
 	an ECR repo in the currently logged in AWS account will be used.  A common alternative is to run docker registry locally and override
@@ -77,14 +84,11 @@ Each project folder contains a Makefile with the following build targets.
 		* `make run-buildkit-and-registry`
 		* `export BUILDKIT_HOST=docker-container://buildkitd`
 		* `make stop-buildkit-and-registry` to cleanup
-	* (Experimental) `docker buildx` can be used which may be easier to setup since docker now ships with the buildx plugin.
-	docker buildx also uses buildkit behind the scenes so it should result in creating an image which is the same as using `buildctl` directly as prow does.
-		* You need to create a builder using either the `docker-container` or `remote` driver. For example: `docker buildx create --name multiarch --driver docker-container --use`
 * See [docker-auth.md](./docker-auth.md) for helpful tips for configuring, securing, and using your AWS credentials with the targets in this project.
 * By default, `IMAGE_REPO` will be set to your AWS account's private ECR registry based on your AWS_REGION. If you want to create the neccessary registeries
 for the current project:
 	* `make create-ecr-repos`
-	* If you would like to create these repos in your ECR public registry - `IMAGE_REPO=public.ecr.aws/<id> create-ecr-repos`
+	* If you would like to create these repos in your ECR public registry set `IMAGE_REPO=public.ecr.aws/<id> create-ecr-repos`
 * Some projects download built artifacts from our dev pipelines. To pull these from the EKS-Anywere dev bucket
 	* `export ARTIFACTS_BUCKET=s3://projectbuildpipeline-857-pipelineoutputartifactsb-10ajmk30khe3f`
 

--- a/projects/kubernetes-sigs/kind/build/build-kind-node-image.sh
+++ b/projects/kubernetes-sigs/kind/build/build-kind-node-image.sh
@@ -40,6 +40,8 @@ function build::kind::build_node_image(){
     export EKSD_ASSET_URL=$EKSD_ASSET_URL
     export KUBE_ARCH=$ARCH
 
+    build::common::check_for_qemu linux/$ARCH
+
     KIND_PATH="$MAKE_ROOT/_output/bin/kind/$(uname | tr '[:upper:]' '[:lower:]')-$BUILDER_PLATFORM_ARCH/kind"
     $KIND_PATH build node-image $MAKE_ROOT/images/k8s.io/kubernetes \
         --base-image $INTERMEDIATE_BASE_IMAGE --image $INTERMEDIATE_NODE_IMAGE --arch $ARCH      


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In the case of cross-compiling, we use the builder base but the platform may not always match the host.  For this to work you need qemu installed, which we do all over and have in the docs.  This adds a check for this and a message to guide the user.

Interestingly, I was going to do the same for buildctl and buildx, but buildkit (which powers both) seems to ship with its own qemu and so you do not actually have to run the binfmt install... this is news to me....

I also updated the building locally doc a bit, reorg mainly but a few update items.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
