### PR TITLE
Support release-branched projects and passing project name in README version check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,12 +206,12 @@ generate: generate-project-list generate-staging-buildspec
 
 .PHONY: validate-generated
 validate-generated: generate validate-release-buildspecs validate-eksd-releases
-	@if [ "$$(git status --porcelain -- UPSTREAM_PROJECTS.yaml release/staging-build.yml release/checksums-build.yml **/batch-build.yml | wc -l)" -gt 0 ]; then \
-		echo "Error: Generated files, UPSTREAM_PROJECTS.yaml release/staging-build.yml release/checksums-build.yml batch-build.yml, do not match expected. Please run `make generate` to update"; \
-		git diff -- UPSTREAM_PROJECTS.yaml release/staging-build.yml release/checksums-build.yml **/batch-build.yml; \
+	build/lib/readme_check.sh
+	@if [ "$$(git status --porcelain -- UPSTREAM_PROJECTS.yaml release/staging-build.yml release/checksums-build.yml **/batch-build.yml **/README.md | wc -l)" -gt 0 ]; then \
+		echo "Error: Generated files, UPSTREAM_PROJECTS.yaml README.md release/staging-build.yml release/checksums-build.yml batch-build.yml, do not match expected. Please run 'make generate' to update"; \
+		git --no-pager diff -- UPSTREAM_PROJECTS.yaml release/staging-build.yml release/checksums-build.yml **/batch-build.yml **/README.md; \
 		exit 1; \
 	fi
-	build/lib/readme_check.sh
 
 .PHONY: check-project-path-exists
 check-project-path-exists:

--- a/build/lib/readme_check.sh
+++ b/build/lib/readme_check.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#set -x
+# set -x
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -23,28 +23,68 @@ source "${SCRIPT_ROOT}/common.sh"
 
 RETURN=0
 SED=$(build::find::gnu_variant_on_mac sed)
+PROJECT=${1:-}
 
-for GIT_TAG_FILE in projects/*/*/GIT_TAG
-do
-    VERSION="$(cat $GIT_TAG_FILE | $SED "s,-,--,g")"
-    README="$(dirname $GIT_TAG_FILE)/README.md"
+SUPPORTED_RELEASE_BRANCHES=($(cat $SCRIPT_ROOT/../../release/SUPPORTED_RELEASE_BRANCHES))
+LATEST_RELEASE_BRANCH=${SUPPORTED_RELEASE_BRANCHES[-1]}
+
+function check_and_update_readme() {
+    local -r git_tag_file=$1
+    local -r project_path=$2
+    local -r release_branched=$3
+
+    if [ ! -f $git_tag_file ]; then
+        return
+    fi
+    VERSION="$(cat $git_tag_file | $SED "s,-,--,g")"
+    README="$project_path/README.md"
     if [ ! -f $README ]
     then
         echo "Missing file $README"
         continue
     fi
+
     EXPECTED_VERSION="img.shields.io/badge/version-$VERSION"
+    if [ "$release_branched" = "true" ]; then
+        RELEASE_BRANCH=$(basename $(dirname $git_tag_file) | $SED "s,-,--,g")
+        EXPECTED_VERSION=img.shields.io/badge/$RELEASE_BRANCH%20version-$VERSION
+    fi
     if grep -l "$EXPECTED_VERSION" ${README} >/dev/null
     then
-        continue
+        echo "Actual version in README matches expected version"
+        return
     fi
-    if ! grep "img.shields.io/badge/version" ${README} >/dev/null
+    VERSION_SEARCH_PATTERN="img.shields.io/badge/version"
+    if [ "$release_branched" = "true" ]; then
+        VERSION_SEARCH_PATTERN=img.shields.io/badge/$RELEASE_BRANCH%20version
+    fi
+    if ! grep $VERSION_SEARCH_PATTERN ${README} >/dev/null
     then
-        echo "Did not find version $README"
-        continue
+        echo "Did not find version  in $README"
+        return
     fi
-    RETURN=-1
-    ACTUAL_VERSION=$(grep "img.shields.io/badge/version" ${README} | $SED -e 's,.*img.shields.io/badge/version-,,' -e 's/-blue).*$//')
-    echo "Version mismatch $README expected $VERSION actual $ACTUAL_VERSION"
+
+    ACTUAL_VERSION=$(grep $VERSION_SEARCH_PATTERN ${README} | $SED -e "s,.*$VERSION_SEARCH_PATTERN-,," -e 's/-blue).*$//')
+    echo "Version mismatch in $README - expected $VERSION, actual $ACTUAL_VERSION"
     $SED -i -e "s/$ACTUAL_VERSION/$VERSION/" $README
+}
+
+PROJECTS="projects/*/*"
+if [ -n "$PROJECT" ]; then
+    PROJECTS=projects/$PROJECT
+fi
+
+for PROJECT in $PROJECTS
+do
+    RELEASE_BRANCHED=false
+    if [ -f "$PROJECT/GIT_TAG" ] & [ -f "$PROJECT/$LATEST_RELEASE_BRANCH/GIT_TAG" ]; then
+        RELEASE_BRANCHED=true
+    fi
+    if [ "$RELEASE_BRANCHED" = "true" ]; then
+        for branch in ${SUPPORTED_RELEASE_BRANCHES[@]}; do
+            check_and_update_readme $PROJECT/$branch/GIT_TAG $PROJECT true
+        done
+    else
+        check_and_update_readme "$PROJECT/GIT_TAG" $PROJECT false
+    fi
 done

