### PR TITLE
Update upgrader script to upgrade binaries only when there is a version diff 

### DIFF
--- a/projects/aws/upgrader/upgrade.sh
+++ b/projects/aws/upgrader/upgrade.sh
@@ -78,6 +78,8 @@ kubeadm_in_first_cp(){
   kubeadm upgrade apply "$kube_version" --config "$new_kubeadm_config" --ignore-preflight-errors=CoreDNSUnsupportedPlugins,CoreDNSMigration --allow-experimental-upgrades --yes
 
   restore_coredns_config "$components_dir"
+  else
+  echo "no version change detected for kubeadm, skipping upgrade"
   fi
 }
 
@@ -100,6 +102,8 @@ kubeadm_in_rest_cp(){
   kubeadm version
   kubeadm upgrade node --ignore-preflight-errors=CoreDNSUnsupportedPlugins,CoreDNSMigration
   restore_coredns_config "$components_dir"
+  else
+  echo "no version change detected for kubeadm, skipping upgrade"
   fi
 }
 
@@ -136,6 +140,8 @@ kubeadm_in_worker() {
 
   kubeadm version
   kubeadm upgrade node 
+  else
+  echo "no version change detected for kubeadm, skipping upgrade"
   fi
 }
 
@@ -149,12 +155,14 @@ kubelet_and_kubectl() {
   backup_and_replace /usr/bin/kubelet "$components_dir" "$components_dir/kubelet"
   systemctl daemon-reload
   systemctl restart kubelet
+  else
+  echo "no version change detected for kubectl, skipping upgrade"
   fi
 }
 
 upgrade_containerd() {
   components_dir=$(upgrade_components_bin_dir)
-  if [ $(containerd --version) != $(components_dir/containerd --version) ]; then
+  if [ $(containerd --version) != $($components_dir/containerd/usr/local/bin/containerd --version) ]; then
   containerd --version
 
   # before nsenter, copy /eksa-upgrades to /tmp/eksa-upgrades
@@ -169,6 +177,8 @@ upgrade_containerd() {
   # systemctl stop containerd
 
   systemctl restart containerd
+  else
+  echo "no version change detected for containerd, skipping upgrade"
   fi
 }
 
@@ -191,7 +201,7 @@ cni_plugins() {
 is_version_chage() {
   components_dir=$(upgrade_components_bin_dir)
   current_version=$(/usr/bin/$1 $2)
-  new_version=$($components_dir/$1 $2)
+  new_version=$($components_dir/kubernetes/usr/bin/ $1 $2)
   if [ "$current_version" != "$new_version" ];
   then 
     true


### PR DESCRIPTION
*Issue #, if available:*
Upgrader pod uses a upgrade.sh script that upgrades all the core kubernetes binaries with the binaries that are already baked into the pod. At present, we upgrade the binaries every time the script is invoked to upgrade a particular component. This change adds logic to the script to check if there is any version diff between the existing binary on the host and the binary baked into the pod before proceeding with the upgrade. 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
