### PR TITLE
use tee to fix digest to tmpfile

### DIFF
--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -404,6 +404,12 @@ function build::common::get_clone_url() {
   fi
 }
 
+
+function fail() {
+  echo $1 >&2
+  exit 1
+}
+
 function retry() {
   local n=1
   local max=120

--- a/build/lib/helm_push.sh
+++ b/build/lib/helm_push.sh
@@ -65,12 +65,12 @@ function cleanup() {
 trap cleanup err
 trap "rm -f $TMPFILE" exit
 echo "($(pwd)) \$ helm push ${CHART_FILE} oci://${IMAGE_REGISTRY}/${HELM_DESTINATION_OWNER}"
-helm push ${CHART_FILE} oci://${IMAGE_REGISTRY}/${HELM_DESTINATION_OWNER}  2> ${TMPFILE}
+helm push ${CHART_FILE} oci://${IMAGE_REGISTRY}/${HELM_DESTINATION_OWNER} 2>&1 | tee ${TMPFILE}
 DIGEST=$(grep Digest $TMPFILE | $SED -e 's/Digest: //')
 
 # Adds a 2nd tag to the helm chart for the bundle-release jobs.
 if [[ "${IMAGE_REGISTRY}" != *"public.ecr.aws"* ]]; then
-  MANIFEST=$(aws ecr batch-get-image --repository-name "$HELM_DESTINATION_REPOSITORY" --image-ids imageDigest=${DIGEST} --query "images[].imageManifest" --output text)
+  MANIFEST=$(build::common::echo_and_run aws ecr batch-get-image --repository-name "$HELM_DESTINATION_REPOSITORY" --image-ids imageDigest=${DIGEST} --query "images[].imageManifest" --output text)
   export AWS_PAGER=""
   build::common::echo_and_run aws ecr put-image --repository-name ${HELM_DESTINATION_REPOSITORY} --image-tag ${SEMVER_GIT_TAG}-${LATEST_TAG}-helm --image-manifest "$MANIFEST" --image-manifest-media-type "application/vnd.oci.image.manifest.v1+json"
 fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I *think* I had originally changed this because for some reason tee itself does not work for me on my mac, or my linux instances. It appears that without using tee it does not work in codebuild.. not sure if its a difference in the helm version?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
