### PR TITLE
Make image-builder upgrade flow non-release-branched

### DIFF
--- a/build/lib/generate_staging_buildspec.sh
+++ b/build/lib/generate_staging_buildspec.sh
@@ -165,6 +165,10 @@ for project in "${PROJECTS[@]}"; do
             BUILDSPEC_VARS_KEYS=""
         fi
 
+        if [[ "$BUILDSPECS_VAR" == "UPGRADE_BUILDSPECS" ]] && [[ "${IDENTIFIER}" = "kubernetes_sigs_image_builder" ]]; then
+            BUILDSPEC_VARS_KEYS=""
+        fi
+
         if [[ -n "$BUILDSPEC_VARS_KEYS" ]]; then
             KEYS=(${BUILDSPEC_VARS_KEYS// / })
 

--- a/tools/version-tracker/buildspecs/upgrade.yml
+++ b/tools/version-tracker/buildspecs/upgrade.yml
@@ -368,66 +368,13 @@ batch:
         variables:
           PROJECT_PATH: projects/kubernetes-sigs/cri-tools
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.cri-tools
-    - identifier: kubernetes_sigs_image_builder_bottlerocket_1_25_upgrade_buildspec
+    - identifier: kubernetes_sigs_image_builder
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           PROJECT_PATH: projects/kubernetes-sigs/image-builder
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.image-builder
-          IMAGE_OS: bottlerocket
-          RELEASE_BRANCH: 1-25
-          IMAGE_OS_VERSION: "1"
-    - identifier: kubernetes_sigs_image_builder_bottlerocket_1_26_upgrade_buildspec
-      env:
-        type: ARM_CONTAINER
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          PROJECT_PATH: projects/kubernetes-sigs/image-builder
-          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.image-builder
-          IMAGE_OS: bottlerocket
-          RELEASE_BRANCH: 1-26
-          IMAGE_OS_VERSION: "1"
-    - identifier: kubernetes_sigs_image_builder_bottlerocket_1_27_upgrade_buildspec
-      env:
-        type: ARM_CONTAINER
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          PROJECT_PATH: projects/kubernetes-sigs/image-builder
-          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.image-builder
-          IMAGE_OS: bottlerocket
-          RELEASE_BRANCH: 1-27
-          IMAGE_OS_VERSION: "1"
-    - identifier: kubernetes_sigs_image_builder_bottlerocket_1_28_upgrade_buildspec
-      env:
-        type: ARM_CONTAINER
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          PROJECT_PATH: projects/kubernetes-sigs/image-builder
-          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.image-builder
-          IMAGE_OS: bottlerocket
-          RELEASE_BRANCH: 1-28
-          IMAGE_OS_VERSION: "1"
-    - identifier: kubernetes_sigs_image_builder_bottlerocket_1_29_upgrade_buildspec
-      env:
-        type: ARM_CONTAINER
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          PROJECT_PATH: projects/kubernetes-sigs/image-builder
-          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.image-builder
-          IMAGE_OS: bottlerocket
-          RELEASE_BRANCH: 1-29
-          IMAGE_OS_VERSION: "1"
-    - identifier: kubernetes_sigs_image_builder_bottlerocket_1_30_upgrade_buildspec
-      env:
-        type: ARM_CONTAINER
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          PROJECT_PATH: projects/kubernetes-sigs/image-builder
-          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.image-builder
-          IMAGE_OS: bottlerocket
-          RELEASE_BRANCH: 1-30
-          IMAGE_OS_VERSION: "1"
     - identifier: kubernetes_sigs_kind
       env:
         type: ARM_CONTAINER


### PR DESCRIPTION
The `kubernetes-sigs/image-builder` project uses the same Git tag for all release branches so we do not need to run the upgrade flow separately for every branch. Hence we're modifying the upgrade batch buildspec to have a single entry for the image-builder upgrade job.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
