### PR TITLE
Fix image-builder builds in dev release mode

### DIFF
--- a/build/lib/eksa_releases.sh
+++ b/build/lib/eksa_releases.sh
@@ -31,16 +31,8 @@ function build::eksa_releases::load_bundle_manifest() {
     local -r release_manifest_url=$(build::eksa_releases::get_eksa_release_manifest_url $dev_release $latest)
     local -r release_manifest=$(curl -s --retry 5 $release_manifest_url)
 
-    # The EKSA_RELEASE_VERSION variable is set only when this script is run from the image-builder CLI.
-    # When running the image-builder CLI in dev, the EKSA_RELEASE_VERSION will be set to a dev version
-    # such as v0.0.0-dev, but without the build metadata. This incomplete version is not available in the
-    # dev EKS-A releases manifest and so the yq search will fail. Hence if are running in dev, we append
-    # a wildcard build metadata to the EKSA_RELEASE_VERSION var that will make it pass the yq select check.
     EKSA_RELEASE_VERSION="${EKSA_RELEASE_VERSION:-}"
     local eksa_release_version=${EKSA_RELEASE_VERSION:-$(echo "$release_manifest" | yq e ".spec.latestVersion" -)}
-    if [ $dev_release = true ] && [ -n "$EKSA_RELEASE_VERSION" ]; then
-      eksa_release_version="$eksa_release_version+build.*"
-    fi
     local bundle_manifest_url=$(echo "$release_manifest" | yq e ".spec.releases[] | select(.version == \"$eksa_release_version\") .bundleManifestUrl" -)
     # EKSA_BUNDLE_MANIFEST_URL is set only when image-builder CLI is running in airgapped mode.
     # This will be set to a filepath that has the downloaded or pre-baked bundles file

--- a/projects/aws/image-builder/Makefile
+++ b/projects/aws/image-builder/Makefile
@@ -7,9 +7,9 @@ REPO=image-builder
 REPO_OWNER=aws
 EKS_ANYWHERE_CLONE_URL=https://github.com/aws/eks-anywhere.git
 EKS_ANYWHERE_REPO=eks-anywhere
-EKS_ANYWHERE_REPO_SPARSE_CHECKOUT=release/triggers/bundle-release/development/CLI_MAX_VERSION
-EKS_ANYWHERE_EMBED_VERSION=v0.0.0-dev$(if $(filter main,$(BRANCH_NAME)),,-$(BRANCH_NAME))
+EKS_ANYWHERE_REPO_SPARSE_CHECKOUT=release/triggers/bundle-release/development/CLI_MAX_VERSION scripts/eksa_version.sh
 EKS_ANYWHERE_RELEASE_MANIFEST_URL=https://dev-release-assets.eks-anywhere.model-rocket.aws.dev/$(if $(filter $(BRANCH_NAME),main),,$(BRANCH_NAME)/)eks-a-release.yaml
+EKS_ANYWHERE_EMBED_VERSION=$(shell cd eks-anywhere && source ./scripts/eksa_version.sh && eksa-version::latest_release_verison_in_manifest "$(EKS_ANYWHERE_RELEASE_MANIFEST_URL)")
 
 BINARY_TARGET_FILES=image-builder
 GO_MOD_PATHS=..

--- a/projects/aws/image-builder/builder/constants.go
+++ b/projects/aws/image-builder/builder/constants.go
@@ -62,10 +62,9 @@ const (
 	eksaAnsibleVerbosityEnvVar            string = "EKSA_ANSIBLE_VERBOSITY"
 
 	// Miscellaneous
-	mainBranch            string = "main"
-	devEksaReleaseVersion string = "v0.0.0-dev"
-	amd64                 string = "amd64"
-	arm64                 string = "arm64"
+	mainBranch string = "main"
+	amd64      string = "amd64"
+	arm64      string = "arm64"
 )
 
 var DefaultAMIAdditionalFiles = []File{

--- a/projects/aws/image-builder/builder/utils.go
+++ b/projects/aws/image-builder/builder/utils.go
@@ -286,7 +286,7 @@ func (bo *BuildOptions) getBundle() (*releasev1.Bundles, string, error) {
 	var eksAReleaseVersion, bundleManifestUrl string
 	var foundRelease bool
 	if os.Getenv(eksaUseDevReleaseEnvVar) == "true" {
-		eksAReleaseVersion = devEksaReleaseVersion
+		eksAReleaseVersion = releases.Spec.LatestVersion
 		log.Printf("EKSA_USE_DEV_RELEASE set to true, using EKS-A dev release version: %s", eksAReleaseVersion)
 	} else if bo.EKSAReleaseVersion != "" {
 		eksAReleaseVersion = bo.EKSAReleaseVersion


### PR DESCRIPTION
Fix image-builder builds in dev release mode by supporting the new release manifest versioning scheme.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
