### PR TITLE
Fix logic to get latest GitHub release for a project

### DIFF
--- a/tools/version-tracker/pkg/commands/display/display.go
+++ b/tools/version-tracker/pkg/commands/display/display.go
@@ -77,7 +77,7 @@ func Run(displayOptions *types.DisplayOptions) error {
 			}
 
 			// Get latest revision for the project from GitHub.
-			latestRevision, _, _, err := github.GetLatestRevision(client, org, repoName)
+			latestRevision, _, err := github.GetLatestRevision(client, org, repoName, currentRevision)
 			if err != nil {
 				return fmt.Errorf("getting latest revision from GitHub: %v", err)
 			}


### PR DESCRIPTION
This PR fixes the logic of determining the latest release for a project on GitHub. Previously, we were simply taking the first element in the releases or tag list as the latest revision. But this could lead to false positives if the project released a patch from an older release branch, which would make it appear at the top of the list, below the true latest version.

**Before**
```bash
$ version-tracker display --project cert-manager/cert-manager
ORGANIZATION  REPOSITORY    CURRENT VERSION  LATEST VERSION  
cert-manager  cert-manager  v1.13.2          v1.12.7

$ version-tracker display --project goharbor/harbor 
ORGANIZATION  REPOSITORY  CURRENT VERSION  LATEST VERSION  
goharbor      harbor      v2.9.1           v2.7.4
```

**After**
```bash
$ version-tracker display --project cert-manager/cert-manager  
ORGANIZATION  REPOSITORY    CURRENT VERSION  LATEST VERSION  
cert-manager  cert-manager  v1.13.2          v1.13.3

$ version-tracker display --project goharbor/harbor 
ORGANIZATION  REPOSITORY  CURRENT VERSION  LATEST VERSION  
goharbor      harbor      v2.9.1           v2.9.1
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
