### PR TITLE
Handle KubeletCredentialProviders extraargs for in-place upgrades

### DIFF
--- a/projects/aws/upgrader/upgrade.sh
+++ b/projects/aws/upgrader/upgrade.sh
@@ -63,7 +63,7 @@ kubeadm_in_first_cp(){
   kubectl get cm -n kube-system kubelet-config -ojsonpath='{.data.kubelet}' --kubeconfig /etc/kubernetes/admin.conf >> "$new_kubeadm_config"
 
   # Backup and delete coredns configmap. If the CM doesn't exist, kubeadm will skip its upgrade.
-  # This is desirable for 2 reaons:
+  # This is desirable for 2 reasons:
   # - CAPI already takes care of coredns upgrades
   # - kubeadm will fail when verifying the current version of coredns bc the image tag created by
   #   eks-s is not recognised by the migration verification logic https://github.com/coredns/corefile-migration/blob/master/migration/versions.go
@@ -85,7 +85,7 @@ kubeadm_in_rest_cp(){
   backup_and_replace /usr/bin/kubeadm "$components_dir" "$components_dir/kubeadm"
 
   # Backup and delete coredns configmap. If the CM doesn't exist, kubeadm will skip its upgrade.
-  # This is desirable for 2 reaons:
+  # This is desirable for 2 reasons:
   # - CAPI already takes care of coredns upgrades
   # - kubeadm will fail when verifying the current version of coredns bc the image tag created by
   #   eks-s is not recognised by the migration verification logic https://github.com/coredns/corefile-migration/blob/master/migration/versions.go
@@ -102,7 +102,7 @@ kubeadm_in_rest_cp(){
 backup_and_delete_coredns_config(){
   components_dir=$1
   # Backup and delete coredns configmap. If the CM doesn't exist, kubeadm will skip its upgrade.
-  # This is desirable for 2 reaons:
+  # This is desirable for 2 reasons:
   # - CAPI already takes care of coredns upgrades
   # - kubeadm will fail when verifying the current version of coredns bc the image tag created by
   #   eks-s is not recognised by the migration verification logic https://github.com/coredns/corefile-migration/blob/master/migration/versions.go
@@ -134,14 +134,34 @@ kubeadm_in_worker() {
 }
 
 kubelet_and_kubectl() {
+  kube_version=$(kubeadm version -oshort)
+
   components_dir=$(upgrade_components_kubernetes_bin_dir)
 
   backup_and_replace /usr/bin/kubectl "$components_dir" "$components_dir/kubectl"
 
   systemctl stop kubelet
   backup_and_replace /usr/bin/kubelet "$components_dir" "$components_dir/kubelet"
+
+  # KubeletCredentialProviders support became GA in k8s v1.26, and the feature gate was removed in k8s v1.28.
+  # For in-place upgrades, we should remove this feature gate if it exists on nodes running k8s v1.26 and above.
+  if [[ "$kube_version" != v1.25* ]]; then
+    update_kubelet_extra_args
+  fi
+
   systemctl daemon-reload
   systemctl restart kubelet
+}
+
+update_kubelet_extra_args() {
+  kubelet_extra_args=$(cat /etc/sysconfig/kubelet)
+  feature_gate=" --feature-gates=KubeletCredentialProviders=true"
+  if [[ $kubelet_extra_args == *$feature_gate* ]]; then
+    kubelet_extra_args=${kubelet_extra_args//"$feature_gate"/}
+    mkdir "$components_dir/extraargs"
+    backup_file /etc/sysconfig/kubelet "$components_dir/extraargs"
+    echo "$kubelet_extra_args" > /etc/sysconfig/kubelet
+  fi
 }
 
 upgrade_containerd() {
@@ -150,7 +170,7 @@ upgrade_containerd() {
   containerd --version
 
   # before nsenter, copy /eksa-upgrades to /tmp/eksa-upgrades
-  # IDEA: similiar to the kubeadm flow, we could loop the folder structure
+  # IDEA: similar to the kubeadm flow, we could loop the folder structure
   # and for each binary/config file backup the existing file before copying 
   # so there is a rollback path
   cp -rf $components_dir/containerd/* /
@@ -170,7 +190,7 @@ cni_plugins() {
   /opt/cni/bin/loopback --version
 
   # before nsenter, copy /eksa-upgrades to /tmp/eksa-upgrades
-  # IDEA: similiar to the kubeadm flow, we could loop the folder structure
+  # IDEA: similar to the kubeadm flow, we could loop the folder structure
   # and for each binary/config file backup the existing file before copying 
   # so there is a rollback path
   cp -rf $components_dir/cni-plugins/* /


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/2159

*Description of changes:*
`KubeletCredentialProviders` support became GA in k8s v1.26, and the feature gate was removed in k8s v1.28.
When upgrading nodes in-place from 1.25 -> 1.26 -> 1.27 -> 1.28, the 1.28 upgrade will fail with unrecognized feature flag.
Therefore, we should remove this feature gate if it exists on nodes running k8s v1.26 and above.


in 1.25 node: 

```
capv@tneyla-ub-25-hvcvf:~$ cat /etc/sysconfig/kubelet 

KUBELET_EXTRA_ARGS= --feature-gates=KubeletCredentialProviders=true --image-credential-provider-config=/eksa-packages/credential-provider-config.yaml --image-credential-provider-bin-dir=/eksa-packages/
```

After in-place upgrade to 1.26:
```
capv@tneyla-ub-25-hvcvf:~$ cat /etc/sysconfig/kubelet 

KUBELET_EXTRA_ARGS= --image-credential-provider-config=/eksa-packages/credential-provider-config.yaml --image-credential-provider-bin-dir=/eksa-packages/
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
