### PR TITLE
Handle cases where GitHub release does not exist for tag

### DIFF
--- a/tools/version-tracker/pkg/github/github.go
+++ b/tools/version-tracker/pkg/github/github.go
@@ -149,10 +149,17 @@ func GetLatestRevision(client *github.Client, org, repo, currentRevision string,
 				}
 			}
 			releaseForTag, _, err := client.Repositories.GetReleaseByTag(context.Background(), org, repo, tagName)
+			preRelease := false
 			if err != nil {
-				return "", false, fmt.Errorf("calling GetReleaseByTag API for tag %s in [%s/%s] repository: %v", tagName, org, repo, err)
+				if strings.Contains(err.Error(), "404 Not Found") {
+					preRelease = false
+				} else {
+					return "", false, fmt.Errorf("calling GetReleaseByTag API for tag %s in [%s/%s] repository: %v", tagName, org, repo, err)
+				}
+			} else {
+				preRelease = *releaseForTag.Prerelease
 			}
-			if *releaseForTag.Prerelease {
+			if preRelease {
 				continue
 			}
 


### PR DESCRIPTION
This PR adds logic to handle cases where GitHub release does not exist for tag.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
