### PR TITLE
Fix pre-release detection logic when fetching latest GitHub revision

### DIFF
--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -32,6 +32,7 @@ const (
 	AttributionsFilePattern                 = "*ATTRIBUTION.txt"
 	PatchesDirectory                        = "patches"
 	FailedPatchApplyMarker                  = "patch does not apply"
+	SemverRegex                             = `v?(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?`
 	FailedPatchApplyRegex                   = "Patch failed at .*"
 	FailedPatchFilesRegex                   = "error: (.*): patch does not apply"
 	BottlerocketReleasesFile                = "BOTTLEROCKET_RELEASES"


### PR DESCRIPTION
This PR fixes the pre-release detection logic when fetching the latest revision from GitHub.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
