### PR TITLE
Check for release branch in combine-images buildspec

### DIFF
--- a/buildspecs/combine-images.yml
+++ b/buildspecs/combine-images.yml
@@ -14,4 +14,4 @@ phases:
 
   build:
     commands:
-    - if $(make check-project-path-exists); then make release -C $PROJECT_PATH; fi
+    - if $(make check-project-path-exists) && make check-for-release-branch-skip -C $PROJECT_PATH; then make release -C $PROJECT_PATH; fi


### PR DESCRIPTION
Some packages projects like harbor and emissary build their AMD64 and ARM64 images separately using the standard top-level buildspec and then combine the images into an image manifest in the third stage using the combine-images buildspec. The packages projects are not built for release branch and this is enforced in the standard buildspec by running the `check-for-release-branch-skip` Make target, but this is not present in the combine-images buildspec which causes it to try to pull down images that were never pushed in the first place because they got skipped on the release branch. This PR adds this check to the combine-images buildspec as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
