### PR TITLE
Add patch to update Ubuntu 22.04 ISO URLs to latest stable release

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
@@ -1,4 +1,4 @@
-From 4f22a0f719be7fbb75c1065b1b9311d603056508 Mon Sep 17 00:00:00 2001
+From 27707ab0da8036102933c099321d5f1fdf0aa70c Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:05:13 -0800
 Subject: [PATCH 01/11] OVA improvements
@@ -61,7 +61,7 @@ index 316427ec3..ca23db5f9 100644
        <Property ovf:userConfigurable="false" ovf:value="${BUILD_TIMESTAMP}" ovf:type="string" ovf:key="BUILD_TIMESTAMP"/>
        <Property ovf:userConfigurable="false" ovf:value="${BUILD_DATE}" ovf:type="string" ovf:key="BUILD_DATE"/>
 diff --git a/images/capi/packer/ova/packer-node.json b/images/capi/packer/ova/packer-node.json
-index 1b7b2d13d..f46df3cee 100644
+index 1b7b2d13d..fc6fa6488 100644
 --- a/images/capi/packer/ova/packer-node.json
 +++ b/images/capi/packer/ova/packer-node.json
 @@ -184,6 +184,12 @@
@@ -154,5 +154,5 @@ index 1b7b2d13d..f46df3cee 100644
    }
  }
 -- 
-2.39.3 (Apple Git-145)
+2.39.3 (Apple Git-146)
 

--- a/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
@@ -1,4 +1,4 @@
-From f5fddefc341474427b45eaf41222325fa831ee6e Mon Sep 17 00:00:00 2001
+From dc5f2acc1ab329d571c2acaa7870e97c3d186f48 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 18:36:56 -0800
 Subject: [PATCH 02/11] EKS-D support and changes
@@ -162,7 +162,7 @@ index 9cce0a96a..37fd9e4eb 100644
    "kubernetes_series": "v1.26",
    "kubernetes_source_type": "pkg",
 diff --git a/images/capi/packer/goss/goss-command.yaml b/images/capi/packer/goss/goss-command.yaml
-index 19c202319..a72ed6f17 100644
+index 4c94e64da..1ce7508f5 100644
 --- a/images/capi/packer/goss/goss-command.yaml
 +++ b/images/capi/packer/goss/goss-command.yaml
 @@ -37,6 +37,11 @@ command:
@@ -264,10 +264,10 @@ index 959005df8..2d88c2fb6 100644
        "version": "{{user `goss_version`}}"
      }
 diff --git a/images/capi/packer/ova/packer-node.json b/images/capi/packer/ova/packer-node.json
-index e85dbe077..feeaf1a37 100644
+index fc6fa6488..14753f7ce 100644
 --- a/images/capi/packer/ova/packer-node.json
 +++ b/images/capi/packer/ova/packer-node.json
-@@ -464,7 +464,12 @@
+@@ -467,7 +467,12 @@
          "kubernetes_deb_version": "{{ user `kubernetes_deb_version` }}",
          "kubernetes_rpm_version": "{{ split (user `kubernetes_rpm_version`) \"-\" 0  }}",
          "kubernetes_source_type": "{{user `kubernetes_source_type`}}",
@@ -318,5 +318,5 @@ index 152041455..a04be4e8f 100644
        "version": "{{user `goss_version`}}"
      }
 -- 
-2.39.3 (Apple Git-145)
+2.39.3 (Apple Git-146)
 

--- a/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
@@ -1,4 +1,4 @@
-From 5d046d6ec6b28e6827c3ff0b5df8547d3c411cc0 Mon Sep 17 00:00:00 2001
+From 4add9f1e52568f6c5c92c2baf6d3c10d6010a70e Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Feb 2023 01:39:15 -0800
 Subject: [PATCH 03/11] Snow AMI support
@@ -47,5 +47,5 @@ index eb4552a4c..f5856f4c3 100644
      "ib_version": "{{env `IB_VERSION`}}",
      "iops": "3000",
 -- 
-2.39.3 (Apple Git-145)
+2.39.3 (Apple Git-146)
 

--- a/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22-support-and-improvements.patch
@@ -1,4 +1,4 @@
-From 46ea9af97300b99632ca0557ea5ffd01e4460afb Mon Sep 17 00:00:00 2001
+From c7fcf455104bc7cbcef15b7b36da66f2812424a7 Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Fri, 23 Jun 2023 10:50:08 -0500
 Subject: [PATCH 04/11] Ubuntu 22 support and improvements
