### PR TITLE
Allow projects to selectively upgrade to pre-release tags

### DIFF
--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -301,4 +301,6 @@ var (
 	BottlerocketHostContainers = []string{"admin", "control"}
 
 	CiliumImageDirectories = []string{"cilium", "operator-generic", "cilium-chart"}
+
+	ProjectsSupportingPrereleaseTags = []string{"kubernetes-sigs/cluster-api-provider-cloudstack"}
 )

--- a/tools/version-tracker/pkg/github/github.go
+++ b/tools/version-tracker/pkg/github/github.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/aws/eks-anywhere/pkg/semver"
@@ -146,6 +147,9 @@ func GetLatestRevision(client *github.Client, org, repo, currentRevision string,
 				}
 			}
 			tagNameForSemver := semverRegex.FindString(tagName)
+			if tagNameForSemver == "" {
+				continue
+			}
 
 			if releaseBranched {
 				releaseBranch := os.Getenv(constants.ReleaseBranchEnvvar)
@@ -160,7 +164,7 @@ func GetLatestRevision(client *github.Client, org, repo, currentRevision string,
 			if err != nil {
 				return "", false, fmt.Errorf("getting semver for the version under consideration: %v", err)
 			}
-			if revisionSemver.Prerelease != "" {
+			if !slices.Contains(constants.ProjectsSupportingPrereleaseTags, fmt.Sprintf("%s/%s", org, repo)) && revisionSemver.Prerelease != "" {
 				continue
 			}
 


### PR DESCRIPTION
This PR adds the logic to allow certain projects, governed by a list, to upgrade to pre-release tags. This is because some of the projects we consume have functional changes in release-candidate (RC) tags.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
