### PR TITLE
Allow running EKS-A admin image build on Darwin, update Ubuntu ISO URL

### DIFF
--- a/projects/aws/eks-a-admin-image/Makefile
+++ b/projects/aws/eks-a-admin-image/Makefile
@@ -109,7 +109,7 @@ build-ova: KIND_URL?=$(shell ./build/get_kind_url.sh $(ARTIFACTS_BUCKET) )
 build-ova: export PKR_VAR_kind-url=$(KIND_URL)
 build-ova: $(PACKER) init clean-ova $(OVA_OUTPUT_DIR)
 	echo $(VSPHERE_PASSWORD) $(VSPHERE_USERNAME)
-	$(PACKER) build -only='*.vsphere-iso.*' -var-file=ova/linux/ubuntu/vsphere.ubuntu.pkrvars.hcl .
+	DEBUG=1 $(PACKER) build -force -only='*.vsphere-iso.*' -var-file=ova/linux/ubuntu/vsphere.ubuntu.pkrvars.hcl .
 
 .PHONY: release-ova
 release-ova: build-ova publish-ova-to-s3

--- a/projects/aws/eks-a-admin-image/build/get_latest_eksa_version_by_date.sh
+++ b/projects/aws/eks-a-admin-image/build/get_latest_eksa_version_by_date.sh
@@ -6,6 +6,9 @@ set -o nounset
 set -o pipefail
 
 RELEASES_MANIFEST=$(curl --silent -L $EKSA_RELEASE_MANIFEST_URL)
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd -P)"
+source "${SCRIPT_ROOT}/build/lib/common.sh"
+DATE=$(build::find::gnu_variant_on_mac date)
 
 newest_release_date=0
 newest_release_version=""
@@ -13,7 +16,7 @@ newest_release_version=""
 while IFS=$'\t' read -r date version _; do
     # date is something like '2022-05-05 13:05:34.038243612 +0000 UTC'
     # I can't get `date` to parse this format, so deleting the extra timezone first
-    parsed_date=$(date -d "$(echo $date | awk '{print $1,$2,$3}')" +"%s")
+    parsed_date=$($DATE -d "$(echo $date | awk '{print $1,$2,$3}')" +"%s")
 
     if [ $parsed_date -gt $newest_release_date ];
     then

--- a/projects/aws/eks-a-admin-image/ova/linux/ubuntu/vsphere.ubuntu.pkrvars.hcl
+++ b/projects/aws/eks-a-admin-image/ova/linux/ubuntu/vsphere.ubuntu.pkrvars.hcl
@@ -20,9 +20,9 @@ vm_disk_thin_provisioned = true
 vm_network_card          = "vmxnet3"
 
 // Removable Media Settings
-iso_url           = "https://releases.ubuntu.com/20.04/ubuntu-20.04.4-live-server-amd64.iso"
+iso_url            = "https://releases.ubuntu.com/20.04/ubuntu-20.04.6-live-server-amd64.iso"
 iso_checksum_type  = "sha256"
-iso_checksum_value = "28ccdb56450e643bad03bb7bcf7507ce3d8d90e8bf09e38f6bd9ac298a98eaad"
+iso_checksum_value = "b8f31413336b9393ad5d8ef0282717b2ab19f007df2e9ed5196c13d8f9153c8b"
 
 // Boot Settings
 vm_boot_order = "disk,cdrom"

--- a/projects/aws/eks-a-admin-image/provisioners/install_golang.sh
+++ b/projects/aws/eks-a-admin-image/provisioners/install_golang.sh
@@ -6,7 +6,7 @@ set -o nounset
 set -o pipefail
 
 if [[ "$GO_VERSION" == "latest" ]]; then
-    GO_VERSION="$(curl --silent https://go.dev/VERSION?m=text)";
+    GO_VERSION="$(curl --silent https://go.dev/VERSION?m=text | head -n 1)";
     GO_URL="https://go.dev/dl/${GO_VERSION}.linux-amd64.tar.gz"
 else
     GO_URL="https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"


### PR DESCRIPTION
Allow running EKS-A admin image build on Darwin, by making the `date` command dynamic. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
