### PR TITLE
Fix image tag for bottlerocket control container

### DIFF
--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_CONTROL_CONTAINER_METADATA
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_CONTROL_CONTAINER_METADATA
@@ -1,2 +1,2 @@
-tag: v0.11.1
+tag: v0.7.5
 imageDigest: sha256:61bc99d06b3f60ff7b9bfbc6cf440e17fcc94d0b8d46bbddc760244ba073e7cc


### PR DESCRIPTION
Fix image tag for bottlerocket control container. v0.11.1 is the admin container tag that got copied over mistakenly and checked in when #2765 merged.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
