### PR TITLE
Fix codebuild buildspec for raw builds

### DIFF
--- a/projects/kubernetes-sigs/image-builder/buildspecs/raw.yml
+++ b/projects/kubernetes-sigs/image-builder/buildspecs/raw.yml
@@ -12,4 +12,4 @@ phases:
 
   build:
     commands:      
-      - if make check-for-supported-release-branch IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=raw RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH && make check-for-release-branch-skip -C $PROJECT_PATH; then make binaries -C $CLI_FOLDER && make release IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=raw RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH; fi
+      - if make check-for-supported-release-branch IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=raw RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH && make check-for-release-branch-skip -C $PROJECT_PATH; then make binaries -C $CLI_FOLDER && make release IMAGE_OS=$IMAGE_OS IMAGE_OS_VERSION=$IMAGE_OS_VERSION IMAGE_FORMAT=raw RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH; fi


### PR DESCRIPTION
*Description of changes:*
`IMAGE_OS_VERSION` was not getting set for raw builds during CI runs, which led to builds defaulting to one OS version all the time. This fixes by setting the proper env vars.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
