### PR TITLE
fix raw rhel builds

### DIFF
--- a/projects/kubernetes-sigs/image-builder/build/build_image_on_metal.sh
+++ b/projects/kubernetes-sigs/image-builder/build/build_image_on_metal.sh
@@ -96,7 +96,7 @@ if [ "$CODEBUILD_CI" = "true" ]; then
     RUN_INSTANCE_EXTRA_ARGS="--subnet-id $SUBNET_ID --placement AvailabilityZone=$SUBNET_AZ --security-group-ids $RAW_IMAGE_BUILD_SECURITY_GROUP --associate-public-ip-address"
 fi
 
-AMI_ID="ami-08cb54181472d8110"
+AMI_ID=$(aws ec2 describe-images --owners $BUILD_ACCOUNT_ID --filters "Name=name,Values=$KVM_AMI_NAME_PREFIX" --query 'sort_by(Images, &CreationDate)[-1].[ImageId]' --output text)
 
 MAX_RETRIES=20
 for i in $(seq 1 $MAX_RETRIES); do
@@ -154,7 +154,7 @@ for i in $(seq 1 $MAX_RETRIES); do
 done
 
 # Ensure python/packer/ansible are setup on the ami
-ssh $SSH_OPTS $REMOTE_HOST "make -C $REMOTE_PROJECT_PATH/image-builder/images/capi deps-raw"
+ssh $SSH_OPTS $REMOTE_HOST "packer --version; make -C $REMOTE_PROJECT_PATH/image-builder/images/capi deps-raw"
 
 # If not running on Codebuild, exit gracefully
 if [ "$CODEBUILD_CI" = "false" ]; then

--- a/projects/kubernetes-sigs/image-builder/patches/0027-disable-gpg-for-extra-rpms.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0027-disable-gpg-for-extra-rpms.patch
@@ -1,0 +1,24 @@
+From 7a620192957d2527fb3699ff485c33b44b56150c Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Fri, 1 Dec 2023 15:55:45 -0600
+Subject: [PATCH] disable gpg for extra rpms
+
+---
+ images/capi/ansible/roles/setup/tasks/redhat.yml | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/images/capi/ansible/roles/setup/tasks/redhat.yml b/images/capi/ansible/roles/setup/tasks/redhat.yml
+index a4bc9d03d..72b7a0346 100644
+--- a/images/capi/ansible/roles/setup/tasks/redhat.yml
++++ b/images/capi/ansible/roles/setup/tasks/redhat.yml
+@@ -124,6 +124,7 @@
+     name: "{{ extra_rpms.split() }}"
+     state: present
+     lock_timeout: 60
++    disable_gpg_check: true
+ 
+ - name: ensure iptables present for redhat 8
+   yum:
+-- 
+2.42.0
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The megaraid drivers we install, the rpm was not signed by Dell.  The new version of ansible validates the gpg key and is now failing.  This patches the extra_rpms target to skip this check.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
