### PR TITLE
Allow upgrading projects tracked with commits

### DIFF
--- a/tools/version-tracker/pkg/commands/display/display.go
+++ b/tools/version-tracker/pkg/commands/display/display.go
@@ -93,14 +93,16 @@ func Run(displayOptions *types.DisplayOptions) error {
 			}
 
 			var currentRevision string
+			var isTrackedByCommitHash bool
 			if currentVersion.Tag != "" {
 				currentRevision = currentVersion.Tag
 			} else if currentVersion.Commit != "" {
 				currentRevision = currentVersion.Commit
+				isTrackedByCommitHash = true
 			}
 
 			// Get latest revision for the project from GitHub.
-			latestRevision, _, err := github.GetLatestRevision(client, org, repoName, currentRevision, releaseBranched)
+			latestRevision, _, err := github.GetLatestRevision(client, org, repoName, currentRevision, isTrackedByCommitHash, releaseBranched)
 			if err != nil {
 				return fmt.Errorf("getting latest revision from GitHub: %v", err)
 			}


### PR DESCRIPTION
This PR adds the logic for upgrading projects tracked with commits. In this case, the upgrade is done to the latest commit of the repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