--- a/projects/emissary-ingress/emissary/README.md
+++ b/projects/emissary-ingress/emissary/README.md
@@ -1,5 +1,5 @@
 ## **Emissary-ingress**
-![Version](https://img.shields.io/badge/version-v3.6.0-blue)
+![Version](https://img.shields.io/badge/version-v3.8.1-blue)
 ![Build Status](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoid2Vla0ZUclhyN0dNN1ZLRnRoV3dBV241UDVVUUNmYUFyWVdDUWg3SUdqcThyblJvZ245cHN0cjFhUGNETDZhUkkySUNDZC9kdVFhemlpUjZGclRibUdnPSIsIml2UGFyYW1ldGVyU3BlYyI6IjRsempqaUZTNlB6TjF0bVQiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=main)
 
 Official website: https://www.getambassador.io/docs/

--- a/projects/kubernetes/autoscaler/README.md
+++ b/projects/kubernetes/autoscaler/README.md
@@ -1,10 +1,10 @@
 ## **Kubernetes Cluster Autoscaler**
 ![1.23 Version](https://img.shields.io/badge/1--23%20version-v1.23.1-blue)
-![1.24 Version](https://img.shields.io/badge/1--24%20version-v1.24.0-blue)
-![1.25 Version](https://img.shields.io/badge/1--25%20version-v1.25.0-blue)
-![1.26 Version](https://img.shields.io/badge/1--26%20version-v1.26.1-blue)
-![1.27 Version](https://img.shields.io/badge/1--27%20version-v1.27.1-blue)
-![1.28 Version](https://img.shields.io/badge/1--28%20version-v1.28.0-blue)
+![1.24 Version](https://img.shields.io/badge/1--24%20version-f69e14b5de2e595b55f4ee4dc64952e00e7c7ee9-blue)
+![1.25 Version](https://img.shields.io/badge/1--25%20version-e8d3e9b1d986d540a21913b756cb2b47ffddb918-blue)
+![1.26 Version](https://img.shields.io/badge/1--26%20version-f48095c20ad1b305a1392a3a031b0a7e31e1927a-blue)
+![1.27 Version](https://img.shields.io/badge/1--27%20version-299c9637229fb2bf849c1d86243fe2948d14101e-blue)
+![1.28 Version](https://img.shields.io/badge/1--28%20version-5bcb526e08c17ff93cc6093ee89a95730a90e45b-blue)
 ![Build Status](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiL0tWckptdkxsZEd1cXNiNTBncjRNVU5oekpZRlBkTDNBcFVvZkFOVHZwbTBKUm91QkR6RVN4QlhJWk42cXF3L29FMmdnTXUrVndiay8zVUQ0YjJsc21vPSIsIml2UGFyYW1ldGVyU3BlYyI6Ik1Gd2UwbmRXVWxSRTMvUHQiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=main)
 
 [Autoscaler](https://github.com/kubernetes/autoscaler) defines the cluster autoscaler.

--- a/projects/tinkerbell/tinkerbell-chart/README.md
+++ b/projects/tinkerbell/tinkerbell-chart/README.md
@@ -1,5 +1,5 @@
 # **Tinkerbell Stack Helm Chart**
-![Version](https://img.shields.io/badge/version-0.2.3-blue)
+![Version](https://img.shields.io/badge/version-0.2.4-blue)
 ![Build Status](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoic0w3TWw2ZDdFblpMMDZtamh2S3RiNmVwbTdRaDVlbmgxWGZkVi9WdGZjMDgvL2J2a1ZGSXJoMVV2dWJlNWZpbjV5Z3k4THRjZ0VyWUlBM0RLTUNWaE4wPSIsIml2UGFyYW1ldGVyU3BlYyI6IllIWGJ1SDFRZm1HM0dnK1giLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=main)
 
 ## Updating


### PR DESCRIPTION
* Allow passing project name to readme update script to update version for single project
* Fix bug in echo command that caused the `generate` Make target to be run during in case of error.
* Block merge when project README is not up to date.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
