### PR TITLE
Update ISO URL for Ubuntu 22.04 raw builds

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22-support-and-improvements.patch
@@ -1,9 +1,8 @@
-From 746c48c1ca4bffb049c456df1d88681c15d1b3e7 Mon Sep 17 00:00:00 2001
+From edd6cf8b072366a57cf205ede90db0ddca75329a Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Fri, 23 Jun 2023 10:50:08 -0500
 Subject: [PATCH 04/10] Ubuntu 22 support and improvements
 
-- uses latest ubuntu 22.04 iso
 - adds support for raw ubuntu 22.04 builds
 - Ubuntu switch to offline-install when mirrors are unavailable
 - sets OS_VERSION for goss validation on raw image builds
@@ -324,7 +323,7 @@ index 9ab9bd993..cd0ca68f3 100644
    "iso_checksum_type": "sha256",
 diff --git a/images/capi/packer/raw/raw-ubuntu-2204-efi.json b/images/capi/packer/raw/raw-ubuntu-2204-efi.json
 new file mode 100644
-index 000000000..6839cc2d0
+index 000000000..f720c91c4
 --- /dev/null
 +++ b/images/capi/packer/raw/raw-ubuntu-2204-efi.json
 @@ -0,0 +1,14 @@
@@ -336,15 +335,15 @@ index 000000000..6839cc2d0
 +  "distro_version": "22.04",
 +  "firmware": "OVMF.fd",
 +  "guest_os_type": "ubuntu-64",
-+  "iso_checksum": "5e38b55d57d94ff029719342357325ed3bda38fa80054f9330dc789cd2d43931",
++  "iso_checksum": "a4acfda10b18da50e2ec50ccaf860d7f20b389df8765611142305c0e911d16fd",
 +  "iso_checksum_type": "sha256",
-+  "iso_url": "https://old-releases.ubuntu.com/releases/jammy/ubuntu-22.04.2-live-server-amd64.iso",
++  "iso_url": "https://old-releases.ubuntu.com/releases/22.04/ubuntu-22.04.3-live-server-amd64.iso",
 +  "os_display_name": "Ubuntu 22.04",
 +  "shutdown_command": "shutdown -P now"
 +  }
 diff --git a/images/capi/packer/raw/raw-ubuntu-2204.json b/images/capi/packer/raw/raw-ubuntu-2204.json
 new file mode 100644
-index 000000000..c9cfe7381
+index 000000000..19d571e97
 --- /dev/null
 +++ b/images/capi/packer/raw/raw-ubuntu-2204.json
 @@ -0,0 +1,13 @@
@@ -355,9 +354,9 @@ index 000000000..c9cfe7381
 +  "distro_name": "ubuntu",
 +  "distro_version": "22.04",
 +  "guest_os_type": "ubuntu-64",
-+  "iso_checksum": "5e38b55d57d94ff029719342357325ed3bda38fa80054f9330dc789cd2d43931",
++  "iso_checksum": "a4acfda10b18da50e2ec50ccaf860d7f20b389df8765611142305c0e911d16fd",
 +  "iso_checksum_type": "sha256",
-+  "iso_url": "https://old-releases.ubuntu.com/releases/jammy/ubuntu-22.04.2-live-server-amd64.iso",
++  "iso_url": "https://old-releases.ubuntu.com/releases/22.04/ubuntu-22.04.3-live-server-amd64.iso",
 +  "os_display_name": "Ubuntu 22.04",
 +  "shutdown_command": "shutdown -P now"
 +  }


### PR DESCRIPTION
Updating Ubuntu 22.04 ISO URL for raw builds to latest. This aligns it with the OVA builds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
