### PR TITLE
Place RHEL kickstart files for raw builds in `http` directory

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
@@ -1,4 +1,4 @@
-From 5f1383433d868718bb8c8ba35901a208095e55cd Mon Sep 17 00:00:00 2001
+From 22145b800be457fc0afc11e59771df7be186c6e3 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:05:13 -0800
 Subject: [PATCH 01/10] OVA improvements

--- a/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
@@ -1,4 +1,4 @@
-From 982208f029211d74bf3b1f3dfe358d718fad032a Mon Sep 17 00:00:00 2001
+From 6d3d1e6357299d9fac826536cd72207e4211c553 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 18:36:56 -0800
 Subject: [PATCH 02/10] EKS-D support and changes

--- a/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
@@ -1,4 +1,4 @@
-From 5fe6946f056ce99f9d9288fc18a46ab6a04fd569 Mon Sep 17 00:00:00 2001
+From 655d35d5007e3bc240e246d3cbf7fc51a70b0fb8 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Feb 2023 01:39:15 -0800
 Subject: [PATCH 03/10] Snow AMI support

--- a/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22-support-and-improvements.patch
@@ -1,4 +1,4 @@
-From 3845b201d6632b2642ab2390bc028635a864409f Mon Sep 17 00:00:00 2001
+From 746c48c1ca4bffb049c456df1d88681c15d1b3e7 Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Fri, 23 Jun 2023 10:50:08 -0500
 Subject: [PATCH 04/10] Ubuntu 22 support and improvements

--- a/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
@@ -1,4 +1,4 @@
-From 1ba45327727803fc3671c6aa8fc5de6e3db64dbe Mon Sep 17 00:00:00 2001
+From 4332a320c8c371644c2d5490f58afe3580242c0a Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 6 Dec 2022 15:42:02 -0600
 Subject: [PATCH 05/10] RHEL support and improvements
@@ -11,6 +11,7 @@ Subject: [PATCH 05/10] RHEL support and improvements
 - Remove old kernels
 - Add dracut cmd to generate initramfs with all drivers for rhel raw
 - Add proxy, register with satellite, and pull packages from satellite support to redhat subscription manager
+- Place RHEL kickstart files for raw builds in `http` directory
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---
@@ -20,9 +21,17 @@ Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
  .../ansible/roles/providers/tasks/main.yml    | 15 ++++
  .../capi/ansible/roles/setup/tasks/redhat.yml | 84 +++++++++++++++++++
  images/capi/packer/config/ansible-args.json   |  2 +-
- 6 files changed, 137 insertions(+), 1 deletion(-)
+ .../packer/raw/linux/rhel/{ => http}/7/ks.cfg |  0
+ .../packer/raw/linux/rhel/{ => http}/8/ks.cfg |  0
+ .../raw/linux/rhel/{ => http}/9/ks-efi.cfg    |  0
+ .../packer/raw/linux/rhel/{ => http}/9/ks.cfg |  0
+ 10 files changed, 137 insertions(+), 1 deletion(-)
  create mode 100644 images/capi/ansible/roles/node/tasks/redhat.yml
  create mode 100644 images/capi/ansible/roles/providers/files/etc/systemd/system/cloud-init.service.d/boot-order.conf
+ rename images/capi/packer/raw/linux/rhel/{ => http}/7/ks.cfg (100%)
+ rename images/capi/packer/raw/linux/rhel/{ => http}/8/ks.cfg (100%)
+ rename images/capi/packer/raw/linux/rhel/{ => http}/9/ks-efi.cfg (100%)
+ rename images/capi/packer/raw/linux/rhel/{ => http}/9/ks.cfg (100%)
 
 diff --git a/images/capi/ansible/roles/node/tasks/main.yml b/images/capi/ansible/roles/node/tasks/main.yml
 index 484556b17..78da9fc30 100644
