### PR TITLE
Revert Bottlerocket release update for 1.24 OVA and raw images

### DIFF
--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
@@ -1,7 +1,7 @@
 1-24:
     ami-release-version: v1.19.0
-    ova-release-version: v1.19.0
-    raw-release-version: v1.19.0
+    ova-release-version: v1.18.0
+    raw-release-version: v1.18.0
 1-25:
     ami-release-version: v1.19.0
     ova-release-version: v1.19.0


### PR DESCRIPTION
Bottlerocket [dropped](https://github.com/bottlerocket-os/bottlerocket/commit/f1be358629beccaf3dc4bd18d4939ffec04a2de8) the 1.24 metal and vmWare variants in the latest release but we still need them for our 0.18 releases.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
