### PR TITLE
Extract only the Go binary from GitHub release tarball

### DIFF
--- a/tools/version-tracker/pkg/ecrpublic/ecrpublic.go
+++ b/tools/version-tracker/pkg/ecrpublic/ecrpublic.go
@@ -1,11 +1,10 @@
 package ecrpublic
 
 import (
+	"encoding/json"
 	"fmt"
 	"os/exec"
 	"strings"
-	//"regexp"
-	"encoding/json"
 
 	"github.com/aws/eks-anywhere/pkg/semver"
 

--- a/tools/version-tracker/pkg/github/github.go
+++ b/tools/version-tracker/pkg/github/github.go
@@ -298,22 +298,22 @@ func GetGoVersionForLatestRevision(client *github.Client, org, repo, latestRevis
 			return "", fmt.Errorf("downloading release tarball from URL [%s]: %v", tarballUrl, err)
 		}
 
+		binaryName := projectReleaseAsset.BinaryName
+		if strings.Count(binaryName, "%s") > 0 {
+			binaryName = fmt.Sprintf(binaryName, assetVersionReplacement)
+		}
 		if projectReleaseAsset.Extract {
 			tarballFile, err := os.Open(tarballFilePath)
 			if err != nil {
 				return "", fmt.Errorf("opening tarball filepath: %v", err)
 			}
 
-			err = tar.ExtractTarGz(tarballDownloadPath, tarballFile)
+			err = tar.ExtractFileFromTarball(tarballDownloadPath, tarballFile, binaryName)
 			if err != nil {
 				return "", fmt.Errorf("extracting tarball file: %v", err)
 			}
 		}
 
-		binaryName := projectReleaseAsset.BinaryName
-		if strings.Count(binaryName, "%s") > 0 {
-			binaryName = fmt.Sprintf(binaryName, assetVersionReplacement)
-		}
 		binaryFilePath := filepath.Join(tarballDownloadPath, binaryName)
 		goVersion, err = version.GetGoVersion(binaryFilePath)
 		if err != nil {


### PR DESCRIPTION
We only require the Go binary to check the Go version information, so we can skip extracting all other files in the GitHub release tarball.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
