### PR TITLE
Run OVA image builds against dev vCenter

### DIFF
--- a/projects/kubernetes-sigs/image-builder/buildspecs/ova.yml
+++ b/projects/kubernetes-sigs/image-builder/buildspecs/ova.yml
@@ -8,11 +8,11 @@ env:
     CLI_FOLDER: "projects/aws/image-builder"
     GOPATH: "/home/imagebuilder/go"
   secrets-manager:
-    GOVC_DATACENTER: "vsphere_ci_beta_connection:vsphere_datacenter"
-    GOVC_URL: "vsphere_ci_beta_connection:vsphere_url"
-    GOVC_USERNAME: "vsphere_ci_beta_connection:vsphere_username"
-    GOVC_PASSWORD: "vsphere_ci_beta_connection:vsphere_password"
-    VSPHERE_CONNECTION_DATA: "vsphere_ci_beta_connection:vsphere_connection_data"
+    GOVC_DATACENTER: "vsphere_dev_beta_connection:vsphere_datacenter"
+    GOVC_URL: "vsphere_dev_beta_connection:vsphere_url"
+    GOVC_USERNAME: "vsphere_dev_beta_connection:vsphere_username"
+    GOVC_PASSWORD: "vsphere_dev_beta_connection:vsphere_password"
+    VSPHERE_CONNECTION_DATA: "vsphere_dev_beta_connection:vsphere_connection_data"
 
 phases:
   pre_build:


### PR DESCRIPTION
Run OVA image builds against dev vCenter till CI issues are fixed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
