### PR TITLE
Bump EKS-D releases to latest

### DIFF
--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -23,16 +23,16 @@ releases:
   number: 33
 - branch: 1-25
   kubeVersion: v1.25.16
-  number: 34
+  number: 35
 - branch: 1-26
-  kubeVersion: v1.26.13
-  number: 30
+  kubeVersion: v1.26.14
+  number: 31
 - branch: 1-27
-  kubeVersion: v1.27.10
-  number: 24
+  kubeVersion: v1.27.11
+  number: 25
 - branch: 1-28
-  kubeVersion: v1.28.6
-  number: 17
+  kubeVersion: v1.28.7
+  number: 18
 - branch: 1-29
   kubeVersion: v1.29.1
-  number: 6
+  number: 7


### PR DESCRIPTION
Backporting #3020 to release-0.19 branch.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
