### PR TITLE
Bump Eks-d release to latest on release branch

### DIFF
--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -23,16 +23,16 @@ releases:
   number: 33
 - branch: 1-25
   kubeVersion: v1.25.16
-  number: 35
+  number: 37
 - branch: 1-26
   kubeVersion: v1.26.14
-  number: 31
+  number: 33
 - branch: 1-27
   kubeVersion: v1.27.11
-  number: 25
+  number: 27
 - branch: 1-28
   kubeVersion: v1.28.7
-  number: 18
+  number: 20
 - branch: 1-29
   kubeVersion: v1.29.1
-  number: 7
+  number: 9


### PR DESCRIPTION
*Issue #, if available:*
Bump Eks-d release to latest for release 19.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
