### PR TITLE
cleans up helm chart building and pushing

### DIFF
--- a/build/lib/buildkit.sh
+++ b/build/lib/buildkit.sh
@@ -105,7 +105,7 @@ else
     log_file=$(mktemp)
     trap "rm -f $log_file" EXIT
     if ! $CMD $ARGS 2>&1 | tee $log_file; then      
-        if grep -q "blobs/uploads/\": EOF" $log_file ; then
+        if grep -q "blobs/uploads/\": EOF" $log_file || grep -q "blobs/uploads.*404 Not Found" $log_file; then
             echo "******************************************************"
             echo "Ensure container registry and repository exists!!"
             echo "Try running make create-ecr-repos to create ecr repositories in your aws account."

--- a/build/lib/image_shasum.sh
+++ b/build/lib/image_shasum.sh
@@ -28,11 +28,8 @@ TMPFILE=$(mktemp)
 trap "rm -f $TMPFILE" exit
 TARGET=${REGISTRY}/${REPOSITORY}:${IMAGE_TAG}
 
->&2 echo -n "Checking for the existence of ${TARGET}..."
-if skopeo inspect -n --raw docker://${TARGET} >${TMPFILE} 2>/dev/null; then
-  >&2 echo "Found!"
+if build::common::echo_and_run skopeo inspect -n --raw docker://${TARGET} >${TMPFILE}; then
+  >&2 echo "Found: $(skopeo manifest-digest ${TMPFILE})"
   skopeo manifest-digest ${TMPFILE}
-else
-  >&2 echo "Not Found!"
 fi
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This is a further attempt at cleaning up the helm building process.  This removes (almost) all the ecr/public specific logic in favor of using skopeo where possible to support any registry, including local ones.

This simplifies the logic when looking for images down:
- for the actual images associated with whatever project is building, it tries to find and pull them from whatever image_regi is configured. It no longer is checking other regi, like ecr-public.
- for images that come from other projects, it also pulls them from the current regi, but it has to use the `latest` tag to try and find it vs the specific tag, since those images would have been built previous and have different specific tags.
- for images found via `latest`, it will use the aws cli to find another tag associated with that image to be used in the helm chart. i honestly dont know the significance here, but this is how its always been so there must be a decent reason

When pushing the final chart, it used to use the aws cli to add a second tag to the helm chart in ecr, this is changed to use skopeo copy instead to be more generic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
