### PR TITLE
Use go.mod file to retrieve cert-manager Go version

### DIFF
--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -117,11 +117,6 @@ var (
 			Extract:                  false,
 			TrimLeadingVersionPrefix: true,
 		},
-		"cert-manager/cert-manager": {
-			AssetName:  "cert-manager-cmctl-linux-amd64.tar.gz",
-			BinaryName: "cmctl",
-			Extract:    true,
-		},
 		"containerd/containerd": {
 			AssetName:                "containerd-%s-linux-amd64.tar.gz",
 			BinaryName:               "bin/containerd",
@@ -208,6 +203,10 @@ var (
 		"brancz/kube-rbac-proxy": {
 			SourceOfTruthFile:     ".github/workflows/build.yml",
 			GoVersionSearchString: `go-version: '(1\.\d\d)\.\d+'`,
+		},
+		"cert-manager/cert-manager": {
+			SourceOfTruthFile:     "go.mod",
+			GoVersionSearchString: `go (1\.\d\d)`,
 		},
 		"emissary-ingress/emissary": {
 			SourceOfTruthFile:     "go.mod",


### PR DESCRIPTION
From cert-manager v0.15.0 onwards, the `cmctl` binaries are no longer included in the GitHub releases and are released separately in another project `cert-manager/cmctl`. So we're just using the go.mod file to retrieve the Go version to use for cert-manager.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
