### PR TITLE
Fix checksums and attribution generation during upgrade

### DIFF
--- a/tools/version-tracker/pkg/github/github.go
+++ b/tools/version-tracker/pkg/github/github.go
@@ -348,7 +348,7 @@ func CreatePullRequest(client *github.Client, org, repo, title, body, baseRepoOw
 
 	// Check if there is already a pull request from the head branch to the base branch.
 	pullRequests, _, err := client.PullRequests.List(context.Background(), baseRepoOwner, constants.BuildToolingRepoName, &github.PullRequestListOptions{
-		Base: fmt.Sprintf("%s:%s", baseRepoOwner, baseBranch),
+		Base: baseBranch,
 		Head: fmt.Sprintf("%s:%s", headRepoOwner, headBranch),
 	})
 	if err != nil {


### PR DESCRIPTION
The checksums and attribution generation was under the incorrect `if` block, which caused it to get executed only for projects with patches. This PR fixes the conditions to get the desired upgrade flow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
