### PR TITLE
Add 1-29 release branch Bottlerocket artifacts

### DIFF
--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
@@ -14,3 +14,6 @@
     ami-release-version: v1.19.1
     ova-release-version: v1.19.1
     raw-release-version: v1.19.1
+1-29:
+    ami-release-version: v1.19.1
+    ova-release-version: 1.19.2


### PR DESCRIPTION
Add 1-29 release branch Bottlerocket artifacts for VMWare and AWS variants.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
