### PR TITLE
Remove IMAGE_OS_VERSION command-line Make variable

### DIFF
--- a/projects/kubernetes-sigs/image-builder/buildspecs/ami.yml
+++ b/projects/kubernetes-sigs/image-builder/buildspecs/ami.yml
@@ -16,4 +16,4 @@ phases:
 
   build:
     commands:
-      - if make check-for-supported-release-branch IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=ami RELEASE_BRANCH=$RELEASE_BRANCH  -C $PROJECT_PATH && make check-for-release-branch-skip -C $PROJECT_PATH; then make binaries -C $CLI_FOLDER && make release IMAGE_OS=$IMAGE_OS IMAGE_OS_VERSION=$IMAGE_OS_VERSION IMAGE_FORMAT=ami RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH; fi
+      - if make check-for-supported-release-branch IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=ami RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH && make check-for-release-branch-skip -C $PROJECT_PATH; then make binaries -C $CLI_FOLDER && make release IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=ami RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH; fi

--- a/projects/kubernetes-sigs/image-builder/buildspecs/cloudstack.yml
+++ b/projects/kubernetes-sigs/image-builder/buildspecs/cloudstack.yml
@@ -12,4 +12,4 @@ phases:
 
   build:
     commands:
-      - if make check-for-supported-release-branch IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=cloudstack RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH && make check-for-release-branch-skip -C $PROJECT_PATH; then make binaries -C $CLI_FOLDER && make release IMAGE_OS=$IMAGE_OS IMAGE_OS_VERSION=$IMAGE_OS_VERSION IMAGE_FORMAT=cloudstack RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH; fi
+      - if make check-for-supported-release-branch IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=cloudstack RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH && make check-for-release-branch-skip -C $PROJECT_PATH; then make binaries -C $CLI_FOLDER && make release IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=cloudstack RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH; fi

--- a/projects/kubernetes-sigs/image-builder/buildspecs/ova.yml
+++ b/projects/kubernetes-sigs/image-builder/buildspecs/ova.yml
@@ -22,4 +22,4 @@ phases:
 
   build:
     commands:      
-      - if make check-for-supported-release-branch IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=ova RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH && make check-for-release-branch-skip -C $PROJECT_PATH; then make binaries -C $CLI_FOLDER && make release IMAGE_OS=$IMAGE_OS IMAGE_OS_VERSION=$IMAGE_OS_VERSION IMAGE_FORMAT=ova RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH; fi
+      - if make check-for-supported-release-branch IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=ova RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH && make check-for-release-branch-skip -C $PROJECT_PATH; then make binaries -C $CLI_FOLDER && make release IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=ova RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH; fi

--- a/projects/kubernetes-sigs/image-builder/buildspecs/raw.yml
+++ b/projects/kubernetes-sigs/image-builder/buildspecs/raw.yml
@@ -12,4 +12,4 @@ phases:
 
   build:
     commands:      
-      - if make check-for-supported-release-branch IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=raw RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH && make check-for-release-branch-skip -C $PROJECT_PATH; then make binaries -C $CLI_FOLDER && make release IMAGE_OS=$IMAGE_OS IMAGE_OS_VERSION=$IMAGE_OS_VERSION IMAGE_FORMAT=raw RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH; fi
+      - if make check-for-supported-release-branch IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=raw RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH && make check-for-release-branch-skip -C $PROJECT_PATH; then make binaries -C $CLI_FOLDER && make release IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=raw RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH; fi


### PR DESCRIPTION
This PR removes the IMAGE_OS_VERSION from image-builder buildspecs because all the individual image build projects set the IMAGE_OS_VERSION env var, but we dont set it in the staging buildspec so it causes issues. We don't need to set it in the staging buildspec since we only build Bottlerocket, which defaults to `1`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
