### PR TITLE
Add patch to force-delete Nutanix builder VMs

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0001-Force-delete-Nutanix-builder-VMs-on-failure.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0001-Force-delete-Nutanix-builder-VMs-on-failure.patch
@@ -1,0 +1,24 @@
+From f774d9a0df083f88e441b2b38d3b79616f98e789 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Mon, 20 May 2024 16:53:01 -0400
+Subject: [PATCH] Force-delete Nutanix builder VMs on failure
+
+---
+ images/capi/packer/nutanix/packer.json | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/images/capi/packer/nutanix/packer.json b/images/capi/packer/nutanix/packer.json
+index de9a4a43b..f46c8d8d2 100644
+--- a/images/capi/packer/nutanix/packer.json
++++ b/images/capi/packer/nutanix/packer.json
+@@ -165,6 +165,6 @@
+     "source_image_force": "false",
+     "ssh_password": "builder",
+     "ssh_username": "builder",
+-    "vm_force_delete": "false"
++    "vm_force_delete": "true"
+   }
+ }
+-- 
+2.39.3 (Apple Git-146)
+


### PR DESCRIPTION
Nutanix build failures leave behind running VMs on Nutanix Prism central, so this PR adds a patch that force-deletes these VMs even on failure. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
