### PR TITLE
Fix upgrader script to check if kubelet config exists before updating it

### DIFF
--- a/projects/aws/upgrader/upgrade.sh
+++ b/projects/aws/upgrader/upgrade.sh
@@ -165,13 +165,18 @@ kubelet_and_kubectl() {
 }
 
 update_kubelet_extra_args() {
-  kubelet_extra_args=$(cat /etc/sysconfig/kubelet)
+  kubelet_conf="/etc/sysconfig/kubelet"
+  if [ ! -f kubelet_conf ]; then
+    echo "kubelet config file ${kubelet_conf} not found, skipping"
+    return
+  fi
+  kubelet_extra_args=$(cat ${kubelet_conf})
   feature_gate=" --feature-gates=KubeletCredentialProviders=true"
   if [[ $kubelet_extra_args == *$feature_gate* ]]; then
     kubelet_extra_args=${kubelet_extra_args//"$feature_gate"/}
     mkdir "$components_dir/extraargs"
-    backup_file /etc/sysconfig/kubelet "$components_dir/extraargs"
-    echo "$kubelet_extra_args" > /etc/sysconfig/kubelet
+    backup_file ${kubelet_conf} "$components_dir/extraargs"
+    echo "$kubelet_extra_args" > ${kubelet_conf}
   fi
 }
 


### PR DESCRIPTION
*Description of changes:*
We added a fix in https://github.com/aws/eks-anywhere-build-tooling/pull/2891 to remove kubelet extra args when upgrading to k8s >= 1.26 as that kubelet extra args is deprecated/removed. The problem is that config file is created by one of the `eksa-packages` pods. So the packages wasn't deployed or failed to deploy, this file wouldn't exist and the in-place upgrade would fail.
This PR adds a check to see if this kubelet config file exists before trying to modify it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
