### PR TITLE
Add patch to revert deprecation of disk size capacityInKB field

### DIFF
--- a/projects/vmware/govmomi/CHECKSUMS
+++ b/projects/vmware/govmomi/CHECKSUMS
@@ -1,2 +1,2 @@
-8d0d4bd22beeeee4a825d008fb910273728a8053130096f9b70f82eb98e61256  _output/bin/govmomi/linux-amd64/govc
-814db41341ea2f9b452e77ace4f28de362d9af2df6bb4458841b2ef47687e6b3  _output/bin/govmomi/linux-arm64/govc
+7ec7b16a766bceaa88c76f89b166a8927b3c1ad2b439a2ab6265a617c1de953c  _output/bin/govmomi/linux-amd64/govc
+2d2e74085b583e0f62e15d3ddf39b552fb0746f02797eba934f3442254a20484  _output/bin/govmomi/linux-arm64/govc

--- a/projects/vmware/govmomi/patches/0001-Revert-zero-value-change-for-capacityInKB.patch
+++ b/projects/vmware/govmomi/patches/0001-Revert-zero-value-change-for-capacityInKB.patch
@@ -1,0 +1,25 @@
+From 1d7b9719b3716285fa0d6a876141447d85c52ac5 Mon Sep 17 00:00:00 2001
+From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
+Date: Wed, 15 May 2024 14:14:38 -0400
+Subject: [PATCH] Revert zero value change for capacityInKB
+
+---
+ govc/vm/disk/change.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/govc/vm/disk/change.go b/govc/vm/disk/change.go
+index d57b1bd4..1643a917 100644
+--- a/govc/vm/disk/change.go
++++ b/govc/vm/disk/change.go
+@@ -154,7 +154,7 @@ func (cmd *change) Run(ctx context.Context, f *flag.FlagSet) error {
+ 
+ 	if int64(cmd.bytes) != 0 {
+ 		editdisk.CapacityInBytes = int64(cmd.bytes)
+-		editdisk.CapacityInKB = int64(0) // zero deprecated field
++		editdisk.CapacityInKB = int64(cmd.bytes) / 1024
+ 	}
+ 
+ 	if editdisk.StorageIOAllocation == nil {
+-- 
+2.39.3 (Apple Git-146)
+


### PR DESCRIPTION
If the `capacityInKB` in the new virtual disk spec is zeroed out, it causes the following error when trying to reconfigure the VM disk size 
```console
govc: error resizing main disk
Logged Item:  Invalid operation for device '0'.
```
So we are adding a patch to set the `capacityInKB` to its actual value, converting from `capacityInBytes`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
