### PR TITLE
Add patch to update Ubuntu 22.04 ISO URLs to latest stable release

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
@@ -1,7 +1,7 @@
 From 22145b800be457fc0afc11e59771df7be186c6e3 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:05:13 -0800
-Subject: [PATCH 01/10] OVA improvements
+Subject: [PATCH 01/11] OVA improvements
 
 - Create /etc/pki/tls/certs dir as part of image-builds
 - Tweak Product info in OVF

--- a/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
@@ -1,7 +1,7 @@
 From 6d3d1e6357299d9fac826536cd72207e4211c553 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 18:36:56 -0800
-Subject: [PATCH 02/10] EKS-D support and changes
+Subject: [PATCH 02/11] EKS-D support and changes
 
 - Add goss validations for EKS-D artifacts
 - Add etcdadm and etcd.tar.gz to image for unstacked etcd support

--- a/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
@@ -1,7 +1,7 @@
 From 655d35d5007e3bc240e246d3cbf7fc51a70b0fb8 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Feb 2023 01:39:15 -0800
-Subject: [PATCH 03/10] Snow AMI support
+Subject: [PATCH 03/11] Snow AMI support
 
 - Add instance metadata options to Packer config
 - Rename Snow node image to reflect appropriate CAPI provider

--- a/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22-support-and-improvements.patch
@@ -1,7 +1,7 @@
-From edd6cf8b072366a57cf205ede90db0ddca75329a Mon Sep 17 00:00:00 2001
+From ad3a07c50e5cbe2f458dc5717a3e4c582e7f383a Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Fri, 23 Jun 2023 10:50:08 -0500
-Subject: [PATCH 04/10] Ubuntu 22 support and improvements
+Subject: [PATCH 04/11] Ubuntu 22 support and improvements
 
 - adds support for raw ubuntu 22.04 builds
 - Ubuntu switch to offline-install when mirrors are unavailable

--- a/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
@@ -1,7 +1,7 @@
-From 4332a320c8c371644c2d5490f58afe3580242c0a Mon Sep 17 00:00:00 2001
+From 41dfda736b1f1c621699a6e2c5c177883a87f802 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 6 Dec 2022 15:42:02 -0600
-Subject: [PATCH 05/10] RHEL support and improvements
+Subject: [PATCH 05/11] RHEL support and improvements
 
 - Exclude kernel and cloud-init from yum updates
 - Patch cloud-init systemd unit to wait for network manager online

--- a/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-RHEL-support-for-AWS-image-builder.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-RHEL-support-for-AWS-image-builder.patch
@@ -1,7 +1,7 @@
-From 786c5f1fcdd347f207213c22a7e3a3f8e969cf89 Mon Sep 17 00:00:00 2001
+From 258ad0ade994a73f068ab20f647dbe661a69c9a0 Mon Sep 17 00:00:00 2001
 From: Ilya Alekseyev <ilya.alekseyev@nutanix.com>
 Date: Wed, 11 Oct 2023 22:07:22 -0400
-Subject: [PATCH 06/10] Nutanix RHEL support for AWS image-builder
+Subject: [PATCH 06/11] Nutanix RHEL support for AWS image-builder
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
@@ -1,7 +1,7 @@
-From 76412b40f37d88a3da517f0663a7b6944d4566fb Mon Sep 17 00:00:00 2001
+From 7c378be6028ed5ba0a377038d03efde182c6f463 Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
 Date: Mon, 21 Aug 2023 18:40:07 -0500
-Subject: [PATCH 07/10] adds retries and timeout to packer image-builder
+Subject: [PATCH 07/11] adds retries and timeout to packer image-builder
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0008-Disable-UDP-offload-service-for-Redhat-and-Ubuntu.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0008-Disable-UDP-offload-service-for-Redhat-and-Ubuntu.patch
@@ -1,7 +1,7 @@
-From 1f2b9ea6f09dd05008a697e260731021b5bca827 Mon Sep 17 00:00:00 2001
+From a91e7e33cd38a1d7e651b25822ea163a447b9a4a Mon Sep 17 00:00:00 2001
 From: Taylor Neyland <tneyla@amazon.com>
 Date: Wed, 19 Jul 2023 12:51:30 -0500
