### PR TITLE
Exclude kernel updates from yum updates in RHEL support and improvements patch

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
@@ -1,4 +1,4 @@
-From 5bd56bd23692f84b4fcfb99ed331831edde522f4 Mon Sep 17 00:00:00 2001
+From 39d6c2028fe9ab086dd233bf2268bc8dbe48d80e Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 6 Dec 2022 15:42:02 -0600
 Subject: [PATCH 05/11] RHEL support and improvements
@@ -13,70 +13,18 @@ Subject: [PATCH 05/11] RHEL support and improvements
 - Add proxy, register with satellite, and pull packages from satellite support to redhat subscription manager
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
+
+- revert rhel kernel updates inclusion
+
+Signed-off-by: Cavaughn Browne <cxbrowne@amazon.com>
 ---
- images/capi/ansible/roles/node/tasks/main.yml |  3 +
- .../capi/ansible/roles/node/tasks/redhat.yml  | 32 +++++++
  .../cloud-init.service.d/boot-order.conf      |  2 +
  .../ansible/roles/providers/tasks/main.yml    | 28 ++++++-
  .../capi/ansible/roles/setup/tasks/redhat.yml | 84 +++++++++++++++++++
  images/capi/packer/config/ansible-args.json   |  2 +-
- 6 files changed, 148 insertions(+), 3 deletions(-)
- create mode 100644 images/capi/ansible/roles/node/tasks/redhat.yml
+ 4 files changed, 113 insertions(+), 3 deletions(-)
  create mode 100644 images/capi/ansible/roles/providers/files/etc/systemd/system/cloud-init.service.d/boot-order.conf
 
-diff --git a/images/capi/ansible/roles/node/tasks/main.yml b/images/capi/ansible/roles/node/tasks/main.yml
-index e0513f565..f2094927f 100644
---- a/images/capi/ansible/roles/node/tasks/main.yml
-+++ b/images/capi/ansible/roles/node/tasks/main.yml
-@@ -18,6 +18,9 @@
- - import_tasks: amazonLinux2.yml
-   when: ansible_distribution == "Amazon"
- 
-+- import_tasks: redhat.yml
-+  when: ansible_distribution == "RedHat"
-+
- # This is required until https://github.com/ansible/ansible/issues/77537 is fixed and used.
- - name: Override Flatcar's OS family
-   set_fact:
-diff --git a/images/capi/ansible/roles/node/tasks/redhat.yml b/images/capi/ansible/roles/node/tasks/redhat.yml
-new file mode 100644
-index 000000000..b2133b6f1
---- /dev/null
-+++ b/images/capi/ansible/roles/node/tasks/redhat.yml
-@@ -0,0 +1,32 @@
-+# Copyright 2020 The Kubernetes Authors.
-+
-+# Licensed under the Apache License, Version 2.0 (the "License");
-+# you may not use this file except in compliance with the License.
-+# You may obtain a copy of the License at
-+
-+# http://www.apache.org/licenses/LICENSE-2.0
-+
-+# Unless required by applicable law or agreed to in writing, software
-+# distributed under the License is distributed on an "AS IS" BASIS,
-+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-+# See the License for the specific language governing permissions and
-+# limitations under the License.
-+
-+---
-+- name: Get the list of installed kernels
-+  ansible.builtin.shell: "rpm -q kernel --qf '%{version}-%{release}\n' | sort -V"
-+  register: installed_kernels
-+
-+- name: Get the current running kernel
-+  ansible.builtin.command: "uname -r"
-+  register: current_kernel
-+
-+- name: Filter out the current kernels
-+  set_fact:
-+    old_kernels: "{{ installed_kernels.stdout_lines | difference([current_kernel.stdout]) |list }}"
-+
-+- name: Remove old kernels
-+  ansible.builtin.yum:
-+    name: "kernel-{{ item }}"
-+    state: absent
-+  loop: "{{ old_kernels }}"
-\ No newline at end of file
 diff --git a/images/capi/ansible/roles/providers/files/etc/systemd/system/cloud-init.service.d/boot-order.conf b/images/capi/ansible/roles/providers/files/etc/systemd/system/cloud-init.service.d/boot-order.conf
 new file mode 100644
 index 000000000..e1059e3eb
@@ -140,7 +88,7 @@ index b802566f4..74fa5964f 100644
    systemd:
      enabled: true
 diff --git a/images/capi/ansible/roles/setup/tasks/redhat.yml b/images/capi/ansible/roles/setup/tasks/redhat.yml
-index 74329afd4..4ebe7d732 100644
+index 74329afd4..5890d4ae7 100644
 --- a/images/capi/ansible/roles/setup/tasks/redhat.yml
 +++ b/images/capi/ansible/roles/setup/tasks/redhat.yml
 @@ -22,7 +22,75 @@
@@ -223,7 +171,7 @@ index 74329afd4..4ebe7d732 100644
    yum:
      name: "*"
      state: latest
-+    exclude: cloud-init*
++    exclude: kernel*,cloud-init*
      lock_timeout: 60
  
  - name: Install baseline dependencies
@@ -258,5 +206,5 @@ index 4176c8ff9..a9b90e83c 100644
    "ansible_scp_extra_args": "{{env `ANSIBLE_SCP_EXTRA_ARGS`}}"
  }
 -- 
-2.34.1
+2.40.1
 


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
This PR reverts the changes in a previous [PR](https://github.com/aws/eks-anywhere-build-tooling/pull/2770/commits/21e0cc86732138454c33cc2f595bf4ffb83e6a30), excluding kernel updates from the RHEL yum updates because newer kernel versions seem to introduce some unidentified networking issues in a k8s cluster

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
