### PR TITLE
Monitor govc session to ensure full VMDK downloads

### DIFF
--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -21,18 +21,18 @@ releases:
   number: 33
   kubeVersion: v1.24.17
 - branch: 1-25
-  number: 30
+  number: 31
   kubeVersion: v1.25.16
 - branch: 1-26
-  number: 26
+  number: 27
   kubeVersion: v1.26.11
 - branch: 1-27
-  number: 20
+  number: 21
   kubeVersion: v1.27.8
 - branch: 1-28
-  number: 13
+  number: 14
   kubeVersion: v1.28.4
 - branch: 1-29
-  number: 2
+  number: 3
   kubeVersion: v1.29.0
 latest: 1-25

--- a/projects/aws/eks-a-admin-image/build/export-ami-to-s3.sh
+++ b/projects/aws/eks-a-admin-image/build/export-ami-to-s3.sh
@@ -122,4 +122,4 @@ done
 INSPECTOR_FINDINGS_REPORT_ID=$(aws inspector2 create-findings-report --filter-criteria '{"resourceId": [{"comparison": "EQUALS", "value": "'"$INSTANCE_ID"'"}], "findingStatus": [{"comparison": "EQUALS", "value": "ACTIVE"}]}' --report-format CSV --s3-destination '{"bucketName": "'"$SNOW_ADMIN_IMAGE_INSPECTOR_BUCKET"'", "kmsKeyArn": "'"$SNOW_ADMIN_IMAGE_INSPECTOR_KMS_KEY_ARN"'"}' --query "reportId" --output text) 
 
 # Make findings report public 
-aws s3api put-object-acl --bucket $SNOW_ADMIN_IMAGE_INSPECTOR_BUCKET --key $INSPECTOR_FINDINGS_REPORT_ID --acl public-read
+aws s3api put-object-acl --bucket $SNOW_ADMIN_IMAGE_INSPECTOR_BUCKET --key $INSPECTOR_FINDINGS_REPORT_ID.csv --acl public-read

--- a/projects/aws/eks-a-admin-image/build/validate-release-manifest-version.sh
+++ b/projects/aws/eks-a-admin-image/build/validate-release-manifest-version.sh
@@ -12,8 +12,8 @@ n=0
 max_attempts=120
 delay=30
 while true; do
