### PR TITLE
Add buildspec for Nutanix image builds

### DIFF
--- a/projects/kubernetes-sigs/image-builder/buildspecs/nutanix.yml
+++ b/projects/kubernetes-sigs/image-builder/buildspecs/nutanix.yml
@@ -1,0 +1,22 @@
+version: 0.2
+
+run-as: imagebuilder
+
+env:
+  variables:
+    HOME: "/home/imagebuilder"
+    CLI_FOLDER: "projects/aws/image-builder"
+    GOPATH: "/home/imagebuilder/go"
+  secrets-manager:
+    NUTANIX_CONNECTION_DATA: "nutanix_ci:nutanix_connection_data"
+
+phases:
+  pre_build:
+    run-as: root
+    commands:
+      - git config --global credential.helper '!aws codecommit credential-helper $@'
+      - git config --global credential.UseHttpPath true
+
+  build:
+    commands:      
+      - if make check-for-supported-release-branch IMAGE_OS=$IMAGE_OS IMAGE_FORMAT=nutanix RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH && make check-for-release-branch-skip -C $PROJECT_PATH; then make binaries -C $CLI_FOLDER && make release IMAGE_OS=$IMAGE_OS IMAGE_OS_VERSION=$IMAGE_OS_VERSION IMAGE_FORMAT=nutanix RELEASE_BRANCH=$RELEASE_BRANCH -C $PROJECT_PATH; fi


### PR DESCRIPTION
Adding buildspec for Nutanix image builds to `release-0.19` branch in order to fix the missing buildspec issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
