### PR TITLE
Ignore nvram when downloading from vSphere content libraries

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0029--Export-ova-file-independently-to-ignore-nvram-file-t.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0029--Export-ova-file-independently-to-ignore-nvram-file-t.patch
@@ -1,0 +1,28 @@
+From d5d6beb104783844e65f0eb233c2026c4ff3d067 Mon Sep 17 00:00:00 2001
+From: Vignesh Goutham Ganesh <vgg@amazon.com>
+Date: Tue, 19 Dec 2023 15:19:36 -0600
+Subject: [PATCH] Export ova file independently to ignore nvram file that
+ causes govc to error
+
+Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
+---
+ images/capi/packer/ova/packer-node.json | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/images/capi/packer/ova/packer-node.json b/images/capi/packer/ova/packer-node.json
+index 0ad54d791..7ea041005 100644
+--- a/images/capi/packer/ova/packer-node.json
++++ b/images/capi/packer/ova/packer-node.json
+@@ -338,7 +338,8 @@
+       ],
+       "inline": [
+         "cd {{user `output_dir`}}",
+-        "govc library.export /{{user `vsphere_library_name`}}/{{user `build_version`}}",
++        "govc library.export /{{user `vsphere_library_name`}}/{{user `build_version`}}/{{user `build_version`}}.ovf",
++        "govc library.export /{{user `vsphere_library_name`}}/{{user `build_version`}}/{{user `build_version`}}-1.vmdk",
+         "govc library.rm /{{user `vsphere_library_name`}}/{{user `build_version`}}",
+         "../hack/image-build-ova.py --vmx {{user `vmx_version`}} --eula ../hack/ovf_eula.txt --ovf_template ../hack/ovf_template.xml --vmdk_file {{user `build_version`}}-1.vmdk"
+       ],
+-- 
+2.39.3 (Apple Git-145)
+


### PR DESCRIPTION
*Description of changes:*
During `govc library.export <template-name>` vSphere downloads the ovf, vmdk and nvram. After the latest update to vSphere, govc fails to download nvram file. Since we do not consume the nvram file, the changes here are a workaround where we download the required files individually. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
