### PR TITLE
Fix Bad Metrics Server Schema

### DIFF
--- a/projects/kubernetes-sigs/metrics-server/1-25/helm/schema.json
+++ b/projects/kubernetes-sigs/metrics-server/1-25/helm/schema.json
@@ -273,9 +273,9 @@
                             "examples": [
                                 "RuntimeDefault"
                             ]
-                        },
+                        }
+                    },
                     "examples": [{}]
-                    }
                 },
                 "capabilities": {
                     "type": "object",
@@ -293,14 +293,14 @@
                             ]
                         }
                     }
-                },
+                }
+            },
             "examples": [{
                 "allowPrivilegeEscalation": false,
                 "readOnlyRootFilesystem": true,
                 "runAsNonRoot": true,
                 "runAsUser": 1000
-            }]
-        },
+            }],
         "priorityClassName": {
             "type": "string",
             "default": "system-cluster-critical",
@@ -792,7 +792,8 @@
             "examples": [
             ]
         }
-    },
+    }
+},
     "examples": [{
         "sourceRegistry": "public.ecr.aws/eks-anywhere",
         "image": {
@@ -885,5 +886,4 @@
         "tolerations": [],
         "affinity": {}
         }]
-    }
 }

--- a/projects/kubernetes-sigs/metrics-server/1-26/helm/schema.json
+++ b/projects/kubernetes-sigs/metrics-server/1-26/helm/schema.json
@@ -273,9 +273,9 @@
                             "examples": [
                                 "RuntimeDefault"
                             ]
-                        },
+                        }
+                    },
                     "examples": [{}]
-                    }
                 },
                 "capabilities": {
                     "type": "object",
@@ -293,14 +293,14 @@
                             ]
                         }
                     }
-                },
+                }
+            },
             "examples": [{
                 "allowPrivilegeEscalation": false,
                 "readOnlyRootFilesystem": true,
                 "runAsNonRoot": true,
                 "runAsUser": 1000
-            }]
-        },
+            }],
         "priorityClassName": {
             "type": "string",
             "default": "system-cluster-critical",
@@ -792,7 +792,8 @@
             "examples": [
             ]
         }
-    },
+    }
+},
     "examples": [{
         "sourceRegistry": "public.ecr.aws/eks-anywhere",
         "image": {
@@ -885,5 +886,4 @@
         "tolerations": [],
         "affinity": {}
         }]
-    }
 }

--- a/projects/kubernetes-sigs/metrics-server/1-27/helm/schema.json
+++ b/projects/kubernetes-sigs/metrics-server/1-27/helm/schema.json
@@ -273,9 +273,9 @@
                             "examples": [
                                 "RuntimeDefault"
                             ]
-                        },
+                        }
+                    },
                     "examples": [{}]
-                    }
                 },
                 "capabilities": {
                     "type": "object",
@@ -293,14 +293,14 @@
                             ]
                         }
                     }
-                },
+                }
+            },
             "examples": [{
                 "allowPrivilegeEscalation": false,
                 "readOnlyRootFilesystem": true,
                 "runAsNonRoot": true,
                 "runAsUser": 1000
-            }]
-        },
+            }],
         "priorityClassName": {
             "type": "string",
             "default": "system-cluster-critical",
@@ -792,7 +792,8 @@
             "examples": [
             ]
         }
-    },
+    }
+},
     "examples": [{
         "sourceRegistry": "public.ecr.aws/eks-anywhere",
         "image": {
@@ -885,5 +886,4 @@
         "tolerations": [],
         "affinity": {}
         }]
-    }
 }

--- a/projects/kubernetes-sigs/metrics-server/1-28/helm/schema.json
+++ b/projects/kubernetes-sigs/metrics-server/1-28/helm/schema.json
@@ -273,9 +273,9 @@
                             "examples": [
                                 "RuntimeDefault"
                             ]
-                        },
+                        }
+                    },
                     "examples": [{}]
-                    }
                 },
                 "capabilities": {
                     "type": "object",
@@ -293,14 +293,14 @@
                             ]
                         }
                     }
-                },
+                }
+            },
             "examples": [{
                 "allowPrivilegeEscalation": false,
                 "readOnlyRootFilesystem": true,
                 "runAsNonRoot": true,
                 "runAsUser": 1000
-            }]
-        },
+            }],
         "priorityClassName": {
             "type": "string",
             "default": "system-cluster-critical",
@@ -792,7 +792,8 @@
             "examples": [
             ]
         }
-    },
+    }
+},
     "examples": [{
         "sourceRegistry": "public.ecr.aws/eks-anywhere",
         "image": {
@@ -885,5 +886,4 @@
         "tolerations": [],
         "affinity": {}
         }]
-    }
 }

--- a/projects/kubernetes-sigs/metrics-server/1-29/helm/schema.json
+++ b/projects/kubernetes-sigs/metrics-server/1-29/helm/schema.json
@@ -273,9 +273,9 @@
                             "examples": [
                                 "RuntimeDefault"
                             ]
-                        },
+                        }
+                    },
                     "examples": [{}]
-                    }
                 },
                 "capabilities": {
                     "type": "object",
@@ -293,14 +293,14 @@
                             ]
                         }
                     }
-                },
+                }
+            },
             "examples": [{
                 "allowPrivilegeEscalation": false,
                 "readOnlyRootFilesystem": true,
                 "runAsNonRoot": true,
                 "runAsUser": 1000
-            }]
-        },
+            }],
         "priorityClassName": {
             "type": "string",
             "default": "system-cluster-critical",
@@ -792,7 +792,8 @@
             "examples": [
             ]
         }
-    },
+    }
+},
     "examples": [{
         "sourceRegistry": "public.ecr.aws/eks-anywhere",
         "image": {
@@ -885,5 +886,4 @@
         "tolerations": [],
         "affinity": {}
         }]
-    }
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

EKS Anywhere Curated Packages accept configuration parameters that are passed in to the underlying helm chart as values.

The packages controller validates these parameters using the schema.json, which is base64 encoded, compressed, and published
as a package attribute in the packagebundle object.

This change was verified by building the helm chart locally and grabbing the schema field from `requires.yaml`.

I then plugged this schema value into the [TestPackageValidate unit test](https://github.com/aws/eks-anywhere-packages/blob/cb5c9870ca6c1ce306db7e479392e29249df8484/pkg/webhook/package_webhook_test.go#L12-L12) in eks-anywhere-packages repo.

By verifying that the test passed, I was able to confirm that the schema was valid.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->