### PR TITLE
Attempt to apply patches and generate checksums/attribution if successful

### DIFF
--- a/tools/version-tracker/pkg/commands/display/display.go
+++ b/tools/version-tracker/pkg/commands/display/display.go
@@ -31,9 +31,15 @@ func Run(displayOptions *types.DisplayOptions) error {
 		return fmt.Errorf("retrieving current working directory: %v", err)
 	}
 
+	// Get base repository owner environment variable if set.
+	baseRepoOwner := os.Getenv(constants.BaseRepoOwnerEnvvar)
+	if baseRepoOwner == "" {
+		baseRepoOwner = constants.DefaultBaseRepoOwner
+	}
+
 	// Clone the eks-anywhere-build-tooling repository.
 	buildToolingRepoPath := filepath.Join(cwd, constants.BuildToolingRepoName)
-	_, _, err = git.CloneRepo(fmt.Sprintf(constants.BuildToolingRepoURL, constants.DefaultBaseRepoOwner), buildToolingRepoPath, "")
+	_, _, err = git.CloneRepo(fmt.Sprintf(constants.BuildToolingRepoURL, baseRepoOwner), buildToolingRepoPath, "")
 	if err != nil {
 		return fmt.Errorf("cloning build-tooling repo: %v", err)
 	}

--- a/tools/version-tracker/pkg/commands/listprojects/listprojects.go
+++ b/tools/version-tracker/pkg/commands/listprojects/listprojects.go
@@ -21,9 +21,15 @@ func Run() error {
 		return fmt.Errorf("retrieving current working directory: %v", err)
 	}
 
+	// Get base repository owner environment variable if set.
+	baseRepoOwner := os.Getenv(constants.BaseRepoOwnerEnvvar)
+	if baseRepoOwner == "" {
+		baseRepoOwner = constants.DefaultBaseRepoOwner
+	}
+
 	// Clone the eks-anywhere-build-tooling repository.
 	buildToolingRepoPath := filepath.Join(cwd, constants.BuildToolingRepoName)
-	_, _, err = git.CloneRepo(fmt.Sprintf(constants.BuildToolingRepoURL, constants.DefaultBaseRepoOwner), buildToolingRepoPath, "")
+	_, _, err = git.CloneRepo(fmt.Sprintf(constants.BuildToolingRepoURL, baseRepoOwner), buildToolingRepoPath, "")
 	if err != nil {
 		return fmt.Errorf("cloning build-tooling repo: %v", err)
 	}

--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -30,6 +30,9 @@ const (
 	ChecksumsFile                           = "CHECKSUMS"
 	AttributionsFilePattern                 = "*ATTRIBUTION.txt"
 	PatchesDirectory                        = "patches"
+	FailedPatchApplyMarker                  = "patch does not apply"
+	FailedPatchApplyRegex                   = "Patch failed at .*"
+	FailedPatchFilesRegex                   = "error: (.*): patch does not apply"
 	BottlerocketReleasesFile                = "BOTTLEROCKET_RELEASES"
 	BottlerocketContainerMetadataFileFormat = "BOTTLEROCKET_%s_CONTAINER_METADATA"
 	BottlerocketHostContainersTOMLFile      = "sources/models/shared-defaults/public-host-containers.toml"
@@ -76,6 +79,12 @@ By submitting this pull request, I confirm that you can use, modify, copy, and r
 
 By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.`
 	PatchesCommentBody = `# This pull request is incomplete!
+## Failed patch details
+**Only %s/%d patches were applied!**
+%s
+The following files in the above patch did not apply successfully:
+%s
+
 The project being upgraded in this pull request needs changes to patches that cannot be handled automatically. A developer will need to regenerate the patches locally and update the pull request. In addition to patches, the checksums and attribution file(s) corresponding to the project will need to be updated.`
 )
 


### PR DESCRIPTION
Whenever the project upgrader encounters a project that has patches, it doesn't try to apply them because it could lead to conflicts with the new Git tag. So it just updates the Git tag, Go version and README files for the project and opens a PR with only these changes, which it then marks as an incomplete PR because patches, attribution and checksums need to be updated. 

However, sometimes patches do get cleanly applied across Git tags, especially if they're smaller patches. This PR adds the logic to always apply patches and decide the flow based on the outcome of the patch application. If patches were successfully applied, it proceeds with the generation of attribution and checksums and includes them in the PR, else it does what it does today, i.e., an incomplete PR with a warning, but with additional information about the patch that failed, and the files in the patch that did not apply correctly.

Example: https://github.com/abhay-krishna/eks-anywhere-build-tooling/pull/57

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
