### PR TITLE
Avoid printing directory name for Make command

### DIFF
--- a/tools/version-tracker/pkg/commands/upgrade/upgrade.go
+++ b/tools/version-tracker/pkg/commands/upgrade/upgrade.go
@@ -892,7 +892,7 @@ func isEKSDistroUpgrade(projectName string) bool {
 }
 
 func getDefaultReleaseBranch(buildToolingRepoPath string) (string, error) {
-	defaultReleaseBranchCommandSequence := fmt.Sprintf("make -C %s get-default-release-branch", buildToolingRepoPath)
+	defaultReleaseBranchCommandSequence := fmt.Sprintf("make --no-print-directory -C %s get-default-release-branch", buildToolingRepoPath)
 	defaultReleaseBranchCmd := exec.Command("bash", "-c", defaultReleaseBranchCommandSequence)
 	defaultReleaseBranch, err := command.ExecCommand(defaultReleaseBranchCmd)
 	if err != nil {


### PR DESCRIPTION
The `MAKEFLAGS` are not preserved when calling `make` through Go code, so the release branch variable ends up including the `Entering directory ...` and `Leaving directory ...` statements printed by `make`. 
```
RELEASE_BRANCH=make[1]: Entering directory `/codebuild/output/src2154812656/src/git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-build-tooling/tools/version-tracker/eks-anywhere-build-tooling'
1-26
make[1]: Leaving directory `/codebuild/output/src2154812656/src/git-codecommit.us-west-2.amazonaws.com/v1/repos/aws.eks-anywhere-build-tooling/tools/version-tracker/eks-anywhere-build-tooling'
```
Thus we need to explicitly pass in the `--no-print-directory` option.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
