### PR TITLE
Skip setting proxy on subscription module, if satellite is part of no_proxy

### DIFF
--- a/projects/aws/image-builder/builder/manifests.go
+++ b/projects/aws/image-builder/builder/manifests.go
@@ -211,7 +211,7 @@ func extractAndPrepManifestTarball(tarballFile, privateEksDServerDomain, private
 				return err
 			}
 
-			fmt.Printf("File: %s, Match: %s, Pattern: %s\n", file.Name(), eksAMatch, eksABundlesManifestFilePattern)
+			fmt.Printf("File: %s, Match: %t, Pattern: %s\n", file.Name(), eksAMatch, eksABundlesManifestFilePattern)
 			if eksAMatch {
 				log.Printf("Replacing EKS-A domain name in file: %s\n", file.Name())
 				if err = replaceStringInFile(absFilePath, fmt.Sprintf("https://%s", eksAnywhereAssetsProdDomain), privateEksAServerDomain); err != nil {

--- a/projects/aws/image-builder/builder/utils.go
+++ b/projects/aws/image-builder/builder/utils.go
@@ -395,6 +395,19 @@ func getEksAReleasesManifestURL(airgapped bool) (string, error) {
 
 // setRhsmProxy takes the proxy config, parses it and sets the appropriate config on rhsm config
 func setRhsmProxy(proxy *ProxyConfig, rhsm *RhsmConfig) error {
+	// Redhat Subscription Ansible module does not take in a no_proxy input.
+	// If user does not want the subscription module to use proxy to reach the RedHat Satellite,
+	// the ServerHostname on RhsmConfig will also be set on the list of hostnames/urls to exclude on the no_proxy list
+	// If detected, skip setting proxy variables on the Redhat subscription module.
+	if proxy.NoProxy != "" {
+		noProxy := strings.Split(proxy.NoProxy, ",")
+		for _, endpoint := range noProxy {
+			if rhsm.ServerHostname == endpoint {
+				// skip setting proxy for subscription module
+				return nil
+			}
+		}
+	}
 	if proxy.HttpProxy != "" {
 		host, port, err := parseUrl(proxy.HttpProxy)
 		if err != nil {

--- a/projects/aws/image-builder/builder/utils_test.go
+++ b/projects/aws/image-builder/builder/utils_test.go
@@ -27,3 +27,81 @@ func TestGetSupportedReleaseBranchesFailure(t *testing.T) {
 			": %s", b.ReleaseChannel)
 	}
 }
+
+func TestSetRhsmProxy(t *testing.T) {
+	testcases := []struct {
+		proxy            *ProxyConfig
+		rhsm             *RhsmConfig
+		outProxyHostname string
+		outProxyPort     string
+		name             string
+		wantErr          bool
+	}{
+		{
+			name: "Successful proxy set on rhsm",
+			proxy: &ProxyConfig{
+				HttpProxy:  "http://test.com:4578",
+				HttpsProxy: "https://test.com:4578",
+			},
+			rhsm: &RhsmConfig{
+				ServerHostname: "redhat-satellite.com",
+			},
+			outProxyHostname: "test.com",
+			outProxyPort:     "4578",
+			wantErr:          false,
+		},
+		{
+			name: "Failed proxy set from parsing url",
+			proxy: &ProxyConfig{
+				HttpProxy:  "http:/test.com:4578",
+				HttpsProxy: "http:/test.com:4578",
+			},
+			rhsm: &RhsmConfig{
+				ServerHostname: "redhat-satellite.com",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Successful proxy set with no proxy",
+			proxy: &ProxyConfig{
+				HttpProxy:  "http://test.com:4578",
+				HttpsProxy: "https://test.com:4578",
+				NoProxy:    "no-proxy.com",
+			},
+			rhsm: &RhsmConfig{
+				ServerHostname: "redhat-satellite.com",
+			},
+			outProxyHostname: "test.com",
+			outProxyPort:     "4578",
+			wantErr:          false,
+		},
+		{
+			name: "Successful nil proxy set with satellite in no proxy",
+			proxy: &ProxyConfig{
+				HttpProxy:  "http://test.com:4578",
+				HttpsProxy: "https://test.com:4578",
+				NoProxy:    "redhat-satellite.com",
+			},
+			rhsm: &RhsmConfig{
+				ServerHostname: "redhat-satellite.com",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := setRhsmProxy(tc.proxy, tc.rhsm)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("Expected nil error. Got: %v", err)
+			}
+			if err == nil {
+				if tc.rhsm.ProxyHostname != tc.outProxyHostname {
+					t.Fatalf("Unexpected Proxy Hostname, Expected: %s, Got: %s", tc.outProxyHostname, tc.rhsm.ProxyHostname)
+				}
+				if tc.rhsm.ProxyPort != tc.outProxyPort {
+					t.Fatalf("Unexpected Proxy Port, Expected: %s, Got: %s", tc.outProxyPort, tc.rhsm.ProxyPort)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
*Description of changes:*
Ansible Redhat subscription module does not support a `no_proxy` field. If the user wants to use proxy, but wants to avoid using proxy to access the Redhat Satellite for registration, they can do so by providing the satellite hostname on the provider configuration json using the `no_proxy` field.

This change, checks if the redhat satellite hostname matches with one of the no_proxy endpoints and if so, skips setting proxy on the subscription module.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