@@ -229,6 +238,22 @@ index d7e50f852..22225c7d3 100644
 +  "ansible_common_vars": "containerd_url={{user `containerd_url`}} containerd_sha256={{user `containerd_sha256`}} pause_image={{user `pause_image`}} containerd_additional_settings={{user `containerd_additional_settings`}} containerd_cri_socket={{user `containerd_cri_socket`}} containerd_version={{user `containerd_version`}} containerd_wasm_shims_url={{user `containerd_wasm_shims_url`}} containerd_wasm_shims_version={{user `containerd_wasm_shims_version`}} containerd_wasm_shims_sha256={{user `containerd_wasm_shims_sha256`}} containerd_wasm_shims_runtimes=\"{{user `containerd_wasm_shims_runtimes`}}\" containerd_wasm_shims_runtime_versions=\"{{user `containerd_wasm_shims_runtime_versions`}}\" crictl_url={{user `crictl_url`}} crictl_sha256={{user `crictl_sha256`}} crictl_source_type={{user `crictl_source_type`}} custom_role_names=\"{{user `custom_role_names`}}\" firstboot_custom_roles_pre=\"{{user `firstboot_custom_roles_pre`}}\" firstboot_custom_roles_post=\"{{user `firstboot_custom_roles_post`}}\" node_custom_roles_pre=\"{{user `node_custom_roles_pre`}}\" node_custom_roles_post=\"{{user `node_custom_roles_post`}}\" disable_public_repos={{user `disable_public_repos`}} extra_debs=\"{{user `extra_debs`}}\" extra_repos=\"{{user `extra_repos`}}\" extra_rpms=\"{{user `extra_rpms`}}\" http_proxy={{user `http_proxy`}} https_proxy={{user `https_proxy`}} kubeadm_template={{user `kubeadm_template`}} kubernetes_apiserver_port={{user `kubernetes_apiserver_port`}} kubernetes_cni_http_source={{user `kubernetes_cni_http_source`}} kubernetes_cni_http_checksum={{user `kubernetes_cni_http_checksum`}} kubernetes_goarch={{user `kubernetes_goarch`}} kubernetes_http_source={{user `kubernetes_http_source`}} kubernetes_container_registry={{user `kubernetes_container_registry`}} kubernetes_rpm_repo={{user `kubernetes_rpm_repo`}} kubernetes_rpm_gpg_key={{user `kubernetes_rpm_gpg_key`}} kubernetes_rpm_gpg_check={{user `kubernetes_rpm_gpg_check`}} kubernetes_deb_repo={{user `kubernetes_deb_repo`}} kubernetes_deb_gpg_key={{user `kubernetes_deb_gpg_key`}} kubernetes_cni_deb_version={{user `kubernetes_cni_deb_version`}} kubernetes_cni_rpm_version={{user `kubernetes_cni_rpm_version`}} kubernetes_cni_semver={{user `kubernetes_cni_semver`}} kubernetes_cni_source_type={{user `kubernetes_cni_source_type`}} kubernetes_semver={{user `kubernetes_semver`}} kubernetes_source_type={{user `kubernetes_source_type`}} kubernetes_load_additional_imgs={{user `kubernetes_load_additional_imgs`}} kubernetes_deb_version={{user `kubernetes_deb_version`}} kubernetes_rpm_version={{user `kubernetes_rpm_version`}} no_proxy={{user `no_proxy`}} pip_conf_file={{user `pip_conf_file`}} python_path={{user `python_path`}} redhat_epel_rpm={{user `redhat_epel_rpm`}} epel_rpm_gpg_key={{user `epel_rpm_gpg_key`}} reenable_public_repos={{user `reenable_public_repos`}} remove_extra_repos={{user `remove_extra_repos`}} systemd_prefix={{user `systemd_prefix`}} sysusr_prefix={{user `sysusr_prefix`}} sysusrlocal_prefix={{user `sysusrlocal_prefix`}} load_additional_components={{ user `load_additional_components`}} additional_registry_images={{ user `additional_registry_images`}} additional_registry_images_list={{ user `additional_registry_images_list`}} additional_url_images={{ user `additional_url_images`}} additional_url_images_list={{ user `additional_url_images_list`}} additional_executables={{ user `additional_executables`}} additional_executables_list={{ user `additional_executables_list`}} additional_executables_destination_path={{ user `additional_executables_destination_path`}} additional_s3={{ user `additional_s3`}} build_target={{ user `build_target`}} amazon_ssm_agent_rpm={{ user `amazon_ssm_agent_rpm` }} enable_containerd_audit={{ user `enable_containerd_audit` }} kubernetes_enable_automatic_resource_sizing={{ user `kubernetes_enable_automatic_resource_sizing` }} etcd_http_source={{user `etcd_http_source`}} etcd_version={{user `etcd_version`}} etcdadm_http_source={{user `etcdadm_http_source`}} etcd_sha256={{user `etcd_sha256`}} etcdadm_version={{user `etcdadm_version`}} rhsm_server_hostname={{ user `rhsm_server_hostname` }} rhsm_server_release_version={{ user `rhsm_server_release_version` }} rhsm_server_proxy_hostname={{ user `rhsm_server_proxy_hostname` }} rhsm_server_proxy_port={{ user `rhsm_server_proxy_port` }}",
    "ansible_scp_extra_args": "{{env `ANSIBLE_SCP_EXTRA_ARGS`}}"
  }
