### PR TITLE
Bump latest version to 1-26 on EKD_LATEST_RELEASES 

### DIFF
--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -1,4 +1,4 @@
-latest: 1-25
+latest: 1-26
 releases:
 - branch: 1-18
   kubeVersion: v1.18.20


### PR DESCRIPTION

The latest field on `EKSD_LATEST_RELEASES` should ideally be maintained at least on par with the minimum Kubernetes version supported for the release as that will help us in maintaining a reasonably decent version skew with the max K8s version supported in the release. Trying to bump this to a more recent K8s version has resulted in issues in the past as this field essentially decides the kubectl version that get installed on cli-tools and the later recent versions might not be backward compatible with the older versions we support. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
