### PR TITLE
Add codeql analysis for container images and binary archives

### DIFF
--- a/.github/workflows/Security/Security-Scanning-and-Vulnerability-Analysis/sample-code-snippet.yml
+++ b/.github/workflows/Security/Security-Scanning-and-Vulnerability-Analysis/sample-code-snippet.yml
@@ -1,0 +1,32 @@
+name: codeql-analysis
+on:
+  pull_request_target:
+    types: [opened]
+jobs:
+  codeql-analysis:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: go, python
+      - name: Build container images and binary archives
+        run: |
+          make build
+          make release
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1
+        with:
+          output: codeql-results
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: codeql-results/codeql-sarif/*.sarif


### PR DESCRIPTION
*Less Secure*

*Description of changes:*

This pull request adds a GitHub Actions workflow that uses CodeQL to scan the container images and binary archives built from the source code. The results are uploaded as a SARIF file and displayed as code scanning alerts in GitHub. This feature enhances the security and reliability of the build artifacts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
![codeimage-snippet_7](https://github.com/aws/eks-anywhere-build-tooling/assets/133382057/b4e47cbb-2119-48ee-b3da-e9a99aa99aa6)

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
