### PR TITLE
Bump Bottlerocket release version to latest

### DIFF
--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
@@ -1,20 +1,20 @@
 1-24:
-    ami-release-version: v1.18.0
-    ova-release-version: v1.18.0
-    raw-release-version: v1.18.0
+    ami-release-version: v1.19.0
+    ova-release-version: v1.19.0
+    raw-release-version: v1.19.0
 1-25:
-    ami-release-version: v1.18.0
-    ova-release-version: v1.18.0
-    raw-release-version: v1.18.0
+    ami-release-version: v1.19.0
+    ova-release-version: v1.19.0
+    raw-release-version: v1.19.0
 1-26:
-    ami-release-version: v1.18.0
-    ova-release-version: v1.18.0
-    raw-release-version: v1.18.0
+    ami-release-version: v1.19.0
+    ova-release-version: v1.19.0
+    raw-release-version: v1.19.0
 1-27:
-    ami-release-version: v1.18.0
-    ova-release-version: v1.18.0
-    raw-release-version: v1.18.0
+    ami-release-version: v1.19.0
+    ova-release-version: v1.19.0
+    raw-release-version: v1.19.0
 1-28:
-    ami-release-version: v1.18.0
-    ova-release-version: v1.18.0
-    raw-release-version: v1.18.0
+    ami-release-version: v1.19.0
+    ova-release-version: v1.19.0
+    raw-release-version: v1.19.0


### PR DESCRIPTION
Backporting #2879 to release-0.18 branch.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