@@ -394,5 +394,5 @@ index 000000000..c9cfe7381
 +  "shutdown_command": "shutdown -P now"
 +  }
 -- 
-2.39.3 (Apple Git-145)
+2.39.3 (Apple Git-146)
 

--- a/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
@@ -1,4 +1,4 @@
-From 5bd56bd23692f84b4fcfb99ed331831edde522f4 Mon Sep 17 00:00:00 2001
+From 7ab47d9b73966b77ed965d9a790eb5baed3d232c Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 6 Dec 2022 15:42:02 -0600
 Subject: [PATCH 05/11] RHEL support and improvements
@@ -20,7 +20,7 @@ Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
  .../ansible/roles/providers/tasks/main.yml    | 15 ++++
  .../capi/ansible/roles/setup/tasks/redhat.yml | 84 +++++++++++++++++++
  images/capi/packer/config/ansible-args.json   |  2 +-
- 6 files changed, 148 insertions(+), 3 deletions(-)
+ 6 files changed, 137 insertions(+), 1 deletion(-)
  create mode 100644 images/capi/ansible/roles/node/tasks/redhat.yml
  create mode 100644 images/capi/ansible/roles/providers/files/etc/systemd/system/cloud-init.service.d/boot-order.conf
 
@@ -113,7 +113,7 @@ index b55b78099..a58f0e7c0 100644
  # Enable all cloud-init services on boot.
  - name: Make sure all cloud init services are enabled
 diff --git a/images/capi/ansible/roles/setup/tasks/redhat.yml b/images/capi/ansible/roles/setup/tasks/redhat.yml
-index 74329afd4..4ebe7d732 100644
+index 74329afd4..e20e3da6c 100644
 --- a/images/capi/ansible/roles/setup/tasks/redhat.yml
 +++ b/images/capi/ansible/roles/setup/tasks/redhat.yml
 @@ -22,6 +22,74 @@