-    LATEST_EKSA_VERSION_S3=$(curl $EKSA_RELEASE_MANIFEST_S3_URL | yq e '.spec.latestVersion' -)
-    LATEST_EKSA_VERSION_CLOUDFRONT=$(curl $EKSA_RELEASE_MANIFEST_CDN_URL | yq e '.spec.latestVersion' -)
+    LATEST_EKSA_VERSION_S3=$(curl $EKSA_RELEASE_MANIFEST_S3_URL | yq e '.spec.releases[-1].version' -)
+    LATEST_EKSA_VERSION_CLOUDFRONT=$(curl $EKSA_RELEASE_MANIFEST_CDN_URL | yq e '.spec.releases[-1].version' -)
     [[ "$LATEST_EKSA_VERSION_S3" == "$LATEST_EKSA_VERSION_CLOUDFRONT" ]] && break || {
         if [[ $n -lt $max_attempts ]]; then
             ((n++))

--- a/projects/kubernetes-sigs/image-builder/build/build_image.sh
+++ b/projects/kubernetes-sigs/image-builder/build/build_image.sh
@@ -57,7 +57,7 @@ function retry_image_builder() {
 
   until [ $n -eq $max ]; do
     failed="false"
-    timeout "1h" ${HOME}/image-builder "$@" && break || {
+    timeout "1.5h" ${HOME}/image-builder "$@" && break || {
       failed="true"
 
       local log_file=$(find $MAKE_ROOT -name "packer.log" -type f)

--- a/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
@@ -1,4 +1,4 @@
-From 9f66569c7ef0777b0f36e5de437d0a13a75e739e Mon Sep 17 00:00:00 2001
+From 4f22a0f719be7fbb75c1065b1b9311d603056508 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:05:13 -0800
 Subject: [PATCH 01/11] OVA improvements
@@ -9,10 +9,10 @@ Subject: [PATCH 01/11] OVA improvements
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---
- .../capi/ansible/roles/sysprep/tasks/main.yml |  9 +++++
+ .../capi/ansible/roles/sysprep/tasks/main.yml |  9 ++++
  images/capi/hack/ovf_template.xml             | 10 +----
- images/capi/packer/ova/packer-node.json       | 38 +++++++++++++------
- 3 files changed, 37 insertions(+), 20 deletions(-)
+ images/capi/packer/ova/packer-node.json       | 41 +++++++++++++------
+ 3 files changed, 40 insertions(+), 20 deletions(-)
 
 diff --git a/images/capi/ansible/roles/sysprep/tasks/main.yml b/images/capi/ansible/roles/sysprep/tasks/main.yml
 index a9fa954d5..a526528ea 100644
@@ -61,7 +61,7 @@ index 316427ec3..ca23db5f9 100644
        <Property ovf:userConfigurable="false" ovf:value="${BUILD_TIMESTAMP}" ovf:type="string" ovf:key="BUILD_TIMESTAMP"/>
        <Property ovf:userConfigurable="false" ovf:value="${BUILD_DATE}" ovf:type="string" ovf:key="BUILD_DATE"/>
 diff --git a/images/capi/packer/ova/packer-node.json b/images/capi/packer/ova/packer-node.json
-index 1b7b2d13d..e85dbe077 100644
+index 1b7b2d13d..f46df3cee 100644
 --- a/images/capi/packer/ova/packer-node.json
 +++ b/images/capi/packer/ova/packer-node.json
 @@ -184,6 +184,12 @@
@@ -128,11 +128,14 @@ index 1b7b2d13d..e85dbe077 100644
      {
        "custom_data": {
          "build_date": "{{isotime}}",
-@@ -324,7 +333,11 @@
+@@ -324,7 +333,14 @@
          "vsphere-iso-base"
        ],
        "inline": [
 -        "./hack/image-build-ova.py --vmx {{user `vmx_version`}} --eula ./hack/ovf_eula.txt --ovf_template ./hack/ovf_template.xml --vmdk_file {{user `build_version`}}-disk-0.vmdk {{user `output_dir`}}"
++        "while true; do govc library.session.ls &> /dev/null || true; sleep 2m; done &",
++        "PID=$!",
++        "trap \"kill $PID\" EXIT",
 +        "govc library.export /{{user `vsphere_library_name`}}/{{user `build_version`}}/{{user `build_version`}}.ovf {{user `output_dir`}}/{{user `build_version`}}.ovf",
 +        "govc library.export /{{user `vsphere_library_name`}}/{{user `build_version`}}/{{user `build_version`}}-1.vmdk {{user `output_dir`}}/{{user `build_version`}}-1.vmdk",
 +        "govc library.export /{{user `vsphere_library_name`}}/{{user `build_version`}}/{{user `build_version`}}-2.nvram {{user `output_dir`}}/{{user `build_version`}}-2.nvram",
@@ -141,7 +144,7 @@ index 1b7b2d13d..e85dbe077 100644
        ],
        "name": "vsphere",
        "type": "shell-local"
-@@ -509,6 +522,7 @@
+@@ -509,6 +525,7 @@
      "resource_pool": "",
      "username": "",
      "vcenter_server": "",


### PR DESCRIPTION
We were facing issues with importing the Ubuntu 22.04 OVAs built in CI, with the most common error being
```console
Reason: Error transferring file ubuntu-2204-kube-v1.28.4-1.vmdk to ds:///vmfs/volumes/vsan:.... Reason: Unable to parse disk image while uploading to: ds:///vmfs/volumes/vsan:...
```
This pointed to an issue with the VMDK itself. To build the OVA, we download the OVF, VMDK and NVRAM from the vCenter Content Library in the Packer post-processor step and then pass them as inputs to a script which packages them into an OVA. Since December 15 or so, we noticed that the OVAs being uploaded to S3 had shrunk in size compared to previous uploads (~6 GB before vs ~2 GB after). Upon downloading the OVA, extracting the VMDK and inspecting it, we encountered the following error.
```console
$ qemu-img check ubuntu-2204-kube-v1.28.4-1.vmdk       
qemu-img: Could not open 'ubuntu-2204-kube-v1.28.4-1.vmdk': Invalid footer
```
This indicates that the VMDK is corrupt and from the size reduction, we hypothesized that it's possibly not being downloaded fully from the Content Library during the image build. To investigate if this was caused due to a vCenter session timeout issue, we monitored the sessions using
```console
$ while true; do govc library.session.ls; done
```
Surprisingly, keeping this session monitoring alive during the VMDK download caused it to download the entire 6GB VMDK instead of cutting short at ~2 GB, and the downloaded VMDK had no errors when inspected.
```console
$ qemu-img check ubuntu-2204-kube-v1.28.4-1.vmdk
No errors were found on the image.
```
The import of this VMDK also worked fine. So we are adding this workaround to the image build by running the session monitor as a background process until the OVA is built.

I've also bumped EKS-D releases and made some fixes to the EKS-A admin AMI while I'm at it. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
