### PR TITLE
Update metrics-server helm chart to 3.12.1

### DIFF
--- a/projects/kubernetes-sigs/metrics-server/1-25/HELM_GIT_TAG
+++ b/projects/kubernetes-sigs/metrics-server/1-25/HELM_GIT_TAG
@@ -1,1 +1,1 @@
-metrics-server-helm-chart-3.11.0
+metrics-server-helm-chart-3.12.1

--- a/projects/kubernetes-sigs/metrics-server/1-25/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-25/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
@@ -1,4 +1,4 @@
-From 844bd83b083847ab7d388e2c5037acf111e2d8a0 Mon Sep 17 00:00:00 2001
+From 4f64a30a6e403f3ca720db3c4174fbf004607ad1 Mon Sep 17 00:00:00 2001
 From: Jonathan Meier <jwmeier@amazon.com>
 Date: Fri, 23 Sep 2022 12:17:23 -0400
 Subject: [PATCH 1/2] Conform helm chart to packages standards
@@ -13,7 +13,7 @@ Subject: [PATCH 1/2] Conform helm chart to packages standards
  6 files changed, 10 insertions(+), 10 deletions(-)
 
 diff --git a/charts/metrics-server/templates/_helpers.tpl b/charts/metrics-server/templates/_helpers.tpl
-index 9b87f11..492e462 100644
+index 9b87f118..492e4623 100644
 --- a/charts/metrics-server/templates/_helpers.tpl
 +++ b/charts/metrics-server/templates/_helpers.tpl
 @@ -68,7 +68,7 @@ Create the name of the service account to use