@@ -229,6 +229,6 @@ index d7e50f852..22225c7d3 100644
 +  "ansible_common_vars": "containerd_url={{user `containerd_url`}} containerd_sha256={{user `containerd_sha256`}} pause_image={{user `pause_image`}} containerd_additional_settings={{user `containerd_additional_settings`}} containerd_cri_socket={{user `containerd_cri_socket`}} containerd_version={{user `containerd_version`}} containerd_wasm_shims_url={{user `containerd_wasm_shims_url`}} containerd_wasm_shims_version={{user `containerd_wasm_shims_version`}} containerd_wasm_shims_sha256={{user `containerd_wasm_shims_sha256`}} containerd_wasm_shims_runtimes=\"{{user `containerd_wasm_shims_runtimes`}}\" containerd_wasm_shims_runtime_versions=\"{{user `containerd_wasm_shims_runtime_versions`}}\" crictl_url={{user `crictl_url`}} crictl_sha256={{user `crictl_sha256`}} crictl_source_type={{user `crictl_source_type`}} custom_role_names=\"{{user `custom_role_names`}}\" firstboot_custom_roles_pre=\"{{user `firstboot_custom_roles_pre`}}\" firstboot_custom_roles_post=\"{{user `firstboot_custom_roles_post`}}\" node_custom_roles_pre=\"{{user `node_custom_roles_pre`}}\" node_custom_roles_post=\"{{user `node_custom_roles_post`}}\" disable_public_repos={{user `disable_public_repos`}} extra_debs=\"{{user `extra_debs`}}\" extra_repos=\"{{user `extra_repos`}}\" extra_rpms=\"{{user `extra_rpms`}}\" http_proxy={{user `http_proxy`}} https_proxy={{user `https_proxy`}} kubeadm_template={{user `kubeadm_template`}} kubernetes_apiserver_port={{user `kubernetes_apiserver_port`}} kubernetes_cni_http_source={{user `kubernetes_cni_http_source`}} kubernetes_cni_http_checksum={{user `kubernetes_cni_http_checksum`}} kubernetes_goarch={{user `kubernetes_goarch`}} kubernetes_http_source={{user `kubernetes_http_source`}} kubernetes_container_registry={{user `kubernetes_container_registry`}} kubernetes_rpm_repo={{user `kubernetes_rpm_repo`}} kubernetes_rpm_gpg_key={{user `kubernetes_rpm_gpg_key`}} kubernetes_rpm_gpg_check={{user `kubernetes_rpm_gpg_check`}} kubernetes_deb_repo={{user `kubernetes_deb_repo`}} kubernetes_deb_gpg_key={{user `kubernetes_deb_gpg_key`}} kubernetes_cni_deb_version={{user `kubernetes_cni_deb_version`}} kubernetes_cni_rpm_version={{user `kubernetes_cni_rpm_version`}} kubernetes_cni_semver={{user `kubernetes_cni_semver`}} kubernetes_cni_source_type={{user `kubernetes_cni_source_type`}} kubernetes_semver={{user `kubernetes_semver`}} kubernetes_source_type={{user `kubernetes_source_type`}} kubernetes_load_additional_imgs={{user `kubernetes_load_additional_imgs`}} kubernetes_deb_version={{user `kubernetes_deb_version`}} kubernetes_rpm_version={{user `kubernetes_rpm_version`}} no_proxy={{user `no_proxy`}} pip_conf_file={{user `pip_conf_file`}} python_path={{user `python_path`}} redhat_epel_rpm={{user `redhat_epel_rpm`}} epel_rpm_gpg_key={{user `epel_rpm_gpg_key`}} reenable_public_repos={{user `reenable_public_repos`}} remove_extra_repos={{user `remove_extra_repos`}} systemd_prefix={{user `systemd_prefix`}} sysusr_prefix={{user `sysusr_prefix`}} sysusrlocal_prefix={{user `sysusrlocal_prefix`}} load_additional_components={{ user `load_additional_components`}} additional_registry_images={{ user `additional_registry_images`}} additional_registry_images_list={{ user `additional_registry_images_list`}} additional_url_images={{ user `additional_url_images`}} additional_url_images_list={{ user `additional_url_images_list`}} additional_executables={{ user `additional_executables`}} additional_executables_list={{ user `additional_executables_list`}} additional_executables_destination_path={{ user `additional_executables_destination_path`}} additional_s3={{ user `additional_s3`}} build_target={{ user `build_target`}} amazon_ssm_agent_rpm={{ user `amazon_ssm_agent_rpm` }} enable_containerd_audit={{ user `enable_containerd_audit` }} kubernetes_enable_automatic_resource_sizing={{ user `kubernetes_enable_automatic_resource_sizing` }} etcd_http_source={{user `etcd_http_source`}} etcd_version={{user `etcd_version`}} etcdadm_http_source={{user `etcdadm_http_source`}} etcd_sha256={{user `etcd_sha256`}} etcdadm_version={{user `etcdadm_version`}} rhsm_server_hostname={{ user `rhsm_server_hostname` }} rhsm_server_release_version={{ user `rhsm_server_release_version` }} rhsm_server_proxy_hostname={{ user `rhsm_server_proxy_hostname` }} rhsm_server_proxy_port={{ user `rhsm_server_proxy_port` }}",
    "ansible_scp_extra_args": "{{env `ANSIBLE_SCP_EXTRA_ARGS`}}"
  }
---
-2.34.1
+-- 
+2.39.3 (Apple Git-146)
 

--- a/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-RHEL-support-for-AWS-image-builder.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-RHEL-support-for-AWS-image-builder.patch
@@ -1,4 +1,4 @@
-From 56c9245719b1ff798bcab6fcbe0cc344fdc84920 Mon Sep 17 00:00:00 2001
+From dddfa68bb2912a76877702a5f9a1d586a51a9193 Mon Sep 17 00:00:00 2001
 From: Ilya Alekseyev <ilya.alekseyev@nutanix.com>
 Date: Wed, 11 Oct 2023 22:07:22 -0400
 Subject: [PATCH 06/11] Nutanix RHEL support for AWS image-builder
@@ -46,5 +46,5 @@ index b7dddb4f2..921a9729f 100644
    "shutdown_command": "shutdown -P now",
    "user_data": "I2Nsb3VkLWNvbmZpZwp1c2VyczoKICAtIG5hbWU6IGJ1aWxkZXIKICAgIHN1ZG86IFsnQUxMPShBTEwpIE5PUEFTU1dEOkFMTCddCmNocGFzc3dkOgogIGxpc3Q6IHwKICAgIGJ1aWxkZXI6YnVpbGRlcgogIGV4cGlyZTogRmFsc2UKc3NoX3B3YXV0aDogVHJ1ZQ=="
 -- 
