### PR TITLE
Merge checksums when building for different architectures separately

### DIFF
--- a/buildspecs/upgrade-buildspec.yml
+++ b/buildspecs/upgrade-buildspec.yml
@@ -11,5 +11,6 @@ phases:
 
   build:
     commands:
+    - echo "CHECKSUMS -text merge=union" > .gitattributes
     - PROJECT_NAME=${PROJECT_PATH#"projects/"}
     - make upgrade -C tools/version-tracker PROJECT=$PROJECT_NAME VERBOSITY=6

--- a/tools/version-tracker/buildspecs/upgrade.yml
+++ b/tools/version-tracker/buildspecs/upgrade.yml
@@ -360,5 +360,6 @@ phases:
       - ./build/lib/setup.sh
   build:
     commands:
+      - echo "CHECKSUMS -text merge=union" > .gitattributes
       - PROJECT_NAME=${PROJECT_PATH#"projects/"}
       - make upgrade -C tools/version-tracker PROJECT=$PROJECT_NAME VERBOSITY=6


### PR DESCRIPTION
Upgrades for some projects, such as containerd, runc, etc. are done in a separate CodeBuild job for amd64 and arm64 to leverage the same architecture for the build instance as the binary we're compiling. However, since both of these push to the same branch/PR, the checksums file on the branch gets overwritten by the job that runs second. In order to avoid that, we're using the `union` merge strategy for the CHECKSUMS files.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