@@ -26,7 +26,7 @@ index 9b87f11..492e462 100644
  
  {{/*
 diff --git a/charts/metrics-server/templates/deployment.yaml b/charts/metrics-server/templates/deployment.yaml
-index 1d656fc..e80dc0f 100644
+index 48cda7fe..d12b5d2e 100644
 --- a/charts/metrics-server/templates/deployment.yaml
 +++ b/charts/metrics-server/templates/deployment.yaml
 @@ -2,7 +2,7 @@ apiVersion: apps/v1
@@ -39,7 +39,7 @@ index 1d656fc..e80dc0f 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
    {{- with .Values.deploymentAnnotations }}
 diff --git a/charts/metrics-server/templates/service.yaml b/charts/metrics-server/templates/service.yaml
-index d45bcf3..260134c 100644
+index d45bcf36..260134cd 100644
 --- a/charts/metrics-server/templates/service.yaml
 +++ b/charts/metrics-server/templates/service.yaml
 @@ -2,7 +2,7 @@ apiVersion: v1
@@ -52,7 +52,7 @@ index d45bcf3..260134c 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
    {{- with .Values.service.labels -}}
 diff --git a/charts/metrics-server/templates/serviceaccount.yaml b/charts/metrics-server/templates/serviceaccount.yaml
-index 80ef699..ce3bd0d 100644
+index 80ef6996..ce3bd0db 100644
 --- a/charts/metrics-server/templates/serviceaccount.yaml
 +++ b/charts/metrics-server/templates/serviceaccount.yaml
 @@ -3,7 +3,7 @@ apiVersion: v1
@@ -65,7 +65,7 @@ index 80ef699..ce3bd0d 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
    {{- with .Values.serviceAccount.annotations }}
 diff --git a/charts/metrics-server/templates/servicemonitor.yaml b/charts/metrics-server/templates/servicemonitor.yaml
-index 5c1c5b7..9e4c9ac 100644
+index 5c1c5b77..9e4c9acb 100644
 --- a/charts/metrics-server/templates/servicemonitor.yaml
 +++ b/charts/metrics-server/templates/servicemonitor.yaml
 @@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
@@ -78,7 +78,7 @@ index 5c1c5b7..9e4c9ac 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
      {{- with .Values.serviceMonitor.additionalLabels }}
 diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
-index fba10aa..38bea8c 100644
+index 4f6b9219..53324671 100644
 --- a/charts/metrics-server/values.yaml
 +++ b/charts/metrics-server/values.yaml
 @@ -2,14 +2,14 @@
@@ -102,5 +102,5 @@ index fba10aa..38bea8c 100644
  nameOverride: ""
  fullnameOverride: ""
 -- 
-2.39.3 (Apple Git-145)
+2.44.0
 

--- a/projects/kubernetes-sigs/metrics-server/1-25/helm/patches/0002-Remove-Addon-Resizer.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-25/helm/patches/0002-Remove-Addon-Resizer.patch
@@ -1,18 +1,18 @@
-From 9bb179b50087d0b0f7ed267e71b9106ad50c148e Mon Sep 17 00:00:00 2001
+From c0e41c2dd014793543a20439104d94c1b5c2510a Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
-Date: Thu, 30 Nov 2023 11:54:54 -0500
+Date: Sun, 2 Jun 2024 17:37:38 -0700
 Subject: [PATCH 2/2] Remove Addon Resizer
 
 ---
- charts/metrics-server/templates/_helpers.tpl  | 21 -----------
+ charts/metrics-server/templates/_helpers.tpl  | 21 ----------
  .../templates/clusterrole-nanny.yaml          | 13 -------
- .../templates/clusterrolebinding-nanny.yaml   | 18 ----------
- .../templates/configmaps-nanny.yaml           | 17 ---------
- .../metrics-server/templates/deployment.yaml  | 35 -------------------
- .../metrics-server/templates/role-nanny.yaml  | 27 --------------
- .../templates/rolebinding-nanny.yaml          | 19 ----------
- charts/metrics-server/values.yaml             | 24 -------------
- 8 files changed, 174 deletions(-)
+ .../templates/clusterrolebinding-nanny.yaml   | 18 ---------
+ .../templates/configmaps-nanny.yaml           | 17 --------
+ .../metrics-server/templates/deployment.yaml  | 39 -------------------
+ .../metrics-server/templates/role-nanny.yaml  | 27 -------------
+ .../templates/rolebinding-nanny.yaml          | 19 ---------
+ charts/metrics-server/values.yaml             | 34 ----------------
+ 8 files changed, 188 deletions(-)
  delete mode 100644 charts/metrics-server/templates/clusterrole-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/clusterrolebinding-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/configmaps-nanny.yaml
@@ -20,7 +20,7 @@ Subject: [PATCH 2/2] Remove Addon Resizer
  delete mode 100644 charts/metrics-server/templates/rolebinding-nanny.yaml
 
 diff --git a/charts/metrics-server/templates/_helpers.tpl b/charts/metrics-server/templates/_helpers.tpl
-index 492e462..e9b4728 100644
+index 492e4623..e9b47284 100644
 --- a/charts/metrics-server/templates/_helpers.tpl
 +++ b/charts/metrics-server/templates/_helpers.tpl
 @@ -71,27 +71,6 @@ The image to use
@@ -53,7 +53,7 @@ index 492e462..e9b4728 100644
    {{- if and (.Capabilities.APIVersions.Has "policy/v1") (semverCompare ">= 1.21-0" .Capabilities.KubeVersion.Version) -}}
 diff --git a/charts/metrics-server/templates/clusterrole-nanny.yaml b/charts/metrics-server/templates/clusterrole-nanny.yaml
 deleted file mode 100644
-index 24edd81..0000000
+index 24edd81c..00000000
 --- a/charts/metrics-server/templates/clusterrole-nanny.yaml
 +++ /dev/null
 @@ -1,13 +0,0 @@
@@ -72,7 +72,7 @@ index 24edd81..0000000
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/clusterrolebinding-nanny.yaml b/charts/metrics-server/templates/clusterrolebinding-nanny.yaml
 deleted file mode 100644
-index 43738cc..0000000
+index 43738ccb..00000000
 --- a/charts/metrics-server/templates/clusterrolebinding-nanny.yaml
 +++ /dev/null
 @@ -1,18 +0,0 @@
@@ -96,7 +96,7 @@ index 43738cc..0000000
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/configmaps-nanny.yaml b/charts/metrics-server/templates/configmaps-nanny.yaml
 deleted file mode 100644
-index c25005e..0000000
+index c25005ec..00000000
 --- a/charts/metrics-server/templates/configmaps-nanny.yaml
 +++ /dev/null
 @@ -1,17 +0,0 @@
@@ -118,15 +118,19 @@ index c25005e..0000000
 -    memoryPerNode: {{ .Values.addonResizer.nanny.extraMemory }}
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/deployment.yaml b/charts/metrics-server/templates/deployment.yaml
-index e80dc0f..0128e28 100644
+index d12b5d2e..209ac328 100644
 --- a/charts/metrics-server/templates/deployment.yaml
 +++ b/charts/metrics-server/templates/deployment.yaml
-@@ -87,44 +87,9 @@ spec:
+@@ -94,48 +94,9 @@ spec:
            resources:
              {{- toYaml . | nindent 12 }}
            {{- end }}
 -        {{- if .Values.addonResizer.enabled }}
 -        - name: metrics-server-nanny
+-          {{- with .Values.addonResizer.securityContext }}
+-          securityContext:
+-            {{- toYaml . | nindent 12 }}
+-          {{- end }}
 -          image: {{ include "metrics-server.addonResizer.image" . }}
 -          env:
 -            - name: MY_POD_NAME
@@ -157,7 +161,7 @@ index e80dc0f..0128e28 100644
 -        {{- end }}
        volumes:
          - name: tmp
-           emptyDir: {}
+           {{- toYaml .Values.tmpVolume | nindent 10 }}
 -      {{- if .Values.addonResizer.enabled }}
 -        - name: nanny-config-volume
 -          configMap:
@@ -168,7 +172,7 @@ index e80dc0f..0128e28 100644
        {{- end }}
 diff --git a/charts/metrics-server/templates/role-nanny.yaml b/charts/metrics-server/templates/role-nanny.yaml
 deleted file mode 100644
-index f0bf8fc..0000000
+index f0bf8fce..00000000
 --- a/charts/metrics-server/templates/role-nanny.yaml
 +++ /dev/null
 @@ -1,27 +0,0 @@
@@ -201,7 +205,7 @@ index f0bf8fc..0000000
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/rolebinding-nanny.yaml b/charts/metrics-server/templates/rolebinding-nanny.yaml
 deleted file mode 100644
-index 73bfaaf..0000000
+index 73bfaaff..00000000
 --- a/charts/metrics-server/templates/rolebinding-nanny.yaml
 +++ /dev/null
 @@ -1,19 +0,0 @@
@@ -225,10 +229,10 @@ index 73bfaaf..0000000
 -{{- end -}}
 -{{- end -}}
 diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
-index 38bea8c..5f12132 100644
+index 53324671..42270159 100644
 --- a/charts/metrics-server/values.yaml
 +++ b/charts/metrics-server/values.yaml
-@@ -123,27 +123,6 @@ service:
+@@ -125,37 +125,6 @@ service:
    #  kubernetes.io/cluster-service: "true"
    #  kubernetes.io/name: "Metrics-server"
  
@@ -236,7 +240,17 @@ index 38bea8c..5f12132 100644
 -  enabled: false
 -  image:
 -    repository: registry.k8s.io/autoscaling/addon-resizer
--    tag: 1.8.19
+-    tag: 1.8.20
+-  securityContext:
+-    allowPrivilegeEscalation: false
+-    readOnlyRootFilesystem: true
+-    runAsNonRoot: true
+-    runAsUser: 1000
+-    seccompProfile:
+-      type: RuntimeDefault
+-    capabilities:
+-      drop:
+-        - ALL
 -  resources:
 -    requests:
 -      cpu: 40m
@@ -256,7 +270,7 @@ index 38bea8c..5f12132 100644
  metrics:
    enabled: false
  
-@@ -160,9 +139,6 @@ resources:
+@@ -172,9 +141,6 @@ resources:
    requests:
      cpu: 100m
      memory: 200Mi
@@ -267,5 +281,5 @@ index 38bea8c..5f12132 100644
  extraVolumeMounts: []
  
 -- 
-2.39.3 (Apple Git-145)
+2.44.0
 

--- a/projects/kubernetes-sigs/metrics-server/1-26/HELM_GIT_TAG
+++ b/projects/kubernetes-sigs/metrics-server/1-26/HELM_GIT_TAG
@@ -1,1 +1,1 @@
-metrics-server-helm-chart-3.11.0
+metrics-server-helm-chart-3.12.1

--- a/projects/kubernetes-sigs/metrics-server/1-26/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-26/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
@@ -1,4 +1,4 @@
-From 844bd83b083847ab7d388e2c5037acf111e2d8a0 Mon Sep 17 00:00:00 2001
+From 4f64a30a6e403f3ca720db3c4174fbf004607ad1 Mon Sep 17 00:00:00 2001
 From: Jonathan Meier <jwmeier@amazon.com>
 Date: Fri, 23 Sep 2022 12:17:23 -0400
 Subject: [PATCH 1/2] Conform helm chart to packages standards
@@ -13,7 +13,7 @@ Subject: [PATCH 1/2] Conform helm chart to packages standards
  6 files changed, 10 insertions(+), 10 deletions(-)
 
 diff --git a/charts/metrics-server/templates/_helpers.tpl b/charts/metrics-server/templates/_helpers.tpl
-index 9b87f11..492e462 100644
+index 9b87f118..492e4623 100644
 --- a/charts/metrics-server/templates/_helpers.tpl
 +++ b/charts/metrics-server/templates/_helpers.tpl
 @@ -68,7 +68,7 @@ Create the name of the service account to use
@@ -26,7 +26,7 @@ index 9b87f11..492e462 100644
  
  {{/*
 diff --git a/charts/metrics-server/templates/deployment.yaml b/charts/metrics-server/templates/deployment.yaml
-index 1d656fc..e80dc0f 100644
+index 48cda7fe..d12b5d2e 100644
 --- a/charts/metrics-server/templates/deployment.yaml
 +++ b/charts/metrics-server/templates/deployment.yaml
 @@ -2,7 +2,7 @@ apiVersion: apps/v1
@@ -39,7 +39,7 @@ index 1d656fc..e80dc0f 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
    {{- with .Values.deploymentAnnotations }}
 diff --git a/charts/metrics-server/templates/service.yaml b/charts/metrics-server/templates/service.yaml
-index d45bcf3..260134c 100644
+index d45bcf36..260134cd 100644
 --- a/charts/metrics-server/templates/service.yaml
 +++ b/charts/metrics-server/templates/service.yaml
 @@ -2,7 +2,7 @@ apiVersion: v1
@@ -52,7 +52,7 @@ index d45bcf3..260134c 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
    {{- with .Values.service.labels -}}
 diff --git a/charts/metrics-server/templates/serviceaccount.yaml b/charts/metrics-server/templates/serviceaccount.yaml
-index 80ef699..ce3bd0d 100644
+index 80ef6996..ce3bd0db 100644
 --- a/charts/metrics-server/templates/serviceaccount.yaml
 +++ b/charts/metrics-server/templates/serviceaccount.yaml
 @@ -3,7 +3,7 @@ apiVersion: v1
@@ -65,7 +65,7 @@ index 80ef699..ce3bd0d 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
    {{- with .Values.serviceAccount.annotations }}
 diff --git a/charts/metrics-server/templates/servicemonitor.yaml b/charts/metrics-server/templates/servicemonitor.yaml
-index 5c1c5b7..9e4c9ac 100644
+index 5c1c5b77..9e4c9acb 100644
 --- a/charts/metrics-server/templates/servicemonitor.yaml
 +++ b/charts/metrics-server/templates/servicemonitor.yaml
 @@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
@@ -78,7 +78,7 @@ index 5c1c5b7..9e4c9ac 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
      {{- with .Values.serviceMonitor.additionalLabels }}
 diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
-index fba10aa..38bea8c 100644
+index 4f6b9219..53324671 100644
 --- a/charts/metrics-server/values.yaml
 +++ b/charts/metrics-server/values.yaml
 @@ -2,14 +2,14 @@
@@ -102,5 +102,5 @@ index fba10aa..38bea8c 100644
  nameOverride: ""
  fullnameOverride: ""
 -- 
-2.39.3 (Apple Git-145)
+2.44.0
 

--- a/projects/kubernetes-sigs/metrics-server/1-26/helm/patches/0002-Remove-Addon-Resizer.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-26/helm/patches/0002-Remove-Addon-Resizer.patch
@@ -1,18 +1,18 @@
-From 9bb179b50087d0b0f7ed267e71b9106ad50c148e Mon Sep 17 00:00:00 2001
+From c0e41c2dd014793543a20439104d94c1b5c2510a Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
-Date: Thu, 30 Nov 2023 11:54:54 -0500
+Date: Sun, 2 Jun 2024 17:37:38 -0700
 Subject: [PATCH 2/2] Remove Addon Resizer
 
 ---
- charts/metrics-server/templates/_helpers.tpl  | 21 -----------
+ charts/metrics-server/templates/_helpers.tpl  | 21 ----------
  .../templates/clusterrole-nanny.yaml          | 13 -------
- .../templates/clusterrolebinding-nanny.yaml   | 18 ----------
- .../templates/configmaps-nanny.yaml           | 17 ---------
- .../metrics-server/templates/deployment.yaml  | 35 -------------------
- .../metrics-server/templates/role-nanny.yaml  | 27 --------------
- .../templates/rolebinding-nanny.yaml          | 19 ----------
- charts/metrics-server/values.yaml             | 24 -------------
- 8 files changed, 174 deletions(-)
+ .../templates/clusterrolebinding-nanny.yaml   | 18 ---------
+ .../templates/configmaps-nanny.yaml           | 17 --------
+ .../metrics-server/templates/deployment.yaml  | 39 -------------------
+ .../metrics-server/templates/role-nanny.yaml  | 27 -------------
+ .../templates/rolebinding-nanny.yaml          | 19 ---------
+ charts/metrics-server/values.yaml             | 34 ----------------
+ 8 files changed, 188 deletions(-)
  delete mode 100644 charts/metrics-server/templates/clusterrole-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/clusterrolebinding-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/configmaps-nanny.yaml
@@ -20,7 +20,7 @@ Subject: [PATCH 2/2] Remove Addon Resizer
  delete mode 100644 charts/metrics-server/templates/rolebinding-nanny.yaml
 
 diff --git a/charts/metrics-server/templates/_helpers.tpl b/charts/metrics-server/templates/_helpers.tpl
-index 492e462..e9b4728 100644
+index 492e4623..e9b47284 100644
 --- a/charts/metrics-server/templates/_helpers.tpl
 +++ b/charts/metrics-server/templates/_helpers.tpl
 @@ -71,27 +71,6 @@ The image to use
@@ -53,7 +53,7 @@ index 492e462..e9b4728 100644
    {{- if and (.Capabilities.APIVersions.Has "policy/v1") (semverCompare ">= 1.21-0" .Capabilities.KubeVersion.Version) -}}
 diff --git a/charts/metrics-server/templates/clusterrole-nanny.yaml b/charts/metrics-server/templates/clusterrole-nanny.yaml
 deleted file mode 100644
-index 24edd81..0000000
+index 24edd81c..00000000
 --- a/charts/metrics-server/templates/clusterrole-nanny.yaml
 +++ /dev/null
 @@ -1,13 +0,0 @@
@@ -72,7 +72,7 @@ index 24edd81..0000000
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/clusterrolebinding-nanny.yaml b/charts/metrics-server/templates/clusterrolebinding-nanny.yaml
 deleted file mode 100644
-index 43738cc..0000000
+index 43738ccb..00000000
 --- a/charts/metrics-server/templates/clusterrolebinding-nanny.yaml
 +++ /dev/null
 @@ -1,18 +0,0 @@
@@ -96,7 +96,7 @@ index 43738cc..0000000
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/configmaps-nanny.yaml b/charts/metrics-server/templates/configmaps-nanny.yaml
 deleted file mode 100644
-index c25005e..0000000
+index c25005ec..00000000
 --- a/charts/metrics-server/templates/configmaps-nanny.yaml
 +++ /dev/null
 @@ -1,17 +0,0 @@
@@ -118,15 +118,19 @@ index c25005e..0000000
 -    memoryPerNode: {{ .Values.addonResizer.nanny.extraMemory }}
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/deployment.yaml b/charts/metrics-server/templates/deployment.yaml
-index e80dc0f..0128e28 100644
+index d12b5d2e..209ac328 100644
 --- a/charts/metrics-server/templates/deployment.yaml
 +++ b/charts/metrics-server/templates/deployment.yaml
-@@ -87,44 +87,9 @@ spec:
+@@ -94,48 +94,9 @@ spec:
            resources:
              {{- toYaml . | nindent 12 }}
            {{- end }}
 -        {{- if .Values.addonResizer.enabled }}
 -        - name: metrics-server-nanny
+-          {{- with .Values.addonResizer.securityContext }}
+-          securityContext:
+-            {{- toYaml . | nindent 12 }}
+-          {{- end }}
 -          image: {{ include "metrics-server.addonResizer.image" . }}
 -          env:
 -            - name: MY_POD_NAME
@@ -157,7 +161,7 @@ index e80dc0f..0128e28 100644
 -        {{- end }}
        volumes:
          - name: tmp
-           emptyDir: {}
+           {{- toYaml .Values.tmpVolume | nindent 10 }}
 -      {{- if .Values.addonResizer.enabled }}
 -        - name: nanny-config-volume
 -          configMap:
@@ -168,7 +172,7 @@ index e80dc0f..0128e28 100644
        {{- end }}
 diff --git a/charts/metrics-server/templates/role-nanny.yaml b/charts/metrics-server/templates/role-nanny.yaml
 deleted file mode 100644
-index f0bf8fc..0000000
+index f0bf8fce..00000000
 --- a/charts/metrics-server/templates/role-nanny.yaml
 +++ /dev/null
 @@ -1,27 +0,0 @@
@@ -201,7 +205,7 @@ index f0bf8fc..0000000
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/rolebinding-nanny.yaml b/charts/metrics-server/templates/rolebinding-nanny.yaml
 deleted file mode 100644
-index 73bfaaf..0000000
+index 73bfaaff..00000000
 --- a/charts/metrics-server/templates/rolebinding-nanny.yaml
 +++ /dev/null
 @@ -1,19 +0,0 @@
@@ -225,10 +229,10 @@ index 73bfaaf..0000000
 -{{- end -}}
 -{{- end -}}
 diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
-index 38bea8c..5f12132 100644
+index 53324671..42270159 100644
 --- a/charts/metrics-server/values.yaml
 +++ b/charts/metrics-server/values.yaml
-@@ -123,27 +123,6 @@ service:
+@@ -125,37 +125,6 @@ service:
    #  kubernetes.io/cluster-service: "true"
    #  kubernetes.io/name: "Metrics-server"
  
@@ -236,7 +240,17 @@ index 38bea8c..5f12132 100644
 -  enabled: false
 -  image:
 -    repository: registry.k8s.io/autoscaling/addon-resizer
--    tag: 1.8.19
+-    tag: 1.8.20
+-  securityContext:
+-    allowPrivilegeEscalation: false
+-    readOnlyRootFilesystem: true
+-    runAsNonRoot: true
+-    runAsUser: 1000
+-    seccompProfile:
+-      type: RuntimeDefault
+-    capabilities:
+-      drop:
+-        - ALL
 -  resources:
 -    requests:
 -      cpu: 40m
@@ -256,7 +270,7 @@ index 38bea8c..5f12132 100644
  metrics:
    enabled: false
  
-@@ -160,9 +139,6 @@ resources:
+@@ -172,9 +141,6 @@ resources:
    requests:
      cpu: 100m
      memory: 200Mi
@@ -267,5 +281,5 @@ index 38bea8c..5f12132 100644
  extraVolumeMounts: []
  
 -- 
-2.39.3 (Apple Git-145)
+2.44.0
 

--- a/projects/kubernetes-sigs/metrics-server/1-27/HELM_GIT_TAG
+++ b/projects/kubernetes-sigs/metrics-server/1-27/HELM_GIT_TAG
@@ -1,1 +1,1 @@
-metrics-server-helm-chart-3.11.0
+metrics-server-helm-chart-3.12.1

--- a/projects/kubernetes-sigs/metrics-server/1-27/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-27/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
@@ -1,4 +1,4 @@
-From 844bd83b083847ab7d388e2c5037acf111e2d8a0 Mon Sep 17 00:00:00 2001
+From 4f64a30a6e403f3ca720db3c4174fbf004607ad1 Mon Sep 17 00:00:00 2001
 From: Jonathan Meier <jwmeier@amazon.com>
 Date: Fri, 23 Sep 2022 12:17:23 -0400
 Subject: [PATCH 1/2] Conform helm chart to packages standards
@@ -13,7 +13,7 @@ Subject: [PATCH 1/2] Conform helm chart to packages standards
  6 files changed, 10 insertions(+), 10 deletions(-)
 
 diff --git a/charts/metrics-server/templates/_helpers.tpl b/charts/metrics-server/templates/_helpers.tpl
-index 9b87f11..492e462 100644
+index 9b87f118..492e4623 100644
 --- a/charts/metrics-server/templates/_helpers.tpl
 +++ b/charts/metrics-server/templates/_helpers.tpl
 @@ -68,7 +68,7 @@ Create the name of the service account to use
@@ -26,7 +26,7 @@ index 9b87f11..492e462 100644
  
  {{/*
 diff --git a/charts/metrics-server/templates/deployment.yaml b/charts/metrics-server/templates/deployment.yaml
-index 1d656fc..e80dc0f 100644
+index 48cda7fe..d12b5d2e 100644
 --- a/charts/metrics-server/templates/deployment.yaml
 +++ b/charts/metrics-server/templates/deployment.yaml
 @@ -2,7 +2,7 @@ apiVersion: apps/v1
@@ -39,7 +39,7 @@ index 1d656fc..e80dc0f 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
    {{- with .Values.deploymentAnnotations }}
 diff --git a/charts/metrics-server/templates/service.yaml b/charts/metrics-server/templates/service.yaml
-index d45bcf3..260134c 100644
+index d45bcf36..260134cd 100644
 --- a/charts/metrics-server/templates/service.yaml
 +++ b/charts/metrics-server/templates/service.yaml
 @@ -2,7 +2,7 @@ apiVersion: v1
@@ -52,7 +52,7 @@ index d45bcf3..260134c 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
    {{- with .Values.service.labels -}}
 diff --git a/charts/metrics-server/templates/serviceaccount.yaml b/charts/metrics-server/templates/serviceaccount.yaml
-index 80ef699..ce3bd0d 100644
+index 80ef6996..ce3bd0db 100644
 --- a/charts/metrics-server/templates/serviceaccount.yaml
 +++ b/charts/metrics-server/templates/serviceaccount.yaml
 @@ -3,7 +3,7 @@ apiVersion: v1
@@ -65,7 +65,7 @@ index 80ef699..ce3bd0d 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
    {{- with .Values.serviceAccount.annotations }}
 diff --git a/charts/metrics-server/templates/servicemonitor.yaml b/charts/metrics-server/templates/servicemonitor.yaml
-index 5c1c5b7..9e4c9ac 100644
+index 5c1c5b77..9e4c9acb 100644
 --- a/charts/metrics-server/templates/servicemonitor.yaml
 +++ b/charts/metrics-server/templates/servicemonitor.yaml
 @@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
@@ -78,7 +78,7 @@ index 5c1c5b7..9e4c9ac 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
      {{- with .Values.serviceMonitor.additionalLabels }}
 diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
-index fba10aa..38bea8c 100644
+index 4f6b9219..53324671 100644
 --- a/charts/metrics-server/values.yaml
 +++ b/charts/metrics-server/values.yaml
 @@ -2,14 +2,14 @@
@@ -102,5 +102,5 @@ index fba10aa..38bea8c 100644
  nameOverride: ""
  fullnameOverride: ""
 -- 
-2.39.3 (Apple Git-145)
+2.44.0
 

--- a/projects/kubernetes-sigs/metrics-server/1-27/helm/patches/0002-Remove-Addon-Resizer.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-27/helm/patches/0002-Remove-Addon-Resizer.patch
@@ -1,18 +1,18 @@
-From 9bb179b50087d0b0f7ed267e71b9106ad50c148e Mon Sep 17 00:00:00 2001
+From c0e41c2dd014793543a20439104d94c1b5c2510a Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
-Date: Thu, 30 Nov 2023 11:54:54 -0500
+Date: Sun, 2 Jun 2024 17:37:38 -0700
 Subject: [PATCH 2/2] Remove Addon Resizer
 
 ---
- charts/metrics-server/templates/_helpers.tpl  | 21 -----------
+ charts/metrics-server/templates/_helpers.tpl  | 21 ----------
  .../templates/clusterrole-nanny.yaml          | 13 -------
- .../templates/clusterrolebinding-nanny.yaml   | 18 ----------
- .../templates/configmaps-nanny.yaml           | 17 ---------
- .../metrics-server/templates/deployment.yaml  | 35 -------------------
- .../metrics-server/templates/role-nanny.yaml  | 27 --------------
- .../templates/rolebinding-nanny.yaml          | 19 ----------
- charts/metrics-server/values.yaml             | 24 -------------
- 8 files changed, 174 deletions(-)
+ .../templates/clusterrolebinding-nanny.yaml   | 18 ---------
+ .../templates/configmaps-nanny.yaml           | 17 --------
+ .../metrics-server/templates/deployment.yaml  | 39 -------------------
+ .../metrics-server/templates/role-nanny.yaml  | 27 -------------
+ .../templates/rolebinding-nanny.yaml          | 19 ---------
+ charts/metrics-server/values.yaml             | 34 ----------------
+ 8 files changed, 188 deletions(-)
  delete mode 100644 charts/metrics-server/templates/clusterrole-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/clusterrolebinding-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/configmaps-nanny.yaml
@@ -20,7 +20,7 @@ Subject: [PATCH 2/2] Remove Addon Resizer
  delete mode 100644 charts/metrics-server/templates/rolebinding-nanny.yaml
 
 diff --git a/charts/metrics-server/templates/_helpers.tpl b/charts/metrics-server/templates/_helpers.tpl
-index 492e462..e9b4728 100644
+index 492e4623..e9b47284 100644
 --- a/charts/metrics-server/templates/_helpers.tpl
 +++ b/charts/metrics-server/templates/_helpers.tpl
 @@ -71,27 +71,6 @@ The image to use
@@ -53,7 +53,7 @@ index 492e462..e9b4728 100644
    {{- if and (.Capabilities.APIVersions.Has "policy/v1") (semverCompare ">= 1.21-0" .Capabilities.KubeVersion.Version) -}}
 diff --git a/charts/metrics-server/templates/clusterrole-nanny.yaml b/charts/metrics-server/templates/clusterrole-nanny.yaml
 deleted file mode 100644
-index 24edd81..0000000
+index 24edd81c..00000000
 --- a/charts/metrics-server/templates/clusterrole-nanny.yaml
 +++ /dev/null
 @@ -1,13 +0,0 @@
@@ -72,7 +72,7 @@ index 24edd81..0000000
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/clusterrolebinding-nanny.yaml b/charts/metrics-server/templates/clusterrolebinding-nanny.yaml
 deleted file mode 100644
-index 43738cc..0000000
+index 43738ccb..00000000
 --- a/charts/metrics-server/templates/clusterrolebinding-nanny.yaml
 +++ /dev/null
 @@ -1,18 +0,0 @@
@@ -96,7 +96,7 @@ index 43738cc..0000000
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/configmaps-nanny.yaml b/charts/metrics-server/templates/configmaps-nanny.yaml
 deleted file mode 100644
-index c25005e..0000000
+index c25005ec..00000000
 --- a/charts/metrics-server/templates/configmaps-nanny.yaml
 +++ /dev/null
 @@ -1,17 +0,0 @@
@@ -118,15 +118,19 @@ index c25005e..0000000
 -    memoryPerNode: {{ .Values.addonResizer.nanny.extraMemory }}
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/deployment.yaml b/charts/metrics-server/templates/deployment.yaml
-index e80dc0f..0128e28 100644
+index d12b5d2e..209ac328 100644
 --- a/charts/metrics-server/templates/deployment.yaml
 +++ b/charts/metrics-server/templates/deployment.yaml
-@@ -87,44 +87,9 @@ spec:
+@@ -94,48 +94,9 @@ spec:
            resources:
              {{- toYaml . | nindent 12 }}
            {{- end }}
 -        {{- if .Values.addonResizer.enabled }}
 -        - name: metrics-server-nanny
+-          {{- with .Values.addonResizer.securityContext }}
+-          securityContext:
+-            {{- toYaml . | nindent 12 }}
+-          {{- end }}
 -          image: {{ include "metrics-server.addonResizer.image" . }}
 -          env:
 -            - name: MY_POD_NAME
@@ -157,7 +161,7 @@ index e80dc0f..0128e28 100644
 -        {{- end }}
        volumes:
          - name: tmp
-           emptyDir: {}
+           {{- toYaml .Values.tmpVolume | nindent 10 }}
 -      {{- if .Values.addonResizer.enabled }}
 -        - name: nanny-config-volume
 -          configMap:
@@ -168,7 +172,7 @@ index e80dc0f..0128e28 100644
        {{- end }}
 diff --git a/charts/metrics-server/templates/role-nanny.yaml b/charts/metrics-server/templates/role-nanny.yaml
 deleted file mode 100644
-index f0bf8fc..0000000
+index f0bf8fce..00000000
 --- a/charts/metrics-server/templates/role-nanny.yaml
 +++ /dev/null
 @@ -1,27 +0,0 @@
@@ -201,7 +205,7 @@ index f0bf8fc..0000000
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/rolebinding-nanny.yaml b/charts/metrics-server/templates/rolebinding-nanny.yaml
 deleted file mode 100644
-index 73bfaaf..0000000
+index 73bfaaff..00000000
 --- a/charts/metrics-server/templates/rolebinding-nanny.yaml
 +++ /dev/null
 @@ -1,19 +0,0 @@
@@ -225,10 +229,10 @@ index 73bfaaf..0000000
 -{{- end -}}
 -{{- end -}}
 diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
-index 38bea8c..5f12132 100644
+index 53324671..42270159 100644
 --- a/charts/metrics-server/values.yaml
 +++ b/charts/metrics-server/values.yaml
-@@ -123,27 +123,6 @@ service:
+@@ -125,37 +125,6 @@ service:
    #  kubernetes.io/cluster-service: "true"
    #  kubernetes.io/name: "Metrics-server"
  
@@ -236,7 +240,17 @@ index 38bea8c..5f12132 100644
 -  enabled: false
 -  image:
 -    repository: registry.k8s.io/autoscaling/addon-resizer
--    tag: 1.8.19
+-    tag: 1.8.20
+-  securityContext:
+-    allowPrivilegeEscalation: false
+-    readOnlyRootFilesystem: true
+-    runAsNonRoot: true
+-    runAsUser: 1000
+-    seccompProfile:
+-      type: RuntimeDefault
+-    capabilities:
+-      drop:
+-        - ALL
 -  resources:
 -    requests:
 -      cpu: 40m
@@ -256,7 +270,7 @@ index 38bea8c..5f12132 100644
  metrics:
    enabled: false
  
-@@ -160,9 +139,6 @@ resources:
+@@ -172,9 +141,6 @@ resources:
    requests:
      cpu: 100m
      memory: 200Mi
@@ -267,5 +281,5 @@ index 38bea8c..5f12132 100644
  extraVolumeMounts: []
  
 -- 
-2.39.3 (Apple Git-145)
+2.44.0
 

--- a/projects/kubernetes-sigs/metrics-server/1-28/HELM_GIT_TAG
+++ b/projects/kubernetes-sigs/metrics-server/1-28/HELM_GIT_TAG
@@ -1,1 +1,1 @@
-metrics-server-helm-chart-3.11.0
+metrics-server-helm-chart-3.12.1

--- a/projects/kubernetes-sigs/metrics-server/1-28/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-28/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
@@ -1,4 +1,4 @@
-From 844bd83b083847ab7d388e2c5037acf111e2d8a0 Mon Sep 17 00:00:00 2001
+From 4f64a30a6e403f3ca720db3c4174fbf004607ad1 Mon Sep 17 00:00:00 2001
 From: Jonathan Meier <jwmeier@amazon.com>
 Date: Fri, 23 Sep 2022 12:17:23 -0400
 Subject: [PATCH 1/2] Conform helm chart to packages standards
@@ -13,7 +13,7 @@ Subject: [PATCH 1/2] Conform helm chart to packages standards
  6 files changed, 10 insertions(+), 10 deletions(-)
 
 diff --git a/charts/metrics-server/templates/_helpers.tpl b/charts/metrics-server/templates/_helpers.tpl
-index 9b87f11..492e462 100644
+index 9b87f118..492e4623 100644
 --- a/charts/metrics-server/templates/_helpers.tpl
 +++ b/charts/metrics-server/templates/_helpers.tpl
 @@ -68,7 +68,7 @@ Create the name of the service account to use
@@ -26,7 +26,7 @@ index 9b87f11..492e462 100644
  
  {{/*
 diff --git a/charts/metrics-server/templates/deployment.yaml b/charts/metrics-server/templates/deployment.yaml
-index 1d656fc..e80dc0f 100644
+index 48cda7fe..d12b5d2e 100644
 --- a/charts/metrics-server/templates/deployment.yaml
 +++ b/charts/metrics-server/templates/deployment.yaml
 @@ -2,7 +2,7 @@ apiVersion: apps/v1
@@ -39,7 +39,7 @@ index 1d656fc..e80dc0f 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
    {{- with .Values.deploymentAnnotations }}
 diff --git a/charts/metrics-server/templates/service.yaml b/charts/metrics-server/templates/service.yaml
-index d45bcf3..260134c 100644
+index d45bcf36..260134cd 100644
 --- a/charts/metrics-server/templates/service.yaml
 +++ b/charts/metrics-server/templates/service.yaml
 @@ -2,7 +2,7 @@ apiVersion: v1
@@ -52,7 +52,7 @@ index d45bcf3..260134c 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
    {{- with .Values.service.labels -}}
 diff --git a/charts/metrics-server/templates/serviceaccount.yaml b/charts/metrics-server/templates/serviceaccount.yaml
-index 80ef699..ce3bd0d 100644
+index 80ef6996..ce3bd0db 100644
 --- a/charts/metrics-server/templates/serviceaccount.yaml
 +++ b/charts/metrics-server/templates/serviceaccount.yaml
 @@ -3,7 +3,7 @@ apiVersion: v1
@@ -65,7 +65,7 @@ index 80ef699..ce3bd0d 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
    {{- with .Values.serviceAccount.annotations }}
 diff --git a/charts/metrics-server/templates/servicemonitor.yaml b/charts/metrics-server/templates/servicemonitor.yaml
-index 5c1c5b7..9e4c9ac 100644
+index 5c1c5b77..9e4c9acb 100644
 --- a/charts/metrics-server/templates/servicemonitor.yaml
 +++ b/charts/metrics-server/templates/servicemonitor.yaml
 @@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
@@ -78,7 +78,7 @@ index 5c1c5b7..9e4c9ac 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
      {{- with .Values.serviceMonitor.additionalLabels }}
 diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
-index fba10aa..38bea8c 100644
+index 4f6b9219..53324671 100644
 --- a/charts/metrics-server/values.yaml
 +++ b/charts/metrics-server/values.yaml
 @@ -2,14 +2,14 @@
@@ -102,5 +102,5 @@ index fba10aa..38bea8c 100644
  nameOverride: ""
  fullnameOverride: ""
 -- 
-2.39.3 (Apple Git-145)
+2.44.0
 

--- a/projects/kubernetes-sigs/metrics-server/1-28/helm/patches/0002-Remove-Addon-Resizer.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-28/helm/patches/0002-Remove-Addon-Resizer.patch
@@ -1,18 +1,18 @@
-From 9bb179b50087d0b0f7ed267e71b9106ad50c148e Mon Sep 17 00:00:00 2001
+From c0e41c2dd014793543a20439104d94c1b5c2510a Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
-Date: Thu, 30 Nov 2023 11:54:54 -0500
+Date: Sun, 2 Jun 2024 17:37:38 -0700
 Subject: [PATCH 2/2] Remove Addon Resizer
 
 ---
- charts/metrics-server/templates/_helpers.tpl  | 21 -----------
+ charts/metrics-server/templates/_helpers.tpl  | 21 ----------
  .../templates/clusterrole-nanny.yaml          | 13 -------
- .../templates/clusterrolebinding-nanny.yaml   | 18 ----------
- .../templates/configmaps-nanny.yaml           | 17 ---------
- .../metrics-server/templates/deployment.yaml  | 35 -------------------
- .../metrics-server/templates/role-nanny.yaml  | 27 --------------
- .../templates/rolebinding-nanny.yaml          | 19 ----------
- charts/metrics-server/values.yaml             | 24 -------------
- 8 files changed, 174 deletions(-)
+ .../templates/clusterrolebinding-nanny.yaml   | 18 ---------
+ .../templates/configmaps-nanny.yaml           | 17 --------
+ .../metrics-server/templates/deployment.yaml  | 39 -------------------
+ .../metrics-server/templates/role-nanny.yaml  | 27 -------------
+ .../templates/rolebinding-nanny.yaml          | 19 ---------
+ charts/metrics-server/values.yaml             | 34 ----------------
+ 8 files changed, 188 deletions(-)
  delete mode 100644 charts/metrics-server/templates/clusterrole-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/clusterrolebinding-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/configmaps-nanny.yaml
@@ -20,7 +20,7 @@ Subject: [PATCH 2/2] Remove Addon Resizer
  delete mode 100644 charts/metrics-server/templates/rolebinding-nanny.yaml
 
 diff --git a/charts/metrics-server/templates/_helpers.tpl b/charts/metrics-server/templates/_helpers.tpl
-index 492e462..e9b4728 100644
+index 492e4623..e9b47284 100644
 --- a/charts/metrics-server/templates/_helpers.tpl
 +++ b/charts/metrics-server/templates/_helpers.tpl
 @@ -71,27 +71,6 @@ The image to use
@@ -53,7 +53,7 @@ index 492e462..e9b4728 100644
    {{- if and (.Capabilities.APIVersions.Has "policy/v1") (semverCompare ">= 1.21-0" .Capabilities.KubeVersion.Version) -}}
 diff --git a/charts/metrics-server/templates/clusterrole-nanny.yaml b/charts/metrics-server/templates/clusterrole-nanny.yaml
 deleted file mode 100644
-index 24edd81..0000000
+index 24edd81c..00000000
 --- a/charts/metrics-server/templates/clusterrole-nanny.yaml
 +++ /dev/null
 @@ -1,13 +0,0 @@
@@ -72,7 +72,7 @@ index 24edd81..0000000
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/clusterrolebinding-nanny.yaml b/charts/metrics-server/templates/clusterrolebinding-nanny.yaml
 deleted file mode 100644
-index 43738cc..0000000
+index 43738ccb..00000000
 --- a/charts/metrics-server/templates/clusterrolebinding-nanny.yaml
 +++ /dev/null
 @@ -1,18 +0,0 @@
@@ -96,7 +96,7 @@ index 43738cc..0000000
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/configmaps-nanny.yaml b/charts/metrics-server/templates/configmaps-nanny.yaml
 deleted file mode 100644
-index c25005e..0000000
+index c25005ec..00000000
 --- a/charts/metrics-server/templates/configmaps-nanny.yaml
 +++ /dev/null
 @@ -1,17 +0,0 @@
@@ -118,15 +118,19 @@ index c25005e..0000000
 -    memoryPerNode: {{ .Values.addonResizer.nanny.extraMemory }}
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/deployment.yaml b/charts/metrics-server/templates/deployment.yaml
-index e80dc0f..0128e28 100644
+index d12b5d2e..209ac328 100644
 --- a/charts/metrics-server/templates/deployment.yaml
 +++ b/charts/metrics-server/templates/deployment.yaml
-@@ -87,44 +87,9 @@ spec:
+@@ -94,48 +94,9 @@ spec:
            resources:
              {{- toYaml . | nindent 12 }}
            {{- end }}
 -        {{- if .Values.addonResizer.enabled }}
 -        - name: metrics-server-nanny
+-          {{- with .Values.addonResizer.securityContext }}
+-          securityContext:
+-            {{- toYaml . | nindent 12 }}
+-          {{- end }}
 -          image: {{ include "metrics-server.addonResizer.image" . }}
 -          env:
 -            - name: MY_POD_NAME
@@ -157,7 +161,7 @@ index e80dc0f..0128e28 100644
 -        {{- end }}
        volumes:
          - name: tmp
-           emptyDir: {}
+           {{- toYaml .Values.tmpVolume | nindent 10 }}
 -      {{- if .Values.addonResizer.enabled }}
 -        - name: nanny-config-volume
 -          configMap:
@@ -168,7 +172,7 @@ index e80dc0f..0128e28 100644
        {{- end }}
 diff --git a/charts/metrics-server/templates/role-nanny.yaml b/charts/metrics-server/templates/role-nanny.yaml
 deleted file mode 100644
-index f0bf8fc..0000000
+index f0bf8fce..00000000
 --- a/charts/metrics-server/templates/role-nanny.yaml
 +++ /dev/null
 @@ -1,27 +0,0 @@
@@ -201,7 +205,7 @@ index f0bf8fc..0000000
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/rolebinding-nanny.yaml b/charts/metrics-server/templates/rolebinding-nanny.yaml
 deleted file mode 100644
-index 73bfaaf..0000000
+index 73bfaaff..00000000
 --- a/charts/metrics-server/templates/rolebinding-nanny.yaml
 +++ /dev/null
 @@ -1,19 +0,0 @@
@@ -225,10 +229,10 @@ index 73bfaaf..0000000
 -{{- end -}}
 -{{- end -}}
 diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
-index 38bea8c..5f12132 100644
+index 53324671..42270159 100644
 --- a/charts/metrics-server/values.yaml
 +++ b/charts/metrics-server/values.yaml
-@@ -123,27 +123,6 @@ service:
+@@ -125,37 +125,6 @@ service:
    #  kubernetes.io/cluster-service: "true"
    #  kubernetes.io/name: "Metrics-server"
  
@@ -236,7 +240,17 @@ index 38bea8c..5f12132 100644
 -  enabled: false
 -  image:
 -    repository: registry.k8s.io/autoscaling/addon-resizer
--    tag: 1.8.19
+-    tag: 1.8.20
+-  securityContext:
+-    allowPrivilegeEscalation: false
+-    readOnlyRootFilesystem: true
+-    runAsNonRoot: true
+-    runAsUser: 1000
+-    seccompProfile:
+-      type: RuntimeDefault
+-    capabilities:
+-      drop:
+-        - ALL
 -  resources:
 -    requests:
 -      cpu: 40m
@@ -256,7 +270,7 @@ index 38bea8c..5f12132 100644
  metrics:
    enabled: false
  
-@@ -160,9 +139,6 @@ resources:
+@@ -172,9 +141,6 @@ resources:
    requests:
      cpu: 100m
      memory: 200Mi
@@ -267,5 +281,5 @@ index 38bea8c..5f12132 100644
  extraVolumeMounts: []
  
 -- 
-2.39.3 (Apple Git-145)
+2.44.0
 

--- a/projects/kubernetes-sigs/metrics-server/1-29/HELM_GIT_TAG
+++ b/projects/kubernetes-sigs/metrics-server/1-29/HELM_GIT_TAG
@@ -1,1 +1,1 @@
-metrics-server-helm-chart-3.11.0
+metrics-server-helm-chart-3.12.1

--- a/projects/kubernetes-sigs/metrics-server/1-29/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-29/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
@@ -1,4 +1,4 @@
-From 844bd83b083847ab7d388e2c5037acf111e2d8a0 Mon Sep 17 00:00:00 2001
+From 4f64a30a6e403f3ca720db3c4174fbf004607ad1 Mon Sep 17 00:00:00 2001
 From: Jonathan Meier <jwmeier@amazon.com>
 Date: Fri, 23 Sep 2022 12:17:23 -0400
 Subject: [PATCH 1/2] Conform helm chart to packages standards
@@ -13,7 +13,7 @@ Subject: [PATCH 1/2] Conform helm chart to packages standards
  6 files changed, 10 insertions(+), 10 deletions(-)
 
 diff --git a/charts/metrics-server/templates/_helpers.tpl b/charts/metrics-server/templates/_helpers.tpl
-index 9b87f11..492e462 100644
+index 9b87f118..492e4623 100644
 --- a/charts/metrics-server/templates/_helpers.tpl
 +++ b/charts/metrics-server/templates/_helpers.tpl
 @@ -68,7 +68,7 @@ Create the name of the service account to use
@@ -26,7 +26,7 @@ index 9b87f11..492e462 100644
  
  {{/*
 diff --git a/charts/metrics-server/templates/deployment.yaml b/charts/metrics-server/templates/deployment.yaml
-index 1d656fc..e80dc0f 100644
+index 48cda7fe..d12b5d2e 100644
 --- a/charts/metrics-server/templates/deployment.yaml
 +++ b/charts/metrics-server/templates/deployment.yaml
 @@ -2,7 +2,7 @@ apiVersion: apps/v1
@@ -39,7 +39,7 @@ index 1d656fc..e80dc0f 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
    {{- with .Values.deploymentAnnotations }}
 diff --git a/charts/metrics-server/templates/service.yaml b/charts/metrics-server/templates/service.yaml
-index d45bcf3..260134c 100644
+index d45bcf36..260134cd 100644
 --- a/charts/metrics-server/templates/service.yaml
 +++ b/charts/metrics-server/templates/service.yaml
 @@ -2,7 +2,7 @@ apiVersion: v1
@@ -52,7 +52,7 @@ index d45bcf3..260134c 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
    {{- with .Values.service.labels -}}
 diff --git a/charts/metrics-server/templates/serviceaccount.yaml b/charts/metrics-server/templates/serviceaccount.yaml
-index 80ef699..ce3bd0d 100644
+index 80ef6996..ce3bd0db 100644
 --- a/charts/metrics-server/templates/serviceaccount.yaml
 +++ b/charts/metrics-server/templates/serviceaccount.yaml
 @@ -3,7 +3,7 @@ apiVersion: v1
@@ -65,7 +65,7 @@ index 80ef699..ce3bd0d 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
    {{- with .Values.serviceAccount.annotations }}
 diff --git a/charts/metrics-server/templates/servicemonitor.yaml b/charts/metrics-server/templates/servicemonitor.yaml
-index 5c1c5b7..9e4c9ac 100644
+index 5c1c5b77..9e4c9acb 100644
 --- a/charts/metrics-server/templates/servicemonitor.yaml
 +++ b/charts/metrics-server/templates/servicemonitor.yaml
 @@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
@@ -78,7 +78,7 @@ index 5c1c5b7..9e4c9ac 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
      {{- with .Values.serviceMonitor.additionalLabels }}
 diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
-index fba10aa..38bea8c 100644
+index 4f6b9219..53324671 100644
 --- a/charts/metrics-server/values.yaml
 +++ b/charts/metrics-server/values.yaml
 @@ -2,14 +2,14 @@
@@ -102,5 +102,5 @@ index fba10aa..38bea8c 100644
  nameOverride: ""
  fullnameOverride: ""
 -- 
-2.39.3 (Apple Git-145)
+2.44.0
 

--- a/projects/kubernetes-sigs/metrics-server/1-29/helm/patches/0002-Remove-Addon-Resizer.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-29/helm/patches/0002-Remove-Addon-Resizer.patch
@@ -1,18 +1,18 @@
-From 9bb179b50087d0b0f7ed267e71b9106ad50c148e Mon Sep 17 00:00:00 2001
+From c0e41c2dd014793543a20439104d94c1b5c2510a Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
-Date: Thu, 30 Nov 2023 11:54:54 -0500
+Date: Sun, 2 Jun 2024 17:37:38 -0700
 Subject: [PATCH 2/2] Remove Addon Resizer
 
 ---
- charts/metrics-server/templates/_helpers.tpl  | 21 -----------
+ charts/metrics-server/templates/_helpers.tpl  | 21 ----------
  .../templates/clusterrole-nanny.yaml          | 13 -------
- .../templates/clusterrolebinding-nanny.yaml   | 18 ----------
- .../templates/configmaps-nanny.yaml           | 17 ---------
- .../metrics-server/templates/deployment.yaml  | 35 -------------------
- .../metrics-server/templates/role-nanny.yaml  | 27 --------------
- .../templates/rolebinding-nanny.yaml          | 19 ----------
- charts/metrics-server/values.yaml             | 24 -------------
- 8 files changed, 174 deletions(-)
+ .../templates/clusterrolebinding-nanny.yaml   | 18 ---------
+ .../templates/configmaps-nanny.yaml           | 17 --------
+ .../metrics-server/templates/deployment.yaml  | 39 -------------------
+ .../metrics-server/templates/role-nanny.yaml  | 27 -------------
+ .../templates/rolebinding-nanny.yaml          | 19 ---------
+ charts/metrics-server/values.yaml             | 34 ----------------
+ 8 files changed, 188 deletions(-)
  delete mode 100644 charts/metrics-server/templates/clusterrole-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/clusterrolebinding-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/configmaps-nanny.yaml
@@ -20,7 +20,7 @@ Subject: [PATCH 2/2] Remove Addon Resizer
  delete mode 100644 charts/metrics-server/templates/rolebinding-nanny.yaml
 
 diff --git a/charts/metrics-server/templates/_helpers.tpl b/charts/metrics-server/templates/_helpers.tpl
-index 492e462..e9b4728 100644
+index 492e4623..e9b47284 100644
 --- a/charts/metrics-server/templates/_helpers.tpl
 +++ b/charts/metrics-server/templates/_helpers.tpl
 @@ -71,27 +71,6 @@ The image to use
@@ -53,7 +53,7 @@ index 492e462..e9b4728 100644
    {{- if and (.Capabilities.APIVersions.Has "policy/v1") (semverCompare ">= 1.21-0" .Capabilities.KubeVersion.Version) -}}
 diff --git a/charts/metrics-server/templates/clusterrole-nanny.yaml b/charts/metrics-server/templates/clusterrole-nanny.yaml
 deleted file mode 100644
-index 24edd81..0000000
+index 24edd81c..00000000
 --- a/charts/metrics-server/templates/clusterrole-nanny.yaml
 +++ /dev/null
 @@ -1,13 +0,0 @@
@@ -72,7 +72,7 @@ index 24edd81..0000000
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/clusterrolebinding-nanny.yaml b/charts/metrics-server/templates/clusterrolebinding-nanny.yaml
 deleted file mode 100644
-index 43738cc..0000000
+index 43738ccb..00000000
 --- a/charts/metrics-server/templates/clusterrolebinding-nanny.yaml
 +++ /dev/null
 @@ -1,18 +0,0 @@
@@ -96,7 +96,7 @@ index 43738cc..0000000
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/configmaps-nanny.yaml b/charts/metrics-server/templates/configmaps-nanny.yaml
 deleted file mode 100644
-index c25005e..0000000
+index c25005ec..00000000
 --- a/charts/metrics-server/templates/configmaps-nanny.yaml
 +++ /dev/null
 @@ -1,17 +0,0 @@
@@ -118,15 +118,19 @@ index c25005e..0000000
 -    memoryPerNode: {{ .Values.addonResizer.nanny.extraMemory }}
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/deployment.yaml b/charts/metrics-server/templates/deployment.yaml
-index e80dc0f..0128e28 100644
+index d12b5d2e..209ac328 100644
 --- a/charts/metrics-server/templates/deployment.yaml
 +++ b/charts/metrics-server/templates/deployment.yaml
-@@ -87,44 +87,9 @@ spec:
+@@ -94,48 +94,9 @@ spec:
            resources:
              {{- toYaml . | nindent 12 }}
            {{- end }}
 -        {{- if .Values.addonResizer.enabled }}
 -        - name: metrics-server-nanny
+-          {{- with .Values.addonResizer.securityContext }}
+-          securityContext:
+-            {{- toYaml . | nindent 12 }}
+-          {{- end }}
 -          image: {{ include "metrics-server.addonResizer.image" . }}
 -          env:
 -            - name: MY_POD_NAME
@@ -157,7 +161,7 @@ index e80dc0f..0128e28 100644
 -        {{- end }}
        volumes:
          - name: tmp
-           emptyDir: {}
+           {{- toYaml .Values.tmpVolume | nindent 10 }}
 -      {{- if .Values.addonResizer.enabled }}
 -        - name: nanny-config-volume
 -          configMap:
@@ -168,7 +172,7 @@ index e80dc0f..0128e28 100644
        {{- end }}
 diff --git a/charts/metrics-server/templates/role-nanny.yaml b/charts/metrics-server/templates/role-nanny.yaml
 deleted file mode 100644
-index f0bf8fc..0000000
+index f0bf8fce..00000000
 --- a/charts/metrics-server/templates/role-nanny.yaml
 +++ /dev/null
 @@ -1,27 +0,0 @@
@@ -201,7 +205,7 @@ index f0bf8fc..0000000
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/rolebinding-nanny.yaml b/charts/metrics-server/templates/rolebinding-nanny.yaml
 deleted file mode 100644
-index 73bfaaf..0000000
+index 73bfaaff..00000000
 --- a/charts/metrics-server/templates/rolebinding-nanny.yaml
 +++ /dev/null
 @@ -1,19 +0,0 @@
@@ -225,10 +229,10 @@ index 73bfaaf..0000000
 -{{- end -}}
 -{{- end -}}
 diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
-index 38bea8c..5f12132 100644
+index 53324671..42270159 100644
 --- a/charts/metrics-server/values.yaml
 +++ b/charts/metrics-server/values.yaml
-@@ -123,27 +123,6 @@ service:
+@@ -125,37 +125,6 @@ service:
    #  kubernetes.io/cluster-service: "true"
    #  kubernetes.io/name: "Metrics-server"
  
@@ -236,7 +240,17 @@ index 38bea8c..5f12132 100644
 -  enabled: false
 -  image:
 -    repository: registry.k8s.io/autoscaling/addon-resizer
--    tag: 1.8.19
+-    tag: 1.8.20
+-  securityContext:
+-    allowPrivilegeEscalation: false
+-    readOnlyRootFilesystem: true
+-    runAsNonRoot: true
+-    runAsUser: 1000
+-    seccompProfile:
+-      type: RuntimeDefault
+-    capabilities:
+-      drop:
+-        - ALL
 -  resources:
 -    requests:
 -      cpu: 40m
@@ -256,7 +270,7 @@ index 38bea8c..5f12132 100644
  metrics:
    enabled: false
  
-@@ -160,9 +139,6 @@ resources:
+@@ -172,9 +141,6 @@ resources:
    requests:
      cpu: 100m
      memory: 200Mi
@@ -267,5 +281,5 @@ index 38bea8c..5f12132 100644
  extraVolumeMounts: []
  
 -- 
-2.39.3 (Apple Git-145)
+2.44.0
 

--- a/projects/kubernetes-sigs/metrics-server/1-30/HELM_GIT_TAG
+++ b/projects/kubernetes-sigs/metrics-server/1-30/HELM_GIT_TAG
@@ -1,1 +1,1 @@
-metrics-server-helm-chart-3.11.0
+metrics-server-helm-chart-3.12.1

--- a/projects/kubernetes-sigs/metrics-server/1-30/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-30/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
@@ -1,4 +1,4 @@
-From 844bd83b083847ab7d388e2c5037acf111e2d8a0 Mon Sep 17 00:00:00 2001
+From 4f64a30a6e403f3ca720db3c4174fbf004607ad1 Mon Sep 17 00:00:00 2001
 From: Jonathan Meier <jwmeier@amazon.com>
 Date: Fri, 23 Sep 2022 12:17:23 -0400
 Subject: [PATCH 1/2] Conform helm chart to packages standards
@@ -13,7 +13,7 @@ Subject: [PATCH 1/2] Conform helm chart to packages standards
  6 files changed, 10 insertions(+), 10 deletions(-)
 
 diff --git a/charts/metrics-server/templates/_helpers.tpl b/charts/metrics-server/templates/_helpers.tpl
-index 9b87f11..492e462 100644
+index 9b87f118..492e4623 100644
 --- a/charts/metrics-server/templates/_helpers.tpl
 +++ b/charts/metrics-server/templates/_helpers.tpl
 @@ -68,7 +68,7 @@ Create the name of the service account to use
@@ -26,7 +26,7 @@ index 9b87f11..492e462 100644
  
  {{/*
 diff --git a/charts/metrics-server/templates/deployment.yaml b/charts/metrics-server/templates/deployment.yaml
-index 1d656fc..e80dc0f 100644
+index 48cda7fe..d12b5d2e 100644
 --- a/charts/metrics-server/templates/deployment.yaml
 +++ b/charts/metrics-server/templates/deployment.yaml
 @@ -2,7 +2,7 @@ apiVersion: apps/v1
@@ -39,7 +39,7 @@ index 1d656fc..e80dc0f 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
    {{- with .Values.deploymentAnnotations }}
 diff --git a/charts/metrics-server/templates/service.yaml b/charts/metrics-server/templates/service.yaml
-index d45bcf3..260134c 100644
+index d45bcf36..260134cd 100644
 --- a/charts/metrics-server/templates/service.yaml
 +++ b/charts/metrics-server/templates/service.yaml
 @@ -2,7 +2,7 @@ apiVersion: v1
@@ -52,7 +52,7 @@ index d45bcf3..260134c 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
    {{- with .Values.service.labels -}}
 diff --git a/charts/metrics-server/templates/serviceaccount.yaml b/charts/metrics-server/templates/serviceaccount.yaml
-index 80ef699..ce3bd0d 100644
+index 80ef6996..ce3bd0db 100644
 --- a/charts/metrics-server/templates/serviceaccount.yaml
 +++ b/charts/metrics-server/templates/serviceaccount.yaml
 @@ -3,7 +3,7 @@ apiVersion: v1
@@ -65,7 +65,7 @@ index 80ef699..ce3bd0d 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
    {{- with .Values.serviceAccount.annotations }}
 diff --git a/charts/metrics-server/templates/servicemonitor.yaml b/charts/metrics-server/templates/servicemonitor.yaml
-index 5c1c5b7..9e4c9ac 100644
+index 5c1c5b77..9e4c9acb 100644
 --- a/charts/metrics-server/templates/servicemonitor.yaml
 +++ b/charts/metrics-server/templates/servicemonitor.yaml
 @@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
@@ -78,7 +78,7 @@ index 5c1c5b7..9e4c9ac 100644
      {{- include "metrics-server.labels" . | nindent 4 }}
      {{- with .Values.serviceMonitor.additionalLabels }}
 diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
-index fba10aa..38bea8c 100644
+index 4f6b9219..53324671 100644
 --- a/charts/metrics-server/values.yaml
 +++ b/charts/metrics-server/values.yaml
 @@ -2,14 +2,14 @@
@@ -102,4 +102,5 @@ index fba10aa..38bea8c 100644
  nameOverride: ""
  fullnameOverride: ""
 -- 
-2.39.3 (Apple Git-145)
+2.44.0
+

--- a/projects/kubernetes-sigs/metrics-server/1-30/helm/patches/0002-Remove-Addon-Resizer.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-30/helm/patches/0002-Remove-Addon-Resizer.patch
@@ -1,18 +1,18 @@
-From 9bb179b50087d0b0f7ed267e71b9106ad50c148e Mon Sep 17 00:00:00 2001
+From c0e41c2dd014793543a20439104d94c1b5c2510a Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
-Date: Thu, 30 Nov 2023 11:54:54 -0500
+Date: Sun, 2 Jun 2024 17:37:38 -0700
 Subject: [PATCH 2/2] Remove Addon Resizer
 
 ---
- charts/metrics-server/templates/_helpers.tpl  | 21 -----------
+ charts/metrics-server/templates/_helpers.tpl  | 21 ----------
  .../templates/clusterrole-nanny.yaml          | 13 -------
- .../templates/clusterrolebinding-nanny.yaml   | 18 ----------
- .../templates/configmaps-nanny.yaml           | 17 ---------
- .../metrics-server/templates/deployment.yaml  | 35 -------------------
- .../metrics-server/templates/role-nanny.yaml  | 27 --------------
- .../templates/rolebinding-nanny.yaml          | 19 ----------
- charts/metrics-server/values.yaml             | 24 -------------
- 8 files changed, 174 deletions(-)
+ .../templates/clusterrolebinding-nanny.yaml   | 18 ---------
+ .../templates/configmaps-nanny.yaml           | 17 --------
+ .../metrics-server/templates/deployment.yaml  | 39 -------------------
+ .../metrics-server/templates/role-nanny.yaml  | 27 -------------
+ .../templates/rolebinding-nanny.yaml          | 19 ---------
+ charts/metrics-server/values.yaml             | 34 ----------------
+ 8 files changed, 188 deletions(-)
  delete mode 100644 charts/metrics-server/templates/clusterrole-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/clusterrolebinding-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/configmaps-nanny.yaml
@@ -20,7 +20,7 @@ Subject: [PATCH 2/2] Remove Addon Resizer
  delete mode 100644 charts/metrics-server/templates/rolebinding-nanny.yaml
 
 diff --git a/charts/metrics-server/templates/_helpers.tpl b/charts/metrics-server/templates/_helpers.tpl
-index 492e462..e9b4728 100644
+index 492e4623..e9b47284 100644
 --- a/charts/metrics-server/templates/_helpers.tpl
 +++ b/charts/metrics-server/templates/_helpers.tpl
 @@ -71,27 +71,6 @@ The image to use
@@ -53,7 +53,7 @@ index 492e462..e9b4728 100644
    {{- if and (.Capabilities.APIVersions.Has "policy/v1") (semverCompare ">= 1.21-0" .Capabilities.KubeVersion.Version) -}}
 diff --git a/charts/metrics-server/templates/clusterrole-nanny.yaml b/charts/metrics-server/templates/clusterrole-nanny.yaml
 deleted file mode 100644
-index 24edd81..0000000
+index 24edd81c..00000000
 --- a/charts/metrics-server/templates/clusterrole-nanny.yaml
 +++ /dev/null
 @@ -1,13 +0,0 @@
@@ -72,7 +72,7 @@ index 24edd81..0000000
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/clusterrolebinding-nanny.yaml b/charts/metrics-server/templates/clusterrolebinding-nanny.yaml
 deleted file mode 100644
-index 43738cc..0000000
+index 43738ccb..00000000
 --- a/charts/metrics-server/templates/clusterrolebinding-nanny.yaml
 +++ /dev/null
 @@ -1,18 +0,0 @@
@@ -96,7 +96,7 @@ index 43738cc..0000000
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/configmaps-nanny.yaml b/charts/metrics-server/templates/configmaps-nanny.yaml
 deleted file mode 100644
-index c25005e..0000000
+index c25005ec..00000000
 --- a/charts/metrics-server/templates/configmaps-nanny.yaml
 +++ /dev/null
 @@ -1,17 +0,0 @@
@@ -118,15 +118,19 @@ index c25005e..0000000
 -    memoryPerNode: {{ .Values.addonResizer.nanny.extraMemory }}
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/deployment.yaml b/charts/metrics-server/templates/deployment.yaml
-index e80dc0f..0128e28 100644
+index d12b5d2e..209ac328 100644
 --- a/charts/metrics-server/templates/deployment.yaml
 +++ b/charts/metrics-server/templates/deployment.yaml
-@@ -87,44 +87,9 @@ spec:
+@@ -94,48 +94,9 @@ spec:
            resources:
              {{- toYaml . | nindent 12 }}
            {{- end }}
 -        {{- if .Values.addonResizer.enabled }}
 -        - name: metrics-server-nanny
+-          {{- with .Values.addonResizer.securityContext }}
+-          securityContext:
+-            {{- toYaml . | nindent 12 }}
+-          {{- end }}
 -          image: {{ include "metrics-server.addonResizer.image" . }}
 -          env:
 -            - name: MY_POD_NAME
@@ -157,7 +161,7 @@ index e80dc0f..0128e28 100644
 -        {{- end }}
        volumes:
          - name: tmp
-           emptyDir: {}
+           {{- toYaml .Values.tmpVolume | nindent 10 }}
 -      {{- if .Values.addonResizer.enabled }}
 -        - name: nanny-config-volume
 -          configMap:
@@ -168,7 +172,7 @@ index e80dc0f..0128e28 100644
        {{- end }}
 diff --git a/charts/metrics-server/templates/role-nanny.yaml b/charts/metrics-server/templates/role-nanny.yaml
 deleted file mode 100644
-index f0bf8fc..0000000
+index f0bf8fce..00000000
 --- a/charts/metrics-server/templates/role-nanny.yaml
 +++ /dev/null
 @@ -1,27 +0,0 @@
@@ -201,7 +205,7 @@ index f0bf8fc..0000000
 -{{- end -}}
 diff --git a/charts/metrics-server/templates/rolebinding-nanny.yaml b/charts/metrics-server/templates/rolebinding-nanny.yaml
 deleted file mode 100644
-index 73bfaaf..0000000
+index 73bfaaff..00000000
 --- a/charts/metrics-server/templates/rolebinding-nanny.yaml
 +++ /dev/null
 @@ -1,19 +0,0 @@
@@ -225,10 +229,10 @@ index 73bfaaf..0000000
 -{{- end -}}
 -{{- end -}}
 diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
-index 38bea8c..5f12132 100644
+index 53324671..42270159 100644
 --- a/charts/metrics-server/values.yaml
 +++ b/charts/metrics-server/values.yaml
-@@ -123,27 +123,6 @@ service:
+@@ -125,37 +125,6 @@ service:
    #  kubernetes.io/cluster-service: "true"
    #  kubernetes.io/name: "Metrics-server"
  
@@ -236,7 +240,17 @@ index 38bea8c..5f12132 100644
 -  enabled: false
 -  image:
 -    repository: registry.k8s.io/autoscaling/addon-resizer
--    tag: 1.8.19
+-    tag: 1.8.20
+-  securityContext:
+-    allowPrivilegeEscalation: false
+-    readOnlyRootFilesystem: true
+-    runAsNonRoot: true
+-    runAsUser: 1000
+-    seccompProfile:
+-      type: RuntimeDefault
+-    capabilities:
+-      drop:
+-        - ALL
 -  resources:
 -    requests:
 -      cpu: 40m
@@ -256,7 +270,7 @@ index 38bea8c..5f12132 100644
  metrics:
    enabled: false
  
-@@ -160,9 +139,6 @@ resources:
+@@ -172,9 +141,6 @@ resources:
    requests:
      cpu: 100m
      memory: 200Mi
@@ -267,5 +281,5 @@ index 38bea8c..5f12132 100644
  extraVolumeMounts: []
  
 -- 
-2.39.3 (Apple Git-145)
+2.44.0
 

--- a/projects/kubernetes-sigs/metrics-server/README.md
+++ b/projects/kubernetes-sigs/metrics-server/README.md
@@ -1,9 +1,9 @@
 ## **AWS Distro for Kubernetes Metrics Server**
-![1.24 Version](https://img.shields.io/badge/1--24%20version-v0.6.4-blue)
-![1.25 Version](https://img.shields.io/badge/1--25%20version-v0.6.4-blue)
-![1.26 Version](https://img.shields.io/badge/1--26%20version-v0.6.4-blue)
-![1.27 Version](https://img.shields.io/badge/1--27%20version-v0.6.4-blue)
-![1.28 Version](https://img.shields.io/badge/1--28%20version-v0.6.4-blue)
+![1.24 Version](https://img.shields.io/badge/1--24%20version-v0.7.1-blue)
+![1.25 Version](https://img.shields.io/badge/1--25%20version-v0.7.1-blue)
+![1.26 Version](https://img.shields.io/badge/1--26%20version-v0.7.1-blue)
+![1.27 Version](https://img.shields.io/badge/1--27%20version-v0.7.1-blue)
+![1.28 Version](https://img.shields.io/badge/1--28%20version-v0.7.1-blue)
 ![Build Status](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiSEFNYVlKSURxN25YRGpuWURwWmZOS05vbkl6YTdHTzNHTFJpdzdHZGJUL001ZlNqS1JhblM0QTl2VytuUzNRQ09WazJwRHVUZnp0dVRCb3dLTUVxb2w4PSIsIml2UGFyYW1ldGVyU3BlYyI6IkJIOGVvTFk2bWVVcnhUTkoiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=main)
 
 AWS Distro for ([Metrics Server](https://github.com/kubernetes-sigs/metrics-server)) is an AWS supported version of the upstream Metrics Server and is distributed by Amazon EKS-D.


### PR DESCRIPTION
### Description of changes:
This PR updates metrics server helm chart from version 3.11.1 to 3.12.1 
### Upstream source of truth:
Upstream IMAGE TAG: https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.7.1  Upstream HELM_GIT_TAG: https://github.com/kubernetes-sigs/metrics-server/releases/tag/metrics-server-helm-chart-3.12.1 
### Explanations of changed patches
Fixed merged conflicts for Remove Addon resizer patch
### Test:
Changes were tested on Kubernetes version 1.29 by doing Helm install of the updated chart.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