-2.39.3 (Apple Git-145)
+2.39.3 (Apple Git-146)
 

--- a/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
@@ -1,4 +1,4 @@
-From 86f97aa19a435b86c60f767597cc4b33f10816f0 Mon Sep 17 00:00:00 2001
+From fa919eeb9a1e8e306d931c0f8bfba2afa8e341ae Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
 Date: Mon, 21 Aug 2023 18:40:07 -0500
 Subject: [PATCH 07/11] adds retries and timeout to packer image-builder
@@ -43,7 +43,7 @@ index c6835bd43..dd2d80126 100644
    "vmx_version": "15",
    "vnc_bind_address": "127.0.0.1",
 diff --git a/images/capi/packer/ova/packer-node.json b/images/capi/packer/ova/packer-node.json
-index feeaf1a37..19795a130 100644
+index 14753f7ce..4290d2c4b 100644
 --- a/images/capi/packer/ova/packer-node.json
 +++ b/images/capi/packer/ova/packer-node.json
 @@ -18,8 +18,9 @@
@@ -110,7 +110,7 @@ index feeaf1a37..19795a130 100644
        "ssh_username": "{{user `ssh_username`}}",
        "template": "{{user `template`}}",
        "type": "vsphere-clone",
-@@ -393,7 +399,9 @@
+@@ -396,7 +402,9 @@
          "--scp-extra-args",
          "{{user `ansible_scp_extra_args`}}"
        ],
@@ -120,7 +120,7 @@ index feeaf1a37..19795a130 100644
        "type": "ansible",
        "user": "{{user `ssh_username`}}"
      },
-@@ -426,7 +434,9 @@
+@@ -429,7 +437,9 @@
          "--scp-extra-args",
          "{{user `ansible_scp_extra_args`}}"
        ],
@@ -201,5 +201,5 @@ index 83aa6b4fb..3b75d291a 100644
        "user": "builder"
      },
 -- 
-2.39.3 (Apple Git-145)
+2.39.3 (Apple Git-146)
 

--- a/projects/kubernetes-sigs/image-builder/patches/0008-Disable-UDP-offload-service-for-Redhat-and-Ubuntu.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0008-Disable-UDP-offload-service-for-Redhat-and-Ubuntu.patch
@@ -1,4 +1,4 @@
-From 3149ef33177d47fc0923bc6b193bbff67e932184 Mon Sep 17 00:00:00 2001
+From 61845889801a9f413c3527c4965b90784350cb9e Mon Sep 17 00:00:00 2001
 From: Taylor Neyland <tneyla@amazon.com>
 Date: Wed, 19 Jul 2023 12:51:30 -0500
 Subject: [PATCH 08/11] Disable UDP offload service for Redhat and Ubuntu
@@ -108,5 +108,5 @@ index b3aeab637..ee1d20c0f 100644
 +    state: stopped
 +  when: ansible_distribution_version is version('22.04', '>=')
 -- 
-2.39.3 (Apple Git-145)
+2.39.3 (Apple Git-146)
 

--- a/projects/kubernetes-sigs/image-builder/patches/0009-Default-Flatcar-version-to-avoid-pulling-from-intern.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0009-Default-Flatcar-version-to-avoid-pulling-from-intern.patch
@@ -1,4 +1,4 @@
-From c1f0760cb15fb65b28b3bccb4058f786aff831f2 Mon Sep 17 00:00:00 2001
+From 7d5dcc5f50eadb9d08e086ec26814203ac24a8c9 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Wed, 20 Sep 2023 10:33:44 -0500
 Subject: [PATCH 09/11] Default Flatcar version to avoid pulling from internet
@@ -23,5 +23,5 @@ index 09945c609..8c33b430f 100644
  override FLATCAR_VERSION := $(shell hack/image-grok-latest-flatcar-version.sh $(FLATCAR_CHANNEL))
  endif
 -- 
-2.39.3 (Apple Git-145)
+2.39.3 (Apple Git-146)
 

