### PR TITLE
Fix kubeversion formatting in EKSD_LATEST_RELEASES

### DIFF
--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -22,22 +22,17 @@ releases:
   kubeVersion: v1.24.17
   number: 33
 - branch: 1-25
-  kubeVersion: |
-    v1.25.16
+  kubeVersion: v1.25.16
   number: 34
 - branch: 1-26
-  kubeVersion: |
-    v1.26.13
+  kubeVersion: v1.26.13
   number: 30
 - branch: 1-27
-  kubeVersion: |
-    v1.27.10
+  kubeVersion: v1.27.10
   number: 24
 - branch: 1-28
-  kubeVersion: |
-    v1.28.6
+  kubeVersion: v1.28.6
   number: 17
 - branch: 1-29
-  kubeVersion: |
-    v1.29.1
+  kubeVersion: v1.29.1
   number: 6


### PR DESCRIPTION
Fix kubeversion formatting in EKSD_LATEST_RELEASES file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
