### PR TITLE
fixes image builder retry logic

### DIFF
--- a/projects/kubernetes-sigs/image-builder/build/build_image.sh
+++ b/projects/kubernetes-sigs/image-builder/build/build_image.sh
@@ -60,10 +60,18 @@ function retry_image_builder() {
         [ ! -f "$log_file" ] && break
         if grep -q "Timeout waiting for IP." "$log_file"; then
           >&2 echo "Failed waiting for IP. This is likely transisent, retrying. Attempt $n/$max:"
-          retry="true"          
+          retry="true"
+        elif grep -q "Cancelling provisioner after a timeout" "$log_file"; then
+          >&2 echo "Provisioner timed out, this could be transisent, retrying. Attempt $n/$max:"
+          retry="true"    
         fi
       fi
-      [ "${retry}" = "true" ] && sleep $delay || failed="true" && break
+      if [ "${retry}" = "true" ]; then
+        sleep $delay
+      else
+        failed="true" 
+        break
+      fi
     }
   done
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

One of our image builds failed waiting on a provisioner, the retry logic was borked and created an infinite loop. This fixes that and retries if we get that specific messsage.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