--- a/projects/kubernetes-sigs/image-builder/patches/0010-Adds-support-for-cloudstack-rhel-9.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0010-Adds-support-for-cloudstack-rhel-9.patch
@@ -1,4 +1,4 @@
-From 2dcea73beae6dfd47e4eccc29ef9b76778cf6b14 Mon Sep 17 00:00:00 2001
+From 96d5c320348d582a62c336dd57989cd07ae759f9 Mon Sep 17 00:00:00 2001
 From: ahreehong <46465244+ahreehong@users.noreply.github.com>
 Date: Tue, 12 Dec 2023 15:01:07 -0800
 Subject: [PATCH 10/11] Adds support for cloudstack rhel 9
@@ -85,5 +85,5 @@ index 000000000..e2fcccc88
 +  "shutdown_command": "shutdown -P now"
 +}
 -- 
-2.39.3 (Apple Git-145)
+2.39.3 (Apple Git-146)
 

--- a/projects/kubernetes-sigs/image-builder/patches/0011-Update-Ubuntu-22.04-ISO-URLs-to-use-stable-URLs.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0011-Update-Ubuntu-22.04-ISO-URLs-to-use-stable-URLs.patch
@@ -1,0 +1,97 @@
+From 5bc2dd870ef09dcf0e1226776cd48525ff580405 Mon Sep 17 00:00:00 2001
+From: Marcus Noble <github@marcusnoble.co.uk>
+Date: Fri, 5 Apr 2024 09:47:34 +0100
+Subject: [PATCH 11/11] Update Ubuntu 22.04 ISO URLs to use stable URLs
+
+Signed-off-by: Marcus Noble <github@marcusnoble.co.uk>
+---
+ images/capi/packer/ova/ubuntu-2204-efi.json       | 4 ++--
+ images/capi/packer/ova/ubuntu-2204.json           | 4 ++--
+ images/capi/packer/proxmox/ubuntu-2204.json       | 5 +++--
+ images/capi/packer/qemu/qemu-ubuntu-2204-efi.json | 4 ++--
+ images/capi/packer/qemu/qemu-ubuntu-2204.json     | 4 ++--
+ 5 files changed, 11 insertions(+), 10 deletions(-)
+
+diff --git a/images/capi/packer/ova/ubuntu-2204-efi.json b/images/capi/packer/ova/ubuntu-2204-efi.json
+index 5d199b8b0..ffd4bf6c8 100644
+--- a/images/capi/packer/ova/ubuntu-2204-efi.json
++++ b/images/capi/packer/ova/ubuntu-2204-efi.json
+@@ -9,9 +9,9 @@
+   "firmware": "efi",
+   "floppy_dirs": "./packer/ova/linux/{{user `distro_name`}}/http/",
+   "guest_os_type": "ubuntu-64",
+-  "iso_checksum": "5e38b55d57d94ff029719342357325ed3bda38fa80054f9330dc789cd2d43931",
++  "iso_checksum": "45f873de9f8cb637345d6e66a583762730bbea30277ef7b32c9c3bd6700a32b2",
+   "iso_checksum_type": "sha256",
+-  "iso_url": "https://old-releases.ubuntu.com/releases/jammy/ubuntu-22.04.2-live-server-amd64.iso",
++  "iso_url": "https://releases.ubuntu.com/22.04.4/ubuntu-22.04.4-live-server-amd64.iso",
+   "os_display_name": "Ubuntu 22.04",
+   "shutdown_command": "shutdown -P now",
+   "vsphere_guest_os_type": "ubuntu64Guest"
+diff --git a/images/capi/packer/ova/ubuntu-2204.json b/images/capi/packer/ova/ubuntu-2204.json
+index 38efb01c8..e436d93b9 100644
+--- a/images/capi/packer/ova/ubuntu-2204.json
++++ b/images/capi/packer/ova/ubuntu-2204.json
+@@ -8,9 +8,9 @@
+   "distro_version": "22.04",
+   "floppy_dirs": "./packer/ova/linux/{{user `distro_name`}}/http/",
+   "guest_os_type": "ubuntu-64",
+-  "iso_checksum": "5e38b55d57d94ff029719342357325ed3bda38fa80054f9330dc789cd2d43931",
++  "iso_checksum": "45f873de9f8cb637345d6e66a583762730bbea30277ef7b32c9c3bd6700a32b2",
+   "iso_checksum_type": "sha256",
+-  "iso_url": "https://old-releases.ubuntu.com/releases/jammy/ubuntu-22.04.2-live-server-amd64.iso",
++  "iso_url": "https://releases.ubuntu.com/22.04.4/ubuntu-22.04.4-live-server-amd64.iso",
+   "os_display_name": "Ubuntu 22.04",
+   "shutdown_command": "shutdown -P now",
+   "vsphere_guest_os_type": "ubuntu64Guest"
+diff --git a/images/capi/packer/proxmox/ubuntu-2204.json b/images/capi/packer/proxmox/ubuntu-2204.json
+index b83551b00..78aacbb94 100644
+--- a/images/capi/packer/proxmox/ubuntu-2204.json
++++ b/images/capi/packer/proxmox/ubuntu-2204.json
+@@ -3,8 +3,9 @@
+   "build_name": "ubuntu-2204",
+   "distribution_version": "2204",
+   "distro_name": "ubuntu",
+-  "iso_checksum": "sha256:5e38b55d57d94ff029719342357325ed3bda38fa80054f9330dc789cd2d43931",
+-  "iso_url": "https://old-releases.ubuntu.com/releases/jammy/ubuntu-22.04.2-live-server-amd64.iso",
++  "iso_checksum": "45f873de9f8cb637345d6e66a583762730bbea30277ef7b32c9c3bd6700a32b2",
++  "iso_checksum_type": "sha256",
++  "iso_url": "https://releases.ubuntu.com/22.04.4/ubuntu-22.04.4-live-server-amd64.iso",
+   "os_display_name": "Ubuntu 22.04",
+   "source_image": "ubuntu-20-04-x64",
+   "unmount_iso": "true",
+diff --git a/images/capi/packer/qemu/qemu-ubuntu-2204-efi.json b/images/capi/packer/qemu/qemu-ubuntu-2204-efi.json
+index b2865f1bc..cde3d1109 100644
+--- a/images/capi/packer/qemu/qemu-ubuntu-2204-efi.json
++++ b/images/capi/packer/qemu/qemu-ubuntu-2204-efi.json
+@@ -5,9 +5,9 @@
+   "firmware": "OVMF.fd",
+   "guest_os_type": "ubuntu-64",
+   "http_directory": "./packer/qemu/linux/ubuntu/http/22.04.efi.qemu",
+-  "iso_checksum": "a4acfda10b18da50e2ec50ccaf860d7f20b389df8765611142305c0e911d16fd",
++  "iso_checksum": "45f873de9f8cb637345d6e66a583762730bbea30277ef7b32c9c3bd6700a32b2",
+   "iso_checksum_type": "sha256",
+-  "iso_url": "https://releases.ubuntu.com/22.04/ubuntu-22.04.3-live-server-amd64.iso",
++  "iso_url": "https://releases.ubuntu.com/22.04.4/ubuntu-22.04.4-live-server-amd64.iso",
+   "os_display_name": "Ubuntu 22.04",
+   "shutdown_command": "shutdown -P now",
+   "unmount_iso": "true"
+diff --git a/images/capi/packer/qemu/qemu-ubuntu-2204.json b/images/capi/packer/qemu/qemu-ubuntu-2204.json
+index 59992352c..02db64723 100644
+--- a/images/capi/packer/qemu/qemu-ubuntu-2204.json
++++ b/images/capi/packer/qemu/qemu-ubuntu-2204.json
+@@ -4,9 +4,9 @@
+   "distribution_version": "2204",
+   "distro_name": "ubuntu",
+   "guest_os_type": "ubuntu-64",
+-  "iso_checksum": "5e38b55d57d94ff029719342357325ed3bda38fa80054f9330dc789cd2d43931",
++  "iso_checksum": "45f873de9f8cb637345d6e66a583762730bbea30277ef7b32c9c3bd6700a32b2",
+   "iso_checksum_type": "sha256",
+-  "iso_url": "https://old-releases.ubuntu.com/releases/jammy/ubuntu-22.04.2-live-server-amd64.iso",
++  "iso_url": "https://releases.ubuntu.com/22.04.4/ubuntu-22.04.4-live-server-amd64.iso",
+   "os_display_name": "Ubuntu 22.04",
+   "shutdown_command": "shutdown -P now",
+   "unmount_iso": "true"
+-- 
+2.39.3 (Apple Git-146)
+


### PR DESCRIPTION
Backporting #3114 to release-0.19 branch

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
