### PR TITLE
Image-builder: Update kernel and keep only 1 kernel on redhat machines

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0028-Remove-old-kernels.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0028-Remove-old-kernels.patch
@@ -1,0 +1,82 @@
+From 39a06391908f873f747f22d49682ec7d6009a7af Mon Sep 17 00:00:00 2001
+From: Vignesh Goutham Ganesh <vgg@amazon.com>
+Date: Thu, 14 Dec 2023 15:36:28 -0600
+Subject: [PATCH] Remove old kernels
+
+Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
+---
+ images/capi/ansible/roles/node/tasks/main.yml |  3 ++
+ .../capi/ansible/roles/node/tasks/redhat.yml  | 32 +++++++++++++++++++
+ .../capi/ansible/roles/setup/tasks/redhat.yml |  2 +-
+ 3 files changed, 36 insertions(+), 1 deletion(-)
+ create mode 100644 images/capi/ansible/roles/node/tasks/redhat.yml
+
+diff --git a/images/capi/ansible/roles/node/tasks/main.yml b/images/capi/ansible/roles/node/tasks/main.yml
+index f9f6b9040..9120073b8 100644
+--- a/images/capi/ansible/roles/node/tasks/main.yml
++++ b/images/capi/ansible/roles/node/tasks/main.yml
+@@ -18,6 +18,9 @@
+ - import_tasks: amazonLinux2.yml
+   when: ansible_distribution == "Amazon"
+ 
++- import_tasks: redhat.yml
++  when: ansible_distribution == "RedHat"
++
+ # This is required until https://github.com/ansible/ansible/issues/77537 is fixed and used.
+ - name: Override Flatcar's OS family
+   set_fact:
+diff --git a/images/capi/ansible/roles/node/tasks/redhat.yml b/images/capi/ansible/roles/node/tasks/redhat.yml
+new file mode 100644
+index 000000000..b2133b6f1
+--- /dev/null
++++ b/images/capi/ansible/roles/node/tasks/redhat.yml
+@@ -0,0 +1,32 @@
++# Copyright 2020 The Kubernetes Authors.
++
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++
++# http://www.apache.org/licenses/LICENSE-2.0
++
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++
++---
++- name: Get the list of installed kernels
++  ansible.builtin.shell: "rpm -q kernel --qf '%{version}-%{release}\n' | sort -V"
++  register: installed_kernels
++
++- name: Get the current running kernel
++  ansible.builtin.command: "uname -r"
++  register: current_kernel
++
++- name: Filter out the current kernels
++  set_fact:
++    old_kernels: "{{ installed_kernels.stdout_lines | difference([current_kernel.stdout]) |list }}"
++
++- name: Remove old kernels
++  ansible.builtin.yum:
++    name: "kernel-{{ item }}"
++    state: absent
++  loop: "{{ old_kernels }}"
+\ No newline at end of file
+diff --git a/images/capi/ansible/roles/setup/tasks/redhat.yml b/images/capi/ansible/roles/setup/tasks/redhat.yml
+index 72b7a0346..da422a10a 100644
+--- a/images/capi/ansible/roles/setup/tasks/redhat.yml
++++ b/images/capi/ansible/roles/setup/tasks/redhat.yml
+@@ -110,7 +110,7 @@
+   yum:
+     name: '*'
+     state: latest
+-    exclude: kernel*,cloud-init*
++    exclude: cloud-init*
+     lock_timeout: 60
+ 
+ - name: install baseline dependencies
+-- 
+2.39.3 (Apple Git-145)
+


### PR DESCRIPTION
*Description of changes:*
Image builder was excluding kernel updates till now. With this change, image builder will update kernels and reboot into the new kernel. Post reboot, if the OS has more than 1 kernel, this change will remove all non-live kernels running on the RHEL machine.

*Testing*
Running image builder with changes output
```
    qemu: TASK [node : Get the list of installed kernels] ********************************
    qemu: changed: [default]
    qemu:
    qemu: TASK [node : Get the current running kernel] ***********************************
    qemu: changed: [default]
    qemu:
    qemu: TASK [node : Set the number of kernels to keep] ********************************
    qemu: ok: [default]
    qemu:
    qemu: TASK [node : Filter out the current kernels] ***********************************
    qemu: ok: [default]
    qemu:
    qemu: TASK [node : Remove old kernels] ***********************************************
    qemu: ok: [default] => (item=['4.18.0-372.9.1.el8'])
```

/hold 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
