### PR TITLE
Fix Go mod location for cluster-autoscaler

### DIFF
--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -237,7 +237,7 @@ var (
 			GoVersionSearchString: `golang:(1\.\d\d)`,
 		},
 		"kubernetes/autoscaler": {
-			SourceOfTruthFile:     "go.mod",
+			SourceOfTruthFile:     "cluster-autoscaler/go.mod",
 			GoVersionSearchString: `go (1\.\d\d)`,
 		},
 		"kubernetes/cloud-provider-aws": {


### PR DESCRIPTION
This PR fixes the Go mod location for cluster-autoscaler.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
