### PR TITLE
Use EKS-D v1.29 prod release assets

### DIFF
--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -33,7 +33,6 @@ releases:
   number: 11
   kubeVersion: v1.28.4
 - branch: 1-29
-  number: 2
-  kubeVersion: v1.29.0-rc.1
-  dev: true
+  number: 1
+  kubeVersion: v1.29.0
 latest: 1-25


### PR DESCRIPTION
EKS-D has completed their v1.29 production launch so we should start using those artifacts instead of the dev ones.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