-Subject: [PATCH 08/10] Disable UDP offload service for Redhat and Ubuntu
+Subject: [PATCH 08/11] Disable UDP offload service for Redhat and Ubuntu
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0009-Default-Flatcar-version-to-avoid-pulling-from-intern.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0009-Default-Flatcar-version-to-avoid-pulling-from-intern.patch
@@ -1,7 +1,7 @@
-From fc3bf99a4a491d9c5f6986efc51a076f823c0e75 Mon Sep 17 00:00:00 2001
+From 9dfd01f4d6ebbc79d3db2e68c0ae7e75337814af Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Wed, 20 Sep 2023 10:33:44 -0500
-Subject: [PATCH 09/10] Default Flatcar version to avoid pulling from internet
+Subject: [PATCH 09/11] Default Flatcar version to avoid pulling from internet
  on every make
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0010-Revert-updates-to-Ubuntu-2004-ISO-URLs.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0010-Revert-updates-to-Ubuntu-2004-ISO-URLs.patch
@@ -1,7 +1,7 @@
-From fda17cb8e1ca9cd2e90450a9bdf76619b364c501 Mon Sep 17 00:00:00 2001
+From 320841f7a1e2a7e805475561faa8bdda32b97351 Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
 Date: Sun, 17 Mar 2024 23:51:54 -0700
-Subject: [PATCH 10/10] Revert updates to Ubuntu 2004 ISO URLs
+Subject: [PATCH 10/11] Revert updates to Ubuntu 2004 ISO URLs
 
 Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>

