### PR TITLE
Improve build fail remediation logic to factor in newer docker versions

### DIFF
--- a/build/lib/buildkit.sh
+++ b/build/lib/buildkit.sh
@@ -128,7 +128,7 @@ else
             echo "Ensure container registry and repository exists!!"
             echo "Try running make create-ecr-repos to create ecr repositories in your aws account."
             echo "******************************************************"
-        elif [ "$CMD" = "docker buildx" ] && grep -i -q "\(multiple platforms\|OCI exporter\) feature is currently not supported" $log_file; then
+        elif [ "$CMD" = "docker buildx" ] && grep -i -q "\(multiple platforms\|OCI exporter\|Multi-platform\)" $log_file; then
             echo "******************************************************"
             echo "When using docker buildx with multiple platforms you can not use the default builder."
             echo "You need to create another builder using the docker-container or remote driver."


### PR DESCRIPTION
*Issue #, if available:*

The current remediation logic greps for a hardcoded string from the error received from `docker buildx` command. Ideally we want to suggest creating a multiarch driver as a workaround if the buildx uses the default driver. To accomplish this, we could just grep for the key words on the error message instead of the entire string as it might change between different docker versions.

*Description of changes:*
Tested locally by building on the default driver on docker version:  25.0.3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
