### PR TITLE
Update ADOT patch to use logging instead of debug exporter

### DIFF
--- a/projects/aws-observability/aws-otel-collector/helm/patches/0003-default-values-patch.yaml
+++ b/projects/aws-observability/aws-otel-collector/helm/patches/0003-default-values-patch.yaml
@@ -1,12 +1,12 @@
-From fc85050abf26cc3042b597794cdfbed75ae3aa1e Mon Sep 17 00:00:00 2001
-From: "Ostosh, Ivy" <ivyjin@amazon.com>
-Date: Fri, 27 Jan 2023 14:54:12 -0600
-Subject: [PATCH 3/3] Update default values
+From e90f72f6a1aa4a0948433b165d06f33757d6d88e Mon Sep 17 00:00:00 2001
+From: ahreehong <46465244+ahreehong@users.noreply.github.com>
+Date: Thu, 18 Jan 2024 14:38:34 -0800
+Subject: [PATCH] Update default values
 
 ---
  .../values.schema.json                        |  3 +-
- charts/opentelemetry-collector/values.yaml    | 57 +------------------
- 2 files changed, 4 insertions(+), 56 deletions(-)
+ charts/opentelemetry-collector/values.yaml    | 64 ++-----------------
+ 2 files changed, 7 insertions(+), 60 deletions(-)
 
 diff --git a/charts/opentelemetry-collector/values.schema.json b/charts/opentelemetry-collector/values.schema.json
 index 5d78b61..cd8aab6 100644
@@ -21,7 +21,7 @@ index 5d78b61..cd8aab6 100644
 +  }
  }
 diff --git a/charts/opentelemetry-collector/values.yaml b/charts/opentelemetry-collector/values.yaml
-index e5df2a6..970bd27 100644
+index e5df2a6..d74daac 100644
 --- a/charts/opentelemetry-collector/values.yaml
 +++ b/charts/opentelemetry-collector/values.yaml
 @@ -8,7 +8,7 @@ fullnameOverride: ""
@@ -33,17 +33,22 @@ index e5df2a6..970bd27 100644
  
  # Specify which namespace should be used to deploy the resources into
  namespaceOverride: ""
-@@ -91,7 +91,8 @@ config:
-     debug: {}
-     # Will be removed in a future release.
-     # Use the debug exporter instead.
+@@ -88,10 +88,10 @@ configMap:
+ # For example, {{ REDACTED_EMAIL }} becomes {{` {{ REDACTED_EMAIL }} `}}.
+ config:
+   exporters:
+-    debug: {}
+-    # Will be removed in a future release.
+-    # Use the debug exporter instead.
 -    logging: {}
++    # Logging will be removed in a future release.
++    # Use the debug exporter insteaåd.
 +    logging:
 +      loglevel: info
    extensions:
      # The health_check extension is mandatory for this chart.
      # Without the health_check extension the collector will fail the readiness and liveliness probes.
-@@ -103,14 +104,6 @@ config:
+@@ -103,14 +103,6 @@ config:
      # If set to null, will be overridden with values based on k8s resource limits
      memory_limiter: null
    receivers:
@@ -58,7 +63,7 @@ index e5df2a6..970bd27 100644
      otlp:
        protocols:
          grpc:
-@@ -125,8 +118,6 @@ config:
+@@ -125,8 +117,6 @@ config:
              static_configs:
                - targets:
                    - ${env:MY_POD_IP}:8888
@@ -67,7 +72,7 @@ index e5df2a6..970bd27 100644
    service:
      telemetry:
        metrics:
-@@ -135,14 +126,6 @@ config:
+@@ -135,33 +125,15 @@ config:
        - health_check
        - memory_ballast
      pipelines:
@@ -81,8 +86,11 @@ index e5df2a6..970bd27 100644
 -          - otlp
        metrics:
          exporters:
-           - debug
-@@ -152,16 +135,6 @@ config:
+-          - debug
++          - logging
+         processors:
+           - memory_limiter
+           - batch
          receivers:
            - otlp
            - prometheus
@@ -99,7 +107,7 @@ index e5df2a6..970bd27 100644
  
  image:
    # If you want to use the core image `otel/opentelemetry-collector`, you also need to change `command.name` value to `otelcol`.
-@@ -254,30 +227,6 @@ ports:
+@@ -254,30 +226,6 @@ ports:
      servicePort: 4318
      hostPort: 4318
      protocol: TCP
@@ -131,5 +139,5 @@ index e5df2a6..970bd27 100644
      # The metrics port is disabled by default. However you need to enable the port
      # in order to use the ServiceMonitor (serviceMonitor.enabled) or PodMonitor (podMonitor.enabled).
 -- 
-2.43.0
+2.40.0
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
ADOT is built upon opentelemetry-collector with customized logging and configuration handling logic that only supports the selected components which have been verified by AWS from the opentelemetry-collector list

This patch updates the ADOT helm chart to use logging exporter rather than debug exporter as debug exporter is not supported in v0.36.0 of ADOT

Related issue on ADOT github:
https://github.com/aws-observability/aws-otel-collector/issues/2470

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

