### PR TITLE
Allow overriding Make variables related to image OS and OS version

### DIFF
--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -79,8 +79,8 @@ SKIP_METAL_INSTANCE_TEST?=false
 # to support a no op attribution target
 TARGETS_ALLOWED_WITH_NO_RELEASE_BRANCH=binaries checksums attribution update-dependency-versions validate-dependency-versions-raw validate-dependency-versions-cloudstack
 
-IMAGE_OS_DIR=$(IMAGE_OS)/$(IMAGE_OS_VERSION)
-IMAGE_OS_WITH_VER=$(IMAGE_OS)-$(IMAGE_OS_VERSION)
+IMAGE_OS_DIR?=$(IMAGE_OS)/$(IMAGE_OS_VERSION)
+IMAGE_OS_WITH_VER?=$(IMAGE_OS)-$(IMAGE_OS_VERSION)
 
 OVA_FORMAT_EXT=ova
 RAW_FORMAT_EXT=gz


### PR DESCRIPTION
Allow overriding Make variables related to image OS and OS version so these can be read in from the environment.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
