### PR TITLE
adds platform warning when building images

### DIFF
--- a/build/lib/buildkit.sh
+++ b/build/lib/buildkit.sh
@@ -53,7 +53,7 @@ if [ "${USE_BUILDX:-}" == "true" ]; then
                         >&2 echo -e "\n****************************************************************"
                         >&2 echo "You are trying to build a $platform based container which does not match your host architecture."
                         >&2 echo "You may run into issues due to docker/buildkit's builtin version of qemu."
-                        >&2 echo "If you have wierd issues that seem to only affect one platform try running the following to register qemu virtualization manually:"
+                        >&2 echo "If you have weird issues that seem to only affect one platform try running the following to register qemu virtualization manually:"
                         >&2 echo "docker run --privileged --rm public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0 --install aarch64,amd64"
                         >&2 echo -e "****************************************************************\n"
                     done

--- a/build/lib/buildkit.sh
+++ b/build/lib/buildkit.sh
@@ -19,6 +19,8 @@ set -o pipefail
 
 BUILD_LIB_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/" && pwd -P)"
 
+source "$BUILD_LIB_ROOT/common.sh"
+
 if [ "${USE_BUILDX:-}" == "true" ]; then
     printf "\nBuilding with docker buildx\n" >&2
 
@@ -40,6 +42,22 @@ if [ "${USE_BUILDX:-}" == "true" ]; then
                     ARGS+="--${1/filename/file} "
                 elif [[ $1 = "no-cache"* ]]; then
                     ARGS+="--${1/no-cache/no-cache-filter} "
+                elif [[ $1 = "platform"* ]]; then
+                    platforms="${1#platform=}"
+                    platforms=(${platforms//,/ })
+                    for platform in "${platforms[@]}"; do
+                        if build::common::is_qemu_available "$platform"; then
+                            continue
+                        fi
+
+                        >&2 echo -e "\n****************************************************************"
+                        >&2 echo "You are trying to build a $platform based container which does not match your host architecture."
+                        >&2 echo "You may run into issues due to docker/buildkit's builtin version of qemu."
+                        >&2 echo "If you have wierd issues that seem to only affect one platform try running the following to register qemu virtualization manually:"
+                        >&2 echo "docker run --privileged --rm public.ecr.aws/eks-distro-build-tooling/binfmt-misc:qemu-v6.1.0 --install aarch64,amd64"
+                        >&2 echo -e "****************************************************************\n"
+                    done
+                    ARGS+="--${1/:/ } "
                 else
                     ARGS+="--${1/:/ } "
                 fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We have a similar warning like this when building via docker, mainly for cgo projects because when running docker containers for a different platform qemu is required.   When running buildkit and needing qemu, there is a builtin version included with buildkit.  However, I have noticed that the later versions of qemu, 7+, do not appear as stable as 6.  @vivek-koppuru was running into issues locally building the upgrader image due to the version of qemu included with buildkit.  Running the install of 6 manually solves the issue.

As a bit of background, building container images for other platforms does not ALWAYS require qemu. If a dockerfile is just a bunch of ADD/COPY layers, then no code is actually being executed.  If there is a RUN (and there may be a few others) layer than this will attempt to execute commands in the given platform. So if building arm on an amd host, then qemu is used.  What is particularly annoying is when there is an issue the error message is usually pretty generic, `<file> not found` which is generally not the case and can send you on a goose chase.

This PR replicates the message we use in a few other places to the buildkit flow, however it does not error since there is a high chance it will not be an issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
