### PR TITLE
Use production release of Kubernetes v1.29 Bottlerocket OVA

### DIFF
--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
@@ -16,4 +16,4 @@
     raw-release-version: v1.19.1
 1-29:
     ami-release-version: v1.19.1
-    ova-release-version: 1.19.2
+    ova-release-version: v1.19.1


### PR DESCRIPTION
Use production release of Kubernetes v1.29 Bottlerocket OVA from v1.19.1, which was released just today.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
