### PR TITLE
Add release notes to PR description

### DIFF
--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -31,7 +31,8 @@ const (
 	BaseRepoHeadRevision        = "refs/remotes/origin/main"
 	PullRequestBody             = `This PR bumps %[1]s/%[2]s to the latest Git revision, along with other updates such as Go version, checksums and attribution files.
 
-[Compare changes](https://github.com/%[1]s/%[2]s/compare/%s...%s)
+[Compare changes](https://github.com/%[1]s/%[2]s/compare/%[3]s...%[4]s)
+[Release notes](https://github.com/%[1]s/%[2]s/releases/%[4]s)
 
 /hold
 /area dependencies


### PR DESCRIPTION
Adding release notes to the upgrade PRs that the bot opens.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
