### PR TITLE
Use Go 1.22 to build version tracker binary

### DIFF
--- a/tools/version-tracker/Makefile
+++ b/tools/version-tracker/Makefile
@@ -1,6 +1,11 @@
+SHELL := bash
+.SHELLFLAGS:=-eux -o pipefail -c
+BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
+
 BINARY_NAME?=version-tracker
 BINARY_PATH?=bin/$(BINARY_NAME)
-GO?=$(shell which go)
+GOLANG_VERSION=1.22
+GO ?= $(shell source $(BASE_DIRECTORY)/build/lib/common.sh && build::common::get_go_path $(GOLANG_VERSION))/go
 DRY_RUN?=false
 VERBOSITY?=0
 


### PR DESCRIPTION
Use Go 1.22 to build version tracker binary since that's the Go version specified in the `go.mod` file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
