### PR TITLE
Fix cert-manager GitHub release tarball name

### DIFF
--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -118,7 +118,7 @@ var (
 			TrimLeadingVersionPrefix: true,
 		},
 		"cert-manager/cert-manager": {
-			AssetName:  "cmctl-linux-amd64.tar.gz",
+			AssetName:  "cert-manager-cmctl-linux-amd64.tar.gz",
 			BinaryName: "cmctl",
 			Extract:    true,
 		},


### PR DESCRIPTION
New releases of cert-manager have changed the asset name for the cert-manager cmctl tarballs, so updating our code to handle that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