+diff --git a/images/capi/packer/raw/linux/rhel/7/ks.cfg b/images/capi/packer/raw/linux/rhel/http/7/ks.cfg
+similarity index 100%
+rename from images/capi/packer/raw/linux/rhel/7/ks.cfg
+rename to images/capi/packer/raw/linux/rhel/http/7/ks.cfg
+diff --git a/images/capi/packer/raw/linux/rhel/8/ks.cfg b/images/capi/packer/raw/linux/rhel/http/8/ks.cfg
+similarity index 100%
+rename from images/capi/packer/raw/linux/rhel/8/ks.cfg
+rename to images/capi/packer/raw/linux/rhel/http/8/ks.cfg
+diff --git a/images/capi/packer/raw/linux/rhel/9/ks-efi.cfg b/images/capi/packer/raw/linux/rhel/http/9/ks-efi.cfg
+similarity index 100%
+rename from images/capi/packer/raw/linux/rhel/9/ks-efi.cfg
+rename to images/capi/packer/raw/linux/rhel/http/9/ks-efi.cfg
+diff --git a/images/capi/packer/raw/linux/rhel/9/ks.cfg b/images/capi/packer/raw/linux/rhel/http/9/ks.cfg
+similarity index 100%
+rename from images/capi/packer/raw/linux/rhel/9/ks.cfg
+rename to images/capi/packer/raw/linux/rhel/http/9/ks.cfg
 -- 
 2.39.3 (Apple Git-146)
 

--- a/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-RHEL-support-for-AWS-image-builder.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-RHEL-support-for-AWS-image-builder.patch
@@ -1,4 +1,4 @@
-From e377d1169743d9b6add30647089952af7f15f454 Mon Sep 17 00:00:00 2001
+From 786c5f1fcdd347f207213c22a7e3a3f8e969cf89 Mon Sep 17 00:00:00 2001
 From: Ilya Alekseyev <ilya.alekseyev@nutanix.com>
 Date: Wed, 11 Oct 2023 22:07:22 -0400
 Subject: [PATCH 06/10] Nutanix RHEL support for AWS image-builder

--- a/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
@@ -1,4 +1,4 @@
-From 60a769679234b52bde6dca826215c408ba14677c Mon Sep 17 00:00:00 2001
+From 76412b40f37d88a3da517f0663a7b6944d4566fb Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
 Date: Mon, 21 Aug 2023 18:40:07 -0500
 Subject: [PATCH 07/10] adds retries and timeout to packer image-builder

--- a/projects/kubernetes-sigs/image-builder/patches/0008-Disable-UDP-offload-service-for-Redhat-and-Ubuntu.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0008-Disable-UDP-offload-service-for-Redhat-and-Ubuntu.patch
@@ -1,4 +1,4 @@
-From 4efa95944cf210a507bcfb36121f743ccb95cea6 Mon Sep 17 00:00:00 2001
+From 1f2b9ea6f09dd05008a697e260731021b5bca827 Mon Sep 17 00:00:00 2001
 From: Taylor Neyland <tneyla@amazon.com>
 Date: Wed, 19 Jul 2023 12:51:30 -0500
 Subject: [PATCH 08/10] Disable UDP offload service for Redhat and Ubuntu

--- a/projects/kubernetes-sigs/image-builder/patches/0009-Default-Flatcar-version-to-avoid-pulling-from-intern.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0009-Default-Flatcar-version-to-avoid-pulling-from-intern.patch
@@ -1,4 +1,4 @@
-From 1b8d2faa3ab0039e86230ff69bcc5eb877748af5 Mon Sep 17 00:00:00 2001
+From fc3bf99a4a491d9c5f6986efc51a076f823c0e75 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Wed, 20 Sep 2023 10:33:44 -0500
 Subject: [PATCH 09/10] Default Flatcar version to avoid pulling from internet

--- a/projects/kubernetes-sigs/image-builder/patches/0010-Revert-updates-to-Ubuntu-2004-ISO-URLs.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0010-Revert-updates-to-Ubuntu-2004-ISO-URLs.patch
@@ -1,4 +1,4 @@
-From d1751390adb1530c95104b886653b28d7d3fe061 Mon Sep 17 00:00:00 2001
+From fda17cb8e1ca9cd2e90450a9bdf76619b364c501 Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
 Date: Sun, 17 Mar 2024 23:51:54 -0700
 Subject: [PATCH 10/10] Revert updates to Ubuntu 2004 ISO URLs


### PR DESCRIPTION
Adding https://github.com/kubernetes-sigs/image-builder/pull/1432 as a patch until it's merged and included in a new release. Instead of adding it as a new patch, I included it in the `0005-RHEL-support-and-improvements.patch` file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
