### PR TITLE
Always delete the Packer builder VM at the end of the build

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
@@ -1,16 +1,18 @@
-From df0fd823551a8daea918118f26dac217f1f2d4da Mon Sep 17 00:00:00 2001
+From 769673a5f47de94093308675d846f4462577317a Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:05:13 -0800
 Subject: [PATCH 01/10] OVA improvements
 
 - Create /etc/pki/tls/certs dir as part of image-builds
 - Tweak Product info in OVF
+- Delete the VM after the build is complete
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---
  images/capi/ansible/roles/sysprep/tasks/main.yml |  9 +++++++++
  images/capi/hack/ovf_template.xml                | 10 ++--------
- 2 files changed, 11 insertions(+), 8 deletions(-)
+ images/capi/packer/ova/packer-node.json          |  2 +-
+ 3 files changed, 12 insertions(+), 9 deletions(-)
 
 diff --git a/images/capi/ansible/roles/sysprep/tasks/main.yml b/images/capi/ansible/roles/sysprep/tasks/main.yml
 index a9fa954d5..a526528ea 100644
@@ -58,6 +60,19 @@ index 316427ec3..ca23db5f9 100644
        <Category>Cluster API Provider (CAPI)</Category>
        <Property ovf:userConfigurable="false" ovf:value="${BUILD_TIMESTAMP}" ovf:type="string" ovf:key="BUILD_TIMESTAMP"/>
        <Property ovf:userConfigurable="false" ovf:value="${BUILD_DATE}" ovf:type="string" ovf:key="BUILD_DATE"/>
+diff --git a/images/capi/packer/ova/packer-node.json b/images/capi/packer/ova/packer-node.json
+index 1b7b2d13d..7b5ef1369 100644
+--- a/images/capi/packer/ova/packer-node.json
++++ b/images/capi/packer/ova/packer-node.json
+@@ -474,7 +474,7 @@
+     "crictl_url": "https://github.com/kubernetes-sigs/cri-tools/releases/download/v{{user `crictl_version`}}/crictl-v{{user `crictl_version`}}-linux-amd64.tar.gz",
+     "crictl_version": null,
+     "datastore": "",
+-    "destroy": "false",
++    "destroy": "true",
+     "disk_size": "20480",
+     "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
+     "export_manifest": "none",
 -- 
 2.39.3 (Apple Git-146)
 


### PR DESCRIPTION
In our content library patch, we had explicitly set the nested `destroy` field in the content library configuration section to `"true"`, so Packer builder VMs were getting deleted when the build finishes. When we removed the patch in #2988, the build fell back to image-builder's default behavior of leaving around VMs. In this PR, I am patching image-builder so we get the old behavior back.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
