### PR TITLE
Add br ova support for release branch 130

### DIFF
--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
@@ -17,3 +17,5 @@
 1-29:
   ami-release-version: v1.19.4
   ova-release-version: v1.19.4
+1-30:
+  ova-release-version: v1.20.0


### PR DESCRIPTION
*Issue #, if available:*
Add release branch support for 1-30 for BottleRocket OVA template builds.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
