### PR TITLE
Add Instructions for Validating Helm Chart

### DIFF
--- a/projects/kubernetes/autoscaler/README.md
+++ b/projects/kubernetes/autoscaler/README.md
@@ -57,3 +57,16 @@ Finally:
 RELEASE_BRANCH=1-XX make clean
 RELEASE_BRANCH=1-XX make build
 ```
+
+#### Validating Helm Chart And Images
+
+An easy way to validate your build is to install the helm chart to a kind cluster.
+
+Install [kind](https://kind.sigs.k8s.io/) and create a cluster.
+
+Then install the helm chart pointing at your personal registry using the command outputted when the build succeeds. For instance:
+```
+helm install cluster-autoscaler oci://public.ecr.aws/b9u1e4h9/cluster-autoscaler/charts/cluster-autoscaler --version 9.34.0-1.27-6444f7f1d05573c56b00d438af946ab9c36951a1 --set sourceRegistry=public.ecr.aws/a9u1e4h1 --set autoDiscovery.clusterName=foobar
+```
+
+Where `public.ecr.aws/b9u1e4h9` would be your personal registry.


### PR DESCRIPTION
*Description of changes:*
Add some documentation to reduce friction in the process of developing and testing curated packages helm charts.

Note that this does not test the helm chart's schema, as that would require generating a bundle and installing
in a cluster running the package controller.

However, this does verify that the helm chart itself is valid yaml and install as expected.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->