### PR TITLE
Add retries in case of Nutanix image size mismatch

### DIFF
--- a/projects/kubernetes-sigs/image-builder/build/build_image.sh
+++ b/projects/kubernetes-sigs/image-builder/build/build_image.sh
@@ -55,7 +55,9 @@ function retry_image_builder() {
   declare -A retryable_messages=(
     ["Timeout waiting for IP."]="Failed waiting for IP"
     ["Timeout waiting for SSH"]="Wrong VM IP might be fetched"
-    ["Cancelling provisioner after a timeout"]="Provisioner timed out")
+    ["Cancelling provisioner after a timeout"]="Provisioner timed out"
+    ["image size mistmatch"]="Nutanix image size mismatch"
+  )
 
   until [ $n -eq $max ]; do
     failed="false"


### PR DESCRIPTION
Nutanix image builds sometimes fail with the flaky issue of image size mismatch. This PR adds a retry for the case when such a failure occurs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
