### PR TITLE
Fix in-place upgrade script to properly upgrade etcd

### DIFF
--- a/projects/aws/upgrader/upgrade.sh
+++ b/projects/aws/upgrader/upgrade.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -o errexit
 set -o nounset
@@ -53,10 +53,9 @@ kubeadm_in_first_cp(){
   kubeadm_config_backup="${components_dir}/kubeadm-config.backup.yaml"
   new_kubeadm_config="${components_dir}/kubeadm-config.yaml"
   kubectl get cm -n kube-system kubeadm-config -ojsonpath='{.data.ClusterConfiguration}' --kubeconfig /etc/kubernetes/admin.conf > "$kubeadm_config_backup"
-  cp "$kubeadm_config_backup" "$new_kubeadm_config"
 
-  if [ "$etcd_version" -ne "NO_UPDATE" ]; then
-    sed -zE "s/(imageRepository: public.ecr.aws\/eks-distro\/etcd-io\n\s+imageTag: )[^\n]*/\1${etcd_version}/" "$new_kubeadm_config" >> "$new_kubeadm_config"
+  if [ "$etcd_version" != "NO_UPDATE" ]; then
+    sed -zE "s/(imageRepository: public.ecr.aws\/eks-distro\/etcd-io\n\s+imageTag: )[^\n]*/\1${etcd_version}/" "$kubeadm_config_backup" > "$new_kubeadm_config"
   fi
 
   # the kubelet config appears to lose values, in the case of a kind cluster the failSwapOn:false


### PR DESCRIPTION
*Description of changes:*
Update the if condition to use the right comparison operater for strings. `-ne` only works for integers and throws and error when used with strings.
Also change the shebang to use `bash` instead of `sh`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