--- a/projects/kubernetes-sigs/image-builder/patches/0011-Update-Ubuntu-22.04-ISO-URLs-to-use-stable-URLs.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0011-Update-Ubuntu-22.04-ISO-URLs-to-use-stable-URLs.patch
@@ -1,0 +1,97 @@
+From ddaa7cf851a2b92fb54bb2238a7c131e3de5336f Mon Sep 17 00:00:00 2001
+From: Marcus Noble <github@marcusnoble.co.uk>
+Date: Fri, 5 Apr 2024 09:47:34 +0100
+Subject: [PATCH 11/11] Update Ubuntu 22.04 ISO URLs to use stable URLs
+
+Signed-off-by: Marcus Noble <github@marcusnoble.co.uk>
+---
+ images/capi/packer/ova/ubuntu-2204-efi.json       | 4 ++--
+ images/capi/packer/ova/ubuntu-2204.json           | 4 ++--
+ images/capi/packer/proxmox/ubuntu-2204.json       | 4 ++--
+ images/capi/packer/qemu/qemu-ubuntu-2204-efi.json | 4 ++--
+ images/capi/packer/qemu/qemu-ubuntu-2204.json     | 4 ++--
+ 5 files changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/images/capi/packer/ova/ubuntu-2204-efi.json b/images/capi/packer/ova/ubuntu-2204-efi.json
+index a2f2fb86f..ffd4bf6c8 100644
+--- a/images/capi/packer/ova/ubuntu-2204-efi.json
++++ b/images/capi/packer/ova/ubuntu-2204-efi.json
+@@ -9,9 +9,9 @@
+   "firmware": "efi",
+   "floppy_dirs": "./packer/ova/linux/{{user `distro_name`}}/http/",
+   "guest_os_type": "ubuntu-64",
+-  "iso_checksum": "a4acfda10b18da50e2ec50ccaf860d7f20b389df8765611142305c0e911d16fd",
++  "iso_checksum": "45f873de9f8cb637345d6e66a583762730bbea30277ef7b32c9c3bd6700a32b2",
+   "iso_checksum_type": "sha256",
+-  "iso_url": "https://old-releases.ubuntu.com/releases/22.04/ubuntu-22.04.3-live-server-amd64.iso",
++  "iso_url": "https://releases.ubuntu.com/22.04.4/ubuntu-22.04.4-live-server-amd64.iso",
+   "os_display_name": "Ubuntu 22.04",
+   "shutdown_command": "shutdown -P now",
+   "vsphere_guest_os_type": "ubuntu64Guest"
+diff --git a/images/capi/packer/ova/ubuntu-2204.json b/images/capi/packer/ova/ubuntu-2204.json
+index b4acf4d9e..e436d93b9 100644
+--- a/images/capi/packer/ova/ubuntu-2204.json
++++ b/images/capi/packer/ova/ubuntu-2204.json
+@@ -8,9 +8,9 @@
+   "distro_version": "22.04",
+   "floppy_dirs": "./packer/ova/linux/{{user `distro_name`}}/http/",
+   "guest_os_type": "ubuntu-64",
+-  "iso_checksum": "a4acfda10b18da50e2ec50ccaf860d7f20b389df8765611142305c0e911d16fd",
++  "iso_checksum": "45f873de9f8cb637345d6e66a583762730bbea30277ef7b32c9c3bd6700a32b2",
+   "iso_checksum_type": "sha256",
+-  "iso_url": "https://old-releases.ubuntu.com/releases/22.04/ubuntu-22.04.3-live-server-amd64.iso",
++  "iso_url": "https://releases.ubuntu.com/22.04.4/ubuntu-22.04.4-live-server-amd64.iso",
+   "os_display_name": "Ubuntu 22.04",
+   "shutdown_command": "shutdown -P now",
+   "vsphere_guest_os_type": "ubuntu64Guest"
+diff --git a/images/capi/packer/proxmox/ubuntu-2204.json b/images/capi/packer/proxmox/ubuntu-2204.json
+index 3006f001b..78aacbb94 100644
+--- a/images/capi/packer/proxmox/ubuntu-2204.json
++++ b/images/capi/packer/proxmox/ubuntu-2204.json
+@@ -3,9 +3,9 @@
+   "build_name": "ubuntu-2204",
+   "distribution_version": "2204",
+   "distro_name": "ubuntu",
+-  "iso_checksum": "a4acfda10b18da50e2ec50ccaf860d7f20b389df8765611142305c0e911d16fd",
++  "iso_checksum": "45f873de9f8cb637345d6e66a583762730bbea30277ef7b32c9c3bd6700a32b2",
+   "iso_checksum_type": "sha256",
+-  "iso_url": "https://old-releases.ubuntu.com/releases/22.04/ubuntu-22.04.3-live-server-amd64.iso",
++  "iso_url": "https://releases.ubuntu.com/22.04.4/ubuntu-22.04.4-live-server-amd64.iso",
+   "os_display_name": "Ubuntu 22.04",
+   "source_image": "ubuntu-20-04-x64",
+   "unmount_iso": "true",
+diff --git a/images/capi/packer/qemu/qemu-ubuntu-2204-efi.json b/images/capi/packer/qemu/qemu-ubuntu-2204-efi.json
+index fa0da36c1..cde3d1109 100644
+--- a/images/capi/packer/qemu/qemu-ubuntu-2204-efi.json
++++ b/images/capi/packer/qemu/qemu-ubuntu-2204-efi.json
+@@ -5,9 +5,9 @@
+   "firmware": "OVMF.fd",
+   "guest_os_type": "ubuntu-64",
+   "http_directory": "./packer/qemu/linux/ubuntu/http/22.04.efi.qemu",
+-  "iso_checksum": "a4acfda10b18da50e2ec50ccaf860d7f20b389df8765611142305c0e911d16fd",
++  "iso_checksum": "45f873de9f8cb637345d6e66a583762730bbea30277ef7b32c9c3bd6700a32b2",
+   "iso_checksum_type": "sha256",
+-  "iso_url": "https://old-releases.ubuntu.com/releases/22.04/ubuntu-22.04.3-live-server-amd64.iso",
++  "iso_url": "https://releases.ubuntu.com/22.04.4/ubuntu-22.04.4-live-server-amd64.iso",
+   "os_display_name": "Ubuntu 22.04",
+   "shutdown_command": "shutdown -P now",
+   "unmount_iso": "true"
+diff --git a/images/capi/packer/qemu/qemu-ubuntu-2204.json b/images/capi/packer/qemu/qemu-ubuntu-2204.json
+index 8857f1299..9a114d361 100644
+--- a/images/capi/packer/qemu/qemu-ubuntu-2204.json
++++ b/images/capi/packer/qemu/qemu-ubuntu-2204.json
+@@ -4,9 +4,9 @@
+   "distribution_version": "2204",
+   "distro_name": "ubuntu",
+   "guest_os_type": "ubuntu-64",
+-  "iso_checksum": "a4acfda10b18da50e2ec50ccaf860d7f20b389df8765611142305c0e911d16fd",
++  "iso_checksum": "45f873de9f8cb637345d6e66a583762730bbea30277ef7b32c9c3bd6700a32b2",
+   "iso_checksum_type": "sha256",
+-  "iso_url": "https://old-releases.ubuntu.com/releases/22.04/ubuntu-22.04.3-live-server-amd64.iso",
++  "iso_url": "https://releases.ubuntu.com/22.04.4/ubuntu-22.04.4-live-server-amd64.iso",
+   "os_display_name": "Ubuntu 22.04",
+   "shutdown_command": "shutdown -P now",
+   "unmount_iso": "true"
+-- 
+2.39.3 (Apple Git-146)
+


### PR DESCRIPTION
Adding a patch for https://github.com/kubernetes-sigs/image-builder/pull/1438. This will be removed when we move to image-builder v0.1.26

/cherrypick release-0.19

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
