### PR TITLE
Use absolute paths during README check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ generate: generate-project-list generate-staging-buildspec
 
 .PHONY: validate-generated
 validate-generated: generate validate-release-buildspecs validate-eksd-releases
-	build/lib/readme_check.sh
+	build/lib/readme_check.sh $(BASE_DIRECTORY)
 	@if [ "$$(git status --porcelain -- UPSTREAM_PROJECTS.yaml release/staging-build.yml release/checksums-build.yml **/batch-build.yml **/README.md | wc -l)" -gt 0 ]; then \
 		echo "Error: Generated files, UPSTREAM_PROJECTS.yaml README.md release/staging-build.yml release/checksums-build.yml batch-build.yml, do not match expected. Please run 'make generate' to update"; \
 		git --no-pager diff -- UPSTREAM_PROJECTS.yaml release/staging-build.yml release/checksums-build.yml **/batch-build.yml **/README.md; \

--- a/build/lib/readme_check.sh
+++ b/build/lib/readme_check.sh
@@ -18,14 +18,15 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+BASE_DIRECTORY="${1?Specify first argument - Base directory of build-tooling repo}"
+PROJECT=${2:-}
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 source "${SCRIPT_ROOT}/common.sh"
 
 RETURN=0
 SED=$(build::find::gnu_variant_on_mac sed)
-PROJECT=${1:-}
 
-SUPPORTED_RELEASE_BRANCHES=($(cat $SCRIPT_ROOT/../../release/SUPPORTED_RELEASE_BRANCHES))
+SUPPORTED_RELEASE_BRANCHES=($(cat $BASE_DIRECTORY/release/SUPPORTED_RELEASE_BRANCHES))
 LATEST_RELEASE_BRANCH=${SUPPORTED_RELEASE_BRANCHES[-1]}
 
 function check_and_update_readme() {
@@ -69,9 +70,9 @@ function check_and_update_readme() {
     $SED -i -e "s/$ACTUAL_VERSION/$VERSION/" $README
 }
 
-PROJECTS="projects/*/*"
+PROJECTS="$BASE_DIRECTORY/projects/*/*"
 if [ -n "$PROJECT" ]; then
-    PROJECTS=projects/$PROJECT
+    PROJECTS=$BASE_DIRECTORY/projects/$PROJECT
 fi
 
 for PROJECT in $PROJECTS


### PR DESCRIPTION
This allows running the script from anywhere, which will be useful for the automation where we can run it against the cloned repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
