### PR TITLE
Download and include the nvram in OVAs:

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0030-Download-and-include-the-nvram.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0030-Download-and-include-the-nvram.patch
@@ -1,0 +1,29 @@
+From 1c0e798973a333b353856cc8742eaa59c5bad164 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Wed, 27 Dec 2023 16:17:54 -0700
+Subject: [PATCH] Download and include the nvram:
+
+govc library.import is failing without this.
+
+"Unable to parse disk image while uploading"
+
+Signed-off-by: Prow Bot <prow@amazonaws.com>
+---
+ images/capi/packer/ova/packer-node.json | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/images/capi/packer/ova/packer-node.json b/images/capi/packer/ova/packer-node.json
+index 7ea041005..e78c241f2 100644
+--- a/images/capi/packer/ova/packer-node.json
++++ b/images/capi/packer/ova/packer-node.json
+@@ -340,6 +340,7 @@
+         "cd {{user `output_dir`}}",
+         "govc library.export /{{user `vsphere_library_name`}}/{{user `build_version`}}/{{user `build_version`}}.ovf",
+         "govc library.export /{{user `vsphere_library_name`}}/{{user `build_version`}}/{{user `build_version`}}-1.vmdk",
++        "govc library.export /{{user `vsphere_library_name`}}/{{user `build_version`}}/{{user `build_version`}}-2.nvram",
+         "govc library.rm /{{user `vsphere_library_name`}}/{{user `build_version`}}",
+         "../hack/image-build-ova.py --vmx {{user `vmx_version`}} --eula ../hack/ovf_eula.txt --ovf_template ../hack/ovf_template.xml --vmdk_file {{user `build_version`}}-1.vmdk"
+       ],
+-- 
+2.42.0
+


### PR DESCRIPTION
govc library.import is failing without this.

"Unable to parse disk image while uploading"

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
