### PR TITLE
Backporting EKS-D release versions for release v0.19.1

### DIFF
--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -1,38 +1,38 @@
+latest: 1-25
 releases:
 - branch: 1-18
-  number: 17
   kubeVersion: v1.18.20
+  number: 17
 - branch: 1-19
-  number: 22
   kubeVersion: v1.19.16
-- branch: 1-20
   number: 22
+- branch: 1-20
   kubeVersion: v1.20.15
+  number: 22
 - branch: 1-21
-  number: 26
   kubeVersion: v1.21.14
+  number: 26
 - branch: 1-22
-  number: 28
   kubeVersion: v1.22.17
+  number: 28
 - branch: 1-23
-  number: 32
   kubeVersion: v1.23.17
+  number: 32
 - branch: 1-24
-  number: 33
   kubeVersion: v1.24.17
-- branch: 1-25
   number: 33
+- branch: 1-25
   kubeVersion: v1.25.16
+  number: 34
 - branch: 1-26
-  number: 29
   kubeVersion: v1.26.13
+  number: 30
 - branch: 1-27
-  number: 23
   kubeVersion: v1.27.10
+  number: 24
 - branch: 1-28
-  number: 16
   kubeVersion: v1.28.6
+  number: 17
 - branch: 1-29
-  number: 5
   kubeVersion: v1.29.1
-latest: 1-25
+  number: 6


### PR DESCRIPTION
*Description of changes:*
Backporting EKS-D release versions for release v0.19.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
