### PR TITLE
Define Go version files for etcdadm bootstrap provider and controller

### DIFF
--- a/projects/aws/image-builder/builder/artifacts.go
+++ b/projects/aws/image-builder/builder/artifacts.go
@@ -6,8 +6,9 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	k8syaml "sigs.k8s.io/yaml"
 	"strings"
+
+	k8syaml "sigs.k8s.io/yaml"
 
 	releasev1 "github.com/aws/eks-anywhere/release/api/v1alpha1"
 	eksDreleasev1 "github.com/aws/eks-distro-build-tooling/release/api/v1alpha1"

--- a/projects/aws/image-builder/builder/builder.go
+++ b/projects/aws/image-builder/builder/builder.go
@@ -80,7 +80,7 @@ func (b *BuildOptions) BuildImage() {
 		b.FilesConfig.FilesAnsibleConfig.CustomRoleNames = additionalFilesCustomRole
 		b.FilesConfig.FilesAnsibleConfig.AnsibleExtraVars = fmt.Sprintf("@%s", additionalFilesList)
 
-		log.Println("Marshaling files ansible config to JSON")
+		log.Println("Marshalling files ansible config to JSON")
 		filesAnsibleConfig, err := json.Marshal(b.FilesConfig.FilesAnsibleConfig)
 		if err != nil {
 			log.Fatalf("Error marshalling files ansible config data: %v", err)
@@ -93,7 +93,7 @@ func (b *BuildOptions) BuildImage() {
 			log.Fatalf("Error writing additional files config file to Packer config directory: %v", err)
 		}
 
-		log.Println("Marshaling additional files list to YAML")
+		log.Println("Marshalling additional files list to YAML")
 		if b.AMIConfig != nil {
 			for index, file := range b.FilesConfig.AdditionalFilesList {
 				for _, defaultFile := range DefaultAMIAdditionalFiles {

--- a/projects/aws/image-builder/builder/utils.go
+++ b/projects/aws/image-builder/builder/utils.go
@@ -168,7 +168,7 @@ func downloadFile(path, url string) error {
 	// Create the leading directories if it doesnt exists
 	dirs := filepath.Dir(path)
 	if _, err := os.Stat(dirs); os.IsNotExist(err) {
-		os.MkdirAll(dirs, 0755)
+		os.MkdirAll(dirs, 0o755)
 	}
 
 	// Create the file

--- a/projects/aws/image-builder/builder/utils_test.go
+++ b/projects/aws/image-builder/builder/utils_test.go
@@ -114,7 +114,7 @@ func TestDownloadFile(t *testing.T) {
 		t.Fatalf("Error getting current working dir: %v", err)
 	}
 	testDir := filepath.Join(cwd, "testdata")
-	os.MkdirAll(testDir, 0755)
+	os.MkdirAll(testDir, 0o755)
 	testcases := []struct {
 		name    string
 		path    string

--- a/projects/aws/image-builder/cmd/downloadartifacts.go
+++ b/projects/aws/image-builder/cmd/downloadartifacts.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"log"
+
+	"github.com/spf13/cobra"
 )
 
 var downloadArtifactsCmd = &cobra.Command{

--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -186,6 +186,14 @@ var (
 
 	// ProjectGoVersionSourceOfTruth is the mapping of project name to Go version source of truth files configuration.
 	ProjectGoVersionSourceOfTruth = map[string]types.GoVersionSourceOfTruth{
+		"aws/etcdadm-bootstrap-provider": {
+			SourceOfTruthFile:     "go.mod",
+			GoVersionSearchString: `go (1\.\d\d)`,
+		},
+		"aws/etcdadm-controller": {
+			SourceOfTruthFile:     "go.mod",
+			GoVersionSearchString: `go (1\.\d\d)`,
+		},
 		"brancz/kube-rbac-proxy": {
 			SourceOfTruthFile:     ".github/workflows/build.yml",
 			GoVersionSearchString: `go-version: '(1\.\d\d)\.\d+'`,


### PR DESCRIPTION
This PR defines the Go version source-of-truth files for the `aws/etcdadm-bootstrap-provider` and `aws/etcdadm-controller` repos so Go version bumps can be automated.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
