### PR TITLE
Remove newlines from kubeVersion field

### DIFF
--- a/tools/version-tracker/pkg/commands/upgrade/upgrade.go
+++ b/tools/version-tracker/pkg/commands/upgrade/upgrade.go
@@ -452,7 +452,9 @@ func getLatestEKSDistroRelease(client *gogithub.Client, branch string) (int, str
 		return 0, "", fmt.Errorf("error converting release number to integer: %v", err)
 	}
 
-	return releaseNumberInt, string(kubeVersion), nil
+	kubeVersionTrimmed := strings.TrimRight(string(kubeVersion), "\n")
+
+	return releaseNumberInt, kubeVersionTrimmed, nil
 }
 
 // updateProjectVersionFile updates the version information stored in a specific file.

--- a/tools/version-tracker/pkg/github/github.go
+++ b/tools/version-tracker/pkg/github/github.go
@@ -359,6 +359,12 @@ func CreatePullRequest(client *github.Client, org, repo, title, body, baseRepoOw
 		pullRequest = pullRequests[0]
 		logger.Info(fmt.Sprintf("A pull request already exists for %s:%s\n", headRepoOwner, headBranch), "Pull request", *pullRequest.HTMLURL)
 
+		pullRequest.Body = github.String(body)
+		pullRequest, _, err = client.PullRequests.Edit(context.Background(), baseRepoOwner, constants.BuildToolingRepoName, *pullRequest.Number, pullRequest)
+		if err != nil {
+			return fmt.Errorf("editing existing pull request %s: %v", pullRequest.HTMLURL, err)
+		}
+
 		// If patches to the project failed to apply, check if the PR already has a comment warning about
 		// the incomplete PR and patches needing to be regenerated.
 		if !patchApplySucceeded {
@@ -381,7 +387,6 @@ func CreatePullRequest(client *github.Client, org, repo, title, body, baseRepoOw
 			Body:                github.String(body),
 			MaintainerCanModify: github.Bool(true),
 		}
-
 		pullRequest, _, err = client.PullRequests.Create(context.Background(), baseRepoOwner, constants.BuildToolingRepoName, newPR)
 		if err != nil {
 			return fmt.Errorf("creating pull request with updated versions from %s to %s: %v", headBranch, baseBranch, err)


### PR DESCRIPTION
The Kubernetes tag file on GitHub has a trailing newline, so we need to remove it before putting it in the EKS-D latest releases file. Also added logic to update the PR description on an existing PR, in case a new version gets released again when the PR is still open.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
