### PR TITLE
Fix attribution and checksum generation for successful patch application

### DIFF
--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -80,7 +80,7 @@ By submitting this pull request, I confirm that you can use, modify, copy, and r
 By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.`
 	PatchesCommentBody = `# This pull request is incomplete!
 ## Failed patch details
-**Only %s/%d patches were applied!**
+**Only %d/%d patches were applied!**
 %s
 The following files in the above patch did not apply successfully:
 %s


### PR DESCRIPTION
This PR fixes the logic for deciding if the patch application was successful.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
