### PR TITLE
Add patch for insecure proxy support for helm

### DIFF
--- a/projects/helm/helm/CHECKSUMS
+++ b/projects/helm/helm/CHECKSUMS
@@ -1,2 +1,2 @@
-20927c86b3fd83e65ebb83bcc849e5037f2f4ac64cf0047b70731416a0224713  _output/bin/helm/linux-amd64/helm
-af6707bc4273a6237d5f7532ed9a960fc91204369aa30499d23903a8d420d284  _output/bin/helm/linux-arm64/helm
+6fcb38a6aaaf27492693db5bcf6aefe733931dfb62d4b4bf7878da1768eeb440  _output/bin/helm/linux-amd64/helm
+ce894fb35526d1566fa5361c50dbc981c86f38facd1fe73c5646b5a5090b69aa  _output/bin/helm/linux-arm64/helm

--- a/projects/helm/helm/patches/0001-bug-add-proxy-support-for-oci-getter.patch
+++ b/projects/helm/helm/patches/0001-bug-add-proxy-support-for-oci-getter.patch
@@ -1,0 +1,27 @@
+From 94c1deae6d5a43491c5a4e8444ecd8273a8122a1 Mon Sep 17 00:00:00 2001
+From: Ricardo Maraschini <ricardo.maraschini@gmail.com>
+Date: Wed, 31 Jan 2024 12:48:22 +0100
+Subject: [PATCH 1/2] bug: add proxy support for oci getter
+
+adds missing proxy support on oci chart getter.
+
+Signed-off-by: Ricardo Maraschini <ricardo.maraschini@gmail.com>
+---
+ pkg/getter/ocigetter.go | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/pkg/getter/ocigetter.go b/pkg/getter/ocigetter.go
+index 209786bd..0547cdcb 100644
+--- a/pkg/getter/ocigetter.go
++++ b/pkg/getter/ocigetter.go
+@@ -119,6 +119,7 @@ func (g *OCIGetter) newRegistryClient() (*registry.Client, error) {
+ 			IdleConnTimeout:       90 * time.Second,
+ 			TLSHandshakeTimeout:   10 * time.Second,
+ 			ExpectContinueTimeout: 1 * time.Second,
++			Proxy:                 http.ProxyFromEnvironment,
+ 		}
+ 	})
+ 
+-- 
+2.40.0
+

--- a/projects/helm/helm/patches/0002-Set-proxy-in-registry-client.patch
+++ b/projects/helm/helm/patches/0002-Set-proxy-in-registry-client.patch
@@ -1,0 +1,25 @@
+From 7c2e46274a80f39f5886c9ec3385758e18180764 Mon Sep 17 00:00:00 2001
+From: Ahree Hong <ahreeh@amazon.com>
+Date: Fri, 29 Mar 2024 18:34:15 -0700
+Subject: [PATCH 2/2] Set proxy in registry client
+
+Signed-off-by: Ahree Hong <ahreeh@amazon.com>
+---
+ pkg/registry/util.go | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/pkg/registry/util.go b/pkg/registry/util.go
+index 8baf0852..2b0dab0c 100644
+--- a/pkg/registry/util.go
++++ b/pkg/registry/util.go
+@@ -156,6 +156,7 @@ func NewRegistryClientWithTLS(out io.Writer, certFile, keyFile, caFile string, i
+ 		ClientOptHTTPClient(&http.Client{
+ 			Transport: &http.Transport{
+ 				TLSClientConfig: tlsConf,
++				Proxy:           http.ProxyFromEnvironment,
+ 			},
+ 		}),
+ 	)
+-- 
+2.40.0
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We removed our patches adding support for the flag --insecure-skip-tls-verify, as the functionality had been added to upstream helm. However, upstream has a bug when using proxy with the --insecure-skip-tls-verify flag so the helm commands fails.

This PR adds a patch to fix this bug

*Testing*
Manually ran helm commands with the `--insecure-skip-tls-verify` flag with proxy and verified the commands work.
Built EKS-A controller to use the patched helm and verified cluster creation worked.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
