### PR TITLE
Bump autoscaler version to latest

### DIFF
--- a/UPSTREAM_PROJECTS.yaml
+++ b/UPSTREAM_PROJECTS.yaml
@@ -141,13 +141,13 @@ projects:
             go_version: "1.19"
           - tag: cluster-autoscaler-1.26.8
             go_version: "1.19"
-          - tag: cluster-autoscaler-1.27.7
+          - tag: cluster-autoscaler-1.27.8
             go_version: "1.20"
-          - tag: cluster-autoscaler-1.28.4
+          - tag: cluster-autoscaler-1.28.5
             go_version: "1.20"
-          - tag: cluster-autoscaler-1.29.2
+          - tag: cluster-autoscaler-1.29.3
             go_version: "1.21"
-          - tag: cluster-autoscaler-1.30.0
+          - tag: cluster-autoscaler-1.30.1
             go_version: "1.22"
       - name: cloud-provider-aws
         versions:

--- a/projects/kubernetes/autoscaler/1-27/CHECKSUMS
+++ b/projects/kubernetes/autoscaler/1-27/CHECKSUMS
@@ -1,2 +1,2 @@
-3752c70164e58badecc1832698051e8b9c4174e20ae972093d6ca3bbf87ead31  _output/1-27/bin/autoscaler/linux-amd64/cluster-autoscaler
-99b6c138a6c878e1d6daa84f0f59b40c7b1d7790dfcd444be0bcb78441211864  _output/1-27/bin/autoscaler/linux-arm64/cluster-autoscaler
+cd327cf5bdecba83b203c92082e1485285f64aad292ab02c5ef85ab4d8f075a6  _output/1-27/bin/autoscaler/linux-amd64/cluster-autoscaler
+ff320879c03e500c649f60c83467e8df0750a3d1fbb2fa1b2b8c6261873d02f2  _output/1-27/bin/autoscaler/linux-arm64/cluster-autoscaler

--- a/projects/kubernetes/autoscaler/1-27/GIT_TAG
+++ b/projects/kubernetes/autoscaler/1-27/GIT_TAG
@@ -1,1 +1,1 @@
-cluster-autoscaler-1.27.7
+cluster-autoscaler-1.27.8

--- a/projects/kubernetes/autoscaler/1-28/CHECKSUMS
+++ b/projects/kubernetes/autoscaler/1-28/CHECKSUMS
@@ -1,2 +1,2 @@
-8fcd176d78be67b23ad4e10e4bf69e8745dcce5083ab17b8d4aa9b7217491c5b  _output/1-28/bin/autoscaler/linux-amd64/cluster-autoscaler
-2d9c76c57d975f79cfe82b25023103a9571c4a6a3f4f03dc53846dc90812336d  _output/1-28/bin/autoscaler/linux-arm64/cluster-autoscaler
+e015b7723e9b93245ce32266da5d4aa2ff8f64b2d681843e35d331dc7eedfb1c  _output/1-28/bin/autoscaler/linux-amd64/cluster-autoscaler
+820a8d60f3eba25d8ca40c1d221e33be55772d238fa59c287e039542af8978be  _output/1-28/bin/autoscaler/linux-arm64/cluster-autoscaler

--- a/projects/kubernetes/autoscaler/1-28/GIT_TAG
+++ b/projects/kubernetes/autoscaler/1-28/GIT_TAG
@@ -1,1 +1,1 @@
-cluster-autoscaler-1.28.4
+cluster-autoscaler-1.28.5

--- a/projects/kubernetes/autoscaler/1-28/HELM_GIT_TAG
+++ b/projects/kubernetes/autoscaler/1-28/HELM_GIT_TAG
@@ -1,1 +1,1 @@
-cluster-autoscaler-chart-9.34.0
+cluster-autoscaler-chart-9.37.0

--- a/projects/kubernetes/autoscaler/1-28/helm/patches/0002-Add-image-values.patch
+++ b/projects/kubernetes/autoscaler/1-28/helm/patches/0002-Add-image-values.patch
@@ -1,15 +1,17 @@
-From a951c07b2633950debe034c32d9df2f37ebe73b5 Mon Sep 17 00:00:00 2001
+From 425c4836f440ea88974a969ba73028c56da366c8 Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
-Date: Thu, 15 Sep 2022 10:30:11 -0400
+Date: Mon, 10 Jun 2024 21:25:54 +0000
 Subject: [PATCH] Add image values
 
 ---
- .../templates/deployment.yaml                 | 12 +++++------
- charts/cluster-autoscaler/values.yaml         | 21 ++++++++++---------
- 2 files changed, 16 insertions(+), 17 deletions(-)
+ .../templates/deployment.yaml                 | 12 +++----
+ charts/cluster-autoscaler/values.yaml         | 20 +++++------
+ charts/cluster-autoscaler/values.yaml.rej     | 36 +++++++++++++++++++
+ 3 files changed, 51 insertions(+), 17 deletions(-)
+ create mode 100644 charts/cluster-autoscaler/values.yaml.rej
 
 diff --git a/charts/cluster-autoscaler/templates/deployment.yaml b/charts/cluster-autoscaler/templates/deployment.yaml
-index 113d92971..82a51bf2d 100644
+index 1b06186bf..0324e1181 100644
 --- a/charts/cluster-autoscaler/templates/deployment.yaml
 +++ b/charts/cluster-autoscaler/templates/deployment.yaml
 @@ -37,6 +37,10 @@ spec:
@@ -32,7 +34,7 @@ index 113d92971..82a51bf2d 100644
            imagePullPolicy: "{{ .Values.image.pullPolicy }}"
            command:
              - ./cluster-autoscaler
-@@ -333,11 +337,5 @@ spec:
+@@ -329,11 +333,5 @@ spec:
            secret:
              secretName: {{ .Values.clusterAPIKubeconfigSecret }}
        {{- end }}
@@ -45,14 +47,10 @@ index 113d92971..82a51bf2d 100644
      {{- end }}
  {{- end }}
 diff --git a/charts/cluster-autoscaler/values.yaml b/charts/cluster-autoscaler/values.yaml
-index 20c2c1479..9157801ae 100644
+index 54e6b13f5..40f66189b 100644
 --- a/charts/cluster-autoscaler/values.yaml
 +++ b/charts/cluster-autoscaler/values.yaml
-@@ -215,23 +215,24 @@ extraVolumeSecrets: {}
- # fullnameOverride -- String to fully override `cluster-autoscaler.fullname` template.
- fullnameOverride: ""
- 
-+
+@@ -232,20 +232,20 @@ fullnameOverride: ""
  # hostNetwork -- Whether to expose network interfaces of the host machine to pods.
  hostNetwork: false
  
@@ -63,11 +61,11 @@ index 20c2c1479..9157801ae 100644
    # image.repository -- Image repository
 -  repository: registry.k8s.io/autoscaling/cluster-autoscaler
 -  # image.tag -- Image tag
--  tag: v1.28.2
+-  tag: v1.30.0
 +  repository: kubernetes/autoscaler
 +  # image.digest -- Image digest
 +  digest: {{kubernetes/autoscaler}}
-+
++  
    # image.pullPolicy -- Image pull policy
    pullPolicy: IfNotPresent
 -  ## Optionally specify an array of imagePullSecrets.
@@ -77,12 +75,54 @@ index 20c2c1479..9157801ae 100644
 -  # image.pullSecrets -- Image pull secrets
 -  pullSecrets: []
 -  # - myRegistrKeySecretName
-+
++  
 +# image pull secrets
 +imagePullSecrets: []
  
  # kubeTargetVersionOverride -- Allow overriding the `.Capabilities.KubeVersion.GitVersion` check. Useful for `helm template` commands.
  kubeTargetVersionOverride: ""
+diff --git a/charts/cluster-autoscaler/values.yaml.rej b/charts/cluster-autoscaler/values.yaml.rej
+new file mode 100644
+index 000000000..09c845102
+--- /dev/null
++++ b/charts/cluster-autoscaler/values.yaml.rej
+@@ -0,0 +1,36 @@
++diff a/charts/cluster-autoscaler/values.yaml b/charts/cluster-autoscaler/values.yaml	(rejected hunks)
++@@ -215,23 +215,24 @@ extraVolumeSecrets: {}
++ # fullnameOverride -- String to fully override `cluster-autoscaler.fullname` template.
++ fullnameOverride: ""
++ 
+++
++ # hostNetwork -- Whether to expose network interfaces of the host machine to pods.
++ hostNetwork: false
++ 
+++# sourceRegistry -- Image registry
+++sourceRegistry: 783794618700.dkr.ecr.us-west-2.amazonaws.com
+++
++ image:
++   # image.repository -- Image repository
++-  repository: registry.k8s.io/autoscaling/cluster-autoscaler
++-  # image.tag -- Image tag
++-  tag: v1.28.2
+++  repository: kubernetes/autoscaler
+++  # image.digest -- Image digest
+++  digest: {{kubernetes/autoscaler}}
+++
++   # image.pullPolicy -- Image pull policy
++   pullPolicy: IfNotPresent
++-  ## Optionally specify an array of imagePullSecrets.
++-  ## Secrets must be manually created in the namespace.
++-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
++-  ##
++-  # image.pullSecrets -- Image pull secrets
++-  pullSecrets: []
++-  # - myRegistrKeySecretName
+++
+++# image pull secrets
+++imagePullSecrets: []
++ 
++ # kubeTargetVersionOverride -- Allow overriding the `.Capabilities.KubeVersion.GitVersion` check. Useful for `helm template` commands.
++ kubeTargetVersionOverride: ""
 -- 
-2.25.1
+2.40.1
 

--- a/projects/kubernetes/autoscaler/1-28/patches/0002-Update-go.mod-Dependencies.patch
+++ b/projects/kubernetes/autoscaler/1-28/patches/0002-Update-go.mod-Dependencies.patch
@@ -1,15 +1,15 @@
-From 219056bc7244a31f723c59517072449d81567b4c Mon Sep 17 00:00:00 2001
+From aa5e3da6cd272a33cd9a151458a0c10a5041777b Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
-Date: Mon, 10 Jun 2024 23:56:08 +0000
+Date: Mon, 10 Jun 2024 18:42:05 +0000
 Subject: [PATCH] Update go.mod Dependencies
 
 ---
- cluster-autoscaler/go.mod |  89 +------
- cluster-autoscaler/go.sum | 533 +-------------------------------------
- 2 files changed, 14 insertions(+), 608 deletions(-)
+ cluster-autoscaler/go.mod |  90 +------
+ cluster-autoscaler/go.sum | 544 --------------------------------------
+ 2 files changed, 9 insertions(+), 625 deletions(-)
 
 diff --git a/cluster-autoscaler/go.mod b/cluster-autoscaler/go.mod
-index 479302a59..b6932b8a2 100644
+index 79ab28c37..8df6bb367 100644
 --- a/cluster-autoscaler/go.mod
 +++ b/cluster-autoscaler/go.mod
 @@ -3,90 +3,41 @@ module k8s.io/autoscaler/cluster-autoscaler
@@ -23,11 +23,11 @@ index 479302a59..b6932b8a2 100644
 -	github.com/Azure/go-autorest/autorest/azure/auth v0.5.8
 -	github.com/Azure/go-autorest/autorest/date v0.3.0
 -	github.com/Azure/go-autorest/autorest/to v0.4.0
--	github.com/Azure/skewer v0.0.17
+-	github.com/Azure/skewer v0.0.14
 -	github.com/aws/aws-sdk-go v1.44.241
+-	github.com/cenkalti/backoff/v4 v4.2.1
 -	github.com/digitalocean/godo v1.27.0
--	github.com/ghodss/yaml v1.0.0
--	github.com/gofrs/uuid v4.2.0+incompatible
+-	github.com/gofrs/uuid v4.4.0+incompatible
  	github.com/gogo/protobuf v1.3.2
  	github.com/golang/mock v1.6.0
  	github.com/google/go-cmp v0.5.9
@@ -36,33 +36,34 @@ index 479302a59..b6932b8a2 100644
 -	github.com/jmespath/go-jmespath v0.4.0
 -	github.com/json-iterator/go v1.1.12
  	github.com/pkg/errors v0.9.1
- 	github.com/prometheus/client_golang v1.14.0
+ 	github.com/prometheus/client_golang v1.16.0
 -	github.com/satori/go.uuid v1.2.0
  	github.com/spf13/pflag v1.0.5
- 	github.com/stretchr/testify v1.8.4
+ 	github.com/stretchr/testify v1.8.2
 -	golang.org/x/crypto v0.21.0
 -	golang.org/x/net v0.23.0
--	golang.org/x/oauth2 v0.7.0
+-	golang.org/x/oauth2 v0.8.0
 -	golang.org/x/sys v0.18.0
 -	google.golang.org/api v0.114.0
  	google.golang.org/grpc v1.56.3
  	google.golang.org/protobuf v1.33.0
 -	gopkg.in/gcfg.v1 v1.2.3
  	gopkg.in/yaml.v2 v2.4.0
- 	k8s.io/api v0.27.14
- 	k8s.io/apimachinery v0.27.14
- 	k8s.io/apiserver v0.27.14
- 	k8s.io/client-go v0.27.14
- 	k8s.io/cloud-provider v0.27.14
+ 	k8s.io/api v0.28.10
+ 	k8s.io/apimachinery v0.28.10
+ 	k8s.io/apiserver v0.28.10
+ 	k8s.io/client-go v0.28.10
+ 	k8s.io/cloud-provider v0.28.10
 -	k8s.io/cloud-provider-aws v1.27.0
- 	k8s.io/component-base v0.27.14
- 	k8s.io/component-helpers v0.27.14
- 	k8s.io/klog/v2 v2.90.1
--	k8s.io/kubelet v0.27.14
- 	k8s.io/kubernetes v1.27.14
+ 	k8s.io/component-base v0.28.10
+ 	k8s.io/component-helpers v0.28.10
+ 	k8s.io/klog/v2 v2.100.1
+-	k8s.io/kubelet v0.28.10
+ 	k8s.io/kubernetes v1.28.10
 -	k8s.io/legacy-cloud-providers v0.0.0
  	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2
--	sigs.k8s.io/cloud-provider-azure v1.27.5
+-	sigs.k8s.io/cloud-provider-azure v1.26.2
+-	sigs.k8s.io/yaml v1.3.0
  )
  
  require (
@@ -75,7 +76,7 @@ index 479302a59..b6932b8a2 100644
 -	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 -	github.com/GoogleCloudPlatform/k8s-cloud-provider v1.18.1-0.20220218231025-f11817397a1b // indirect
 -	github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab // indirect
--	github.com/Microsoft/go-winio v0.4.17 // indirect
+-	github.com/Microsoft/go-winio v0.6.0 // indirect
 -	github.com/Microsoft/hcsshim v0.8.25 // indirect
  	github.com/NYTimes/gziphandler v1.1.1 // indirect
  	github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230321174746-8dcc6526cfb1 // indirect
@@ -83,37 +84,37 @@ index 479302a59..b6932b8a2 100644
  	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
  	github.com/beorn7/perks v1.0.1 // indirect
  	github.com/blang/semver/v4 v4.0.0 // indirect
- 	github.com/cenkalti/backoff/v4 v4.2.0 // indirect
++	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
  	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 -	github.com/checkpoint-restore/go-criu/v5 v5.3.0 // indirect
--	github.com/cilium/ebpf v0.7.0 // indirect
--	github.com/container-storage-interface/spec v1.7.0 // indirect
--	github.com/containerd/cgroups v1.0.1 // indirect
+-	github.com/cilium/ebpf v0.9.1 // indirect
+-	github.com/container-storage-interface/spec v1.8.0 // indirect
+-	github.com/containerd/cgroups v1.1.0 // indirect
 -	github.com/containerd/console v1.0.3 // indirect
--	github.com/containerd/ttrpc v1.1.0 // indirect
+-	github.com/containerd/ttrpc v1.2.2 // indirect
  	github.com/coreos/go-semver v0.3.1 // indirect
  	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 -	github.com/cyphar/filepath-securejoin v0.2.4 // indirect
  	github.com/davecgh/go-spew v1.1.1 // indirect
 -	github.com/dimchansky/utfbom v1.1.1 // indirect
- 	github.com/docker/distribution v2.8.1+incompatible // indirect
+ 	github.com/docker/distribution v2.8.2+incompatible // indirect
 -	github.com/docker/go-units v0.5.0 // indirect
  	github.com/emicklei/go-restful/v3 v3.10.2 // indirect
 -	github.com/euank/go-kmsg-parser v2.0.0+incompatible // indirect
  	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
  	github.com/felixge/httpsnoop v1.0.3 // indirect
  	github.com/fsnotify/fsnotify v1.6.0 // indirect
-@@ -96,61 +47,40 @@ require (
+@@ -96,60 +47,36 @@ require (
  	github.com/go-openapi/jsonpointer v0.19.6 // indirect
  	github.com/go-openapi/jsonreference v0.20.2 // indirect
  	github.com/go-openapi/swag v0.22.3 // indirect
 -	github.com/godbus/dbus/v5 v5.0.6 // indirect
- 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
+-	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
  	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
  	github.com/golang/protobuf v1.5.4 // indirect
--	github.com/google/cadvisor v0.47.2 // indirect
- 	github.com/google/cel-go v0.14.0 // indirect
- 	github.com/google/gnostic v0.6.9 // indirect
+-	github.com/google/cadvisor v0.47.3 // indirect
+ 	github.com/google/cel-go v0.16.1 // indirect
+ 	github.com/google/gnostic-models v0.6.8 // indirect
  	github.com/google/gofuzz v1.2.0 // indirect
 -	github.com/googleapis/enterprise-certificate-proxy v0.2.3 // indirect
 -	github.com/googleapis/gax-go/v2 v2.7.1 // indirect
@@ -131,7 +132,6 @@ index 479302a59..b6932b8a2 100644
  	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 -	github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible // indirect
 -	github.com/mitchellh/go-homedir v1.1.0 // indirect
- 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 -	github.com/moby/ipvs v1.1.0 // indirect
 -	github.com/moby/spdystream v0.2.0 // indirect
  	github.com/moby/sys/mountinfo v0.6.2 // indirect
@@ -141,71 +141,75 @@ index 479302a59..b6932b8a2 100644
 -	github.com/mrunalp/fileutils v0.5.0 // indirect
  	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 -	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
-+	github.com/onsi/ginkgo/v2 v2.9.7 // indirect
-+	github.com/onsi/gomega v1.27.7 // indirect
  	github.com/opencontainers/go-digest v1.0.0 // indirect
--	github.com/opencontainers/runc v1.1.6 // indirect
+-	github.com/opencontainers/runc v1.1.7 // indirect
 -	github.com/opencontainers/runtime-spec v1.0.3-0.20220909204839-494a5a6aca78 // indirect
  	github.com/opencontainers/selinux v1.10.0 // indirect
  	github.com/pmezard/go-difflib v1.0.0 // indirect
- 	github.com/prometheus/client_model v0.3.0 // indirect
- 	github.com/prometheus/common v0.42.0 // indirect
- 	github.com/prometheus/procfs v0.9.0 // indirect
+ 	github.com/prometheus/client_model v0.4.0 // indirect
+ 	github.com/prometheus/common v0.44.0 // indirect
+ 	github.com/prometheus/procfs v0.10.1 // indirect
 -	github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021 // indirect
--	github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646 // indirect
+-	github.com/seccomp/libseccomp-golang v0.10.0 // indirect
 -	github.com/sirupsen/logrus v1.9.0 // indirect
  	github.com/spf13/cobra v1.7.0 // indirect
  	github.com/stoewer/go-strcase v1.3.0 // indirect
  	github.com/stretchr/objx v0.5.0 // indirect
 -	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 // indirect
 -	github.com/vishvananda/netlink v1.1.0 // indirect
--	github.com/vishvananda/netns v0.0.2 // indirect
+-	github.com/vishvananda/netns v0.0.4 // indirect
 -	github.com/vmware/govmomi v0.30.6 // indirect
- 	go.etcd.io/etcd/api/v3 v3.5.7 // indirect
- 	go.etcd.io/etcd/client/pkg/v3 v3.5.7 // indirect
- 	go.etcd.io/etcd/client/v3 v3.5.7 // indirect
+ 	go.etcd.io/etcd/api/v3 v3.5.9 // indirect
+ 	go.etcd.io/etcd/client/pkg/v3 v3.5.9 // indirect
+ 	go.etcd.io/etcd/client/v3 v3.5.9 // indirect
 -	go.opencensus.io v0.24.0 // indirect
 -	go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful v0.35.0 // indirect
  	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.40.0 // indirect
  	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.40.0 // indirect
  	go.opentelemetry.io/otel v1.14.0 // indirect
-@@ -164,10 +94,14 @@ require (
+@@ -163,34 +90,35 @@ require (
  	go.uber.org/atomic v1.10.0 // indirect
  	go.uber.org/multierr v1.11.0 // indirect
  	go.uber.org/zap v1.24.0 // indirect
 +	golang.org/x/crypto v0.21.0 // indirect
  	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // indirect
+-	golang.org/x/mod v0.14.0 // indirect
 +	golang.org/x/net v0.23.0 // indirect
-+	golang.org/x/oauth2 v0.7.0 // indirect
++	golang.org/x/oauth2 v0.8.0 // indirect
  	golang.org/x/sync v0.5.0 // indirect
 +	golang.org/x/sys v0.18.0 // indirect
  	golang.org/x/term v0.18.0 // indirect
--	golang.org/x/text v0.14.0 // indirect
-+	golang.org/x/text v0.15.0 // indirect
+ 	golang.org/x/text v0.14.0 // indirect
  	golang.org/x/time v0.3.0 // indirect
+-	golang.org/x/tools v0.16.1 // indirect
  	google.golang.org/appengine v1.6.7 // indirect
- 	google.golang.org/genproto v0.0.0-20230525234025-438c736192d0 // indirect
-@@ -175,17 +109,14 @@ require (
+ 	google.golang.org/genproto v0.0.0-20230526161137-0005af68ea54 // indirect
+ 	google.golang.org/genproto/googleapis/api v0.0.0-20230525234035-dd9d682886f9 // indirect
  	google.golang.org/genproto/googleapis/rpc v0.0.0-20230525234030-28d5490b6b19 // indirect
  	gopkg.in/inf.v0 v0.9.1 // indirect
  	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 -	gopkg.in/warnings.v0 v0.1.2 // indirect
  	gopkg.in/yaml.v3 v3.0.1 // indirect
- 	k8s.io/controller-manager v0.27.14 // indirect
--	k8s.io/cri-api v0.0.0 // indirect
+ 	k8s.io/apiextensions-apiserver v0.0.0 // indirect
+ 	k8s.io/controller-manager v0.28.10 // indirect
+-	k8s.io/cri-api v0.28.10 // indirect
  	k8s.io/csi-translation-lib v0.27.0 // indirect
  	k8s.io/dynamic-resource-allocation v0.0.0 // indirect
- 	k8s.io/kms v0.27.14 // indirect
- 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect
--	k8s.io/kube-proxy v0.0.0 // indirect
+ 	k8s.io/kms v0.28.10 // indirect
+ 	k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 // indirect
  	k8s.io/kube-scheduler v0.0.0 // indirect
 -	k8s.io/kubectl v0.0.0 // indirect
-+	k8s.io/kubelet v0.27.14 // indirect
++	k8s.io/kubelet v0.28.10 // indirect
  	k8s.io/mount-utils v0.26.0-alpha.0 // indirect
  	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.1.2 // indirect
  	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
+ 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
++	sigs.k8s.io/yaml v1.3.0 // indirect
+ )
+ 
+ replace github.com/aws/aws-sdk-go/service/eks => github.com/aws/aws-sdk-go/service/eks v1.38.49
 diff --git a/cluster-autoscaler/go.sum b/cluster-autoscaler/go.sum
-index e4bfc8112..9e710477c 100644
+index 9aa0950e3..a55c20070 100644
 --- a/cluster-autoscaler/go.sum
 +++ b/cluster-autoscaler/go.sum
 @@ -1,4 +1,3 @@
@@ -245,18 +249,22 @@ index e4bfc8112..9e710477c 100644
  cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
  cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
  cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIAii9o8iA=
-@@ -50,207 +34,76 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
+@@ -50,214 +34,73 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
  cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
  cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
  dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+-github.com/Azure/azure-sdk-for-go v46.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 -github.com/Azure/azure-sdk-for-go v68.0.0+incompatible h1:fcYLmCpyNYRnvJbPerq7U0hS+6+I79yEDJBqVNcqUzU=
 -github.com/Azure/azure-sdk-for-go v68.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 -github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 -github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 -github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
+-github.com/Azure/go-autorest/autorest v0.11.4/go.mod h1:JFgpikqFJ/MleTTxwepExTKnFUKKszPS8UavbQYUMuw=
 -github.com/Azure/go-autorest/autorest v0.11.17/go.mod h1:eipySxLmqSyC5s5k1CLupqet0PSENBEDP93LQ9a8QYw=
 -github.com/Azure/go-autorest/autorest v0.11.29 h1:I4+HL/JDvErx2LjyzaVxllw2lRDB5/BT2Bm4g20iqYw=
 -github.com/Azure/go-autorest/autorest v0.11.29/go.mod h1:ZtEzC4Jy2JDrZLxvWs8LrBWEBycl1hbT1eknI8MtfAs=
+-github.com/Azure/go-autorest/autorest/adal v0.9.0/go.mod h1:/c022QCutn2P7uY+/oQWWNcK9YU+MH96NgK+jErpbcg=
+-github.com/Azure/go-autorest/autorest/adal v0.9.2/go.mod h1:/3SMAM86bP6wC9Ev35peQDUeqFZBMH07vvUOmg4z/fE=
 -github.com/Azure/go-autorest/autorest/adal v0.9.5/go.mod h1:B7KF7jKIeC9Mct5spmyCB/A8CG/sEz1vwIRGv/bbw7A=
 -github.com/Azure/go-autorest/autorest/adal v0.9.11/go.mod h1:nBKAnTomx8gDtl+3ZCJv2v0KACFHWTB2drffI1B68Pk=
 -github.com/Azure/go-autorest/autorest/adal v0.9.22/go.mod h1:XuAbAEUv2Tta//+voMI038TrJBqjKam0me7qR+L8Cmk=
@@ -268,11 +276,13 @@ index e4bfc8112..9e710477c 100644
 -github.com/Azure/go-autorest/autorest/azure/cli v0.4.2/go.mod h1:7qkJkT+j6b+hIpzMOwPChJhTqS8VbsqqgULzMNRugoM=
 -github.com/Azure/go-autorest/autorest/date v0.3.0 h1:7gUk1U5M/CQbp9WoqinNzJar+8KY+LPI6wiWrP/myHw=
 -github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSYnokU+TrmwEsOqdt8Y6sso74=
+-github.com/Azure/go-autorest/autorest/mocks v0.4.0/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
 -github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
 -github.com/Azure/go-autorest/autorest/mocks v0.4.2 h1:PGN4EDXnuQbojHbU0UWoNvmu9AGVwYHG9/fkDYhtAfw=
 -github.com/Azure/go-autorest/autorest/mocks v0.4.2/go.mod h1:Vy7OitM9Kei0i1Oj+LvyAWMXJHeKH1MVlzFugfVrmyU=
 -github.com/Azure/go-autorest/autorest/to v0.4.0 h1:oXVqrxakqqV1UZdSazDOPOLvOIz+XA683u8EctwboHk=
 -github.com/Azure/go-autorest/autorest/to v0.4.0/go.mod h1:fE8iZBn7LQR7zH/9XU2NcPR4o9jEImooCeWJcYV/zLE=
+-github.com/Azure/go-autorest/autorest/validation v0.3.0/go.mod h1:yhLgjC0Wda5DYXl6JAsWyUe4KVNffhoDhG0zVzUMo3E=
 -github.com/Azure/go-autorest/autorest/validation v0.3.1 h1:AgyqjAd94fwNAoTjl/WQXg4VvFeRFpO+UhNyRXqF1ac=
 -github.com/Azure/go-autorest/autorest/validation v0.3.1/go.mod h1:yhLgjC0Wda5DYXl6JAsWyUe4KVNffhoDhG0zVzUMo3E=
 -github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
@@ -280,8 +290,8 @@ index e4bfc8112..9e710477c 100644
 -github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 -github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 -github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
--github.com/Azure/skewer v0.0.17 h1:2jyvHdU+uO9UVylvVq/YEG3OIQLsCeFezFmJW00rEQc=
--github.com/Azure/skewer v0.0.17/go.mod h1:5207ue3Zm+E8QW/e0MISrocDm8pSApfsTe048VaGnN0=
+-github.com/Azure/skewer v0.0.14 h1:0mzUJhspECkajYyynYsOCp//E2PSnYXrgP45bcskqfQ=
+-github.com/Azure/skewer v0.0.14/go.mod h1:6WTecuPyfGtuvS8Mh4JYWuHhO4kcWycGfsUBB+XTFG4=
  github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
  github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 -github.com/GoogleCloudPlatform/k8s-cloud-provider v1.18.1-0.20220218231025-f11817397a1b h1:Heo1J/ttaQFgGJSVnCZquy3e5eH5j1nqxBuomztB3P0=
@@ -289,8 +299,9 @@ index e4bfc8112..9e710477c 100644
 -github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab h1:UKkYhof1njT1/xq4SEg5z+VpTgjmNeHwPGRQl7takDI=
 -github.com/JeffAshton/win_pdh v0.0.0-20161109143554-76bb4ee9f0ab/go.mod h1:3VYc5hodBMJ5+l/7J4xAyMeuM2PNuepvHlGs8yilUCA=
 -github.com/Microsoft/go-winio v0.4.15/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
--github.com/Microsoft/go-winio v0.4.17 h1:iT12IBVClFevaf8PuVyi3UmZOVh4OqnaLxDTW2O6j3w=
 -github.com/Microsoft/go-winio v0.4.17/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
+-github.com/Microsoft/go-winio v0.6.0 h1:slsWYD/zyx7lCXoZVlvQrj0hPTM1HI4+v1sIda2yDvg=
+-github.com/Microsoft/go-winio v0.6.0/go.mod h1:cTAf44im0RAYeL23bpB+fzCyDH2MJiz2BO69KH/soAE=
 -github.com/Microsoft/hcsshim v0.8.25 h1:fRMwXiwk3qDwc0P05eHnh+y2v07JdtsfQ1fuAc69m9g=
 -github.com/Microsoft/hcsshim v0.8.25/go.mod h1:4zegtUJth7lAvFyc6cH2gGQ5B3OFQim01nnU2M8jKDg=
  github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
@@ -323,10 +334,9 @@ index e4bfc8112..9e710477c 100644
 -github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
  github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
  github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
- github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 -github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
- github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+MN3u4=
- github.com/cenkalti/backoff/v4 v4.2.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+ github.com/cenkalti/backoff/v4 v4.2.1 h1:y4OZtCnogmCPw98Zjyt5a6+QwPLGkiQsYW5oUqylYbM=
+ github.com/cenkalti/backoff/v4 v4.2.1/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
  github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
  github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
  github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
@@ -339,8 +349,9 @@ index e4bfc8112..9e710477c 100644
  github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
  github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 -github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
--github.com/cilium/ebpf v0.7.0 h1:1k/q3ATgxSXRdrmPfH8d7YK0GfqVsEKZAX9dQZvs56k=
 -github.com/cilium/ebpf v0.7.0/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2usCA=
+-github.com/cilium/ebpf v0.9.1 h1:64sn2K3UKw8NbP/blsixRpF3nXuyhz/VjRlRzvlBRu4=
+-github.com/cilium/ebpf v0.9.1/go.mod h1:+OhNOIXx/Fnu1IE8bJz2dzOA+VSfyTfdNUVdlQnxUFY=
  github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
  github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 -github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -352,10 +363,11 @@ index e4bfc8112..9e710477c 100644
 -github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
  github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
  github.com/cncf/xds/go v0.0.0-20230607035331-e9ce68804cb4 h1:/inchEIKaYC1Akx+H+gqO04wryn5h75LSazbRlnya1k=
--github.com/container-storage-interface/spec v1.7.0 h1:gW8eyFQUZWWrMWa8p1seJ28gwDoN5CVJ4uAbQ+Hdycw=
--github.com/container-storage-interface/spec v1.7.0/go.mod h1:JYuzLqr9VVNoDJl44xp/8fmCOvWPDKzuGTwCoklhuqk=
--github.com/containerd/cgroups v1.0.1 h1:iJnMvco9XGvKUvNQkv88bE4uJXxRQH18efbKo9w5vHQ=
+-github.com/container-storage-interface/spec v1.8.0 h1:D0vhF3PLIZwlwZEf2eNbpujGCNwspwTYf2idJRJx4xI=
+-github.com/container-storage-interface/spec v1.8.0/go.mod h1:ROLik+GhPslwwWRNFF1KasPzroNARibH2rfz1rkg4H0=
 -github.com/containerd/cgroups v1.0.1/go.mod h1:0SJrPIenamHDcZhEcJMNBB85rHcUsw4f25ZfBiPYRkU=
+-github.com/containerd/cgroups v1.1.0 h1:v8rEWFl6EoqHB+swVNjVoCJE8o3jX7e8nqBGPLaDFBM=
+-github.com/containerd/cgroups v1.1.0/go.mod h1:6ppBcbh/NOOUU+dMKrykgaBnK9lCIBxHqJDGwsa1mIw=
 -github.com/containerd/console v1.0.1/go.mod h1:XUsP6YE/mKtz6bxc+I8UiKKTP04qjQL4qcS3XoQ5xkw=
 -github.com/containerd/console v1.0.2/go.mod h1:ytZPjGgY2oeTkAONYafi2kSj0aYggsf8acV1PGKCbzQ=
 -github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
@@ -364,8 +376,9 @@ index e4bfc8112..9e710477c 100644
 -github.com/containerd/continuity v0.1.0/go.mod h1:ICJu0PwR54nI0yPEnJ6jcS+J7CZAUXrLh8lPo2knzsM=
 -github.com/containerd/fifo v1.0.0/go.mod h1:ocF/ME1SX5b1AOlWi9r677YJmCPSwwWnQ9O123vzpE4=
 -github.com/containerd/go-runc v1.0.0/go.mod h1:cNU0ZbCgCQVZK4lgG3P+9tn9/PaJNmoDXPpoJhDR+Ok=
--github.com/containerd/ttrpc v1.1.0 h1:GbtyLRxb0gOLR0TYQWt3O6B0NvT8tMdorEHqIQo/lWI=
 -github.com/containerd/ttrpc v1.1.0/go.mod h1:XX4ZTnoOId4HklF4edwc4DcqskFZuvXB1Evzy5KFQpQ=
+-github.com/containerd/ttrpc v1.2.2 h1:9vqZr0pxwOF5koz6N0N3kJ0zDHokrcPxIR/ZR2YFtOs=
+-github.com/containerd/ttrpc v1.2.2/go.mod h1:sIT6l32Ph/H9cvnJsfXM5drIVzTr5A2flTf1G5tYZak=
 -github.com/containerd/typeurl v1.0.2 h1:Chlt8zIieDbzQFzXzAeBEF92KhExuE4p9p92/QmY7aY=
 -github.com/containerd/typeurl v1.0.2/go.mod h1:9trJWW2sRlGub4wZJRTW83VtbOLS6hwcDZXTn6oPz9s=
 -github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
@@ -398,8 +411,9 @@ index e4bfc8112..9e710477c 100644
 -github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
 -github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
 -github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
- github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
- github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+-github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+ github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
+ github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 -github.com/docker/docker v20.10.21+incompatible h1:UTLdBmHk3bEY+w8qeO5KttOhy6OmXWsl/FEet9Uswog=
 -github.com/docker/docker v20.10.21+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 -github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
@@ -407,9 +421,8 @@ index e4bfc8112..9e710477c 100644
 -github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 -github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 -github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
- github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
- github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 -github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
  github.com/emicklei/go-restful/v3 v3.10.2 h1:hIovbnmBTLjHXkqEBUz3HGpXZdM7ZrE9fJIZIqlJLqE=
  github.com/emicklei/go-restful/v3 v3.10.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
  github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -429,14 +442,12 @@ index e4bfc8112..9e710477c 100644
  github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
  github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
  github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
- github.com/flowstack/go-jsonschema v0.1.1/go.mod h1:yL7fNggx1o8rm9RlgXv7hTBWxdBM0rVwpMwimd3F3N0=
 -github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
--github.com/frankban/quicktest v1.11.3 h1:8sXhOn0uLys67V8EsXLc6eszDs8VXWxL3iRvebPhedY=
 -github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
+-github.com/frankban/quicktest v1.14.0 h1:+cqqvzZV87b4adx/5ayVOaYZ2CrvM4ejQvUdBzPPUss=
 -github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
  github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
  github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
--github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
  github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
  github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
  github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -453,7 +464,7 @@ index e4bfc8112..9e710477c 100644
  github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
  github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
  github.com/go-logr/logr v1.2.4 h1:g01GSCwiDw2xSZfjJ2/T9M+S6pFdcNtFYsp+Y43HYDQ=
-@@ -265,26 +118,15 @@ github.com/go-openapi/jsonreference v0.20.2 h1:3sVjiK66+uXK/6oQ8xgcRKcFgQ5KXa2Kv
+@@ -272,26 +115,14 @@ github.com/go-openapi/jsonreference v0.20.2 h1:3sVjiK66+uXK/6oQ8xgcRKcFgQ5KXa2Kv
  github.com/go-openapi/jsonreference v0.20.2/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En5Ap4rVB5KVcIDZG2k=
  github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/g=
  github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
@@ -463,8 +474,8 @@ index e4bfc8112..9e710477c 100644
  github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 -github.com/godbus/dbus/v5 v5.0.6 h1:mkgN1ofwASrYnJ5W6U/BxG15eXXXjirgZc7CLqkcaro=
 -github.com/godbus/dbus/v5 v5.0.6/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
--github.com/gofrs/uuid v4.2.0+incompatible h1:yyYWMnhkhrKwwr8gAOcOCYxOOscHgDS9yZgBrnJfGa0=
--github.com/gofrs/uuid v4.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+-github.com/gofrs/uuid v4.4.0+incompatible h1:3qXRTX8/NbyulANqlc0lchS1gqAVxRgsuW1YrTJupqA=
+-github.com/gofrs/uuid v4.4.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 -github.com/gogo/googleapis v1.4.1/go.mod h1:2lpHqI5OcWCtVElxXnPt+s8oJvMpySlOyM6xDCrzib4=
 -github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 -github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
@@ -472,7 +483,7 @@ index e4bfc8112..9e710477c 100644
  github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 -github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
  github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
- github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+-github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
  github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
  github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
  github.com/golang/glog v1.1.0 h1:/d3pCKDPWNnvIWe0vVUpNP32qc8U3PDVxySP/y360qE=
@@ -480,7 +491,7 @@ index e4bfc8112..9e710477c 100644
  github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
  github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
  github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
-@@ -297,7 +139,6 @@ github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
+@@ -304,7 +135,6 @@ github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
  github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
  github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
  github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
@@ -488,7 +499,7 @@ index e4bfc8112..9e710477c 100644
  github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
  github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
  github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-@@ -315,16 +156,12 @@ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QD
+@@ -322,16 +152,12 @@ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QD
  github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
  github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
  github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
@@ -500,12 +511,12 @@ index e4bfc8112..9e710477c 100644
  github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
  github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
  github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
--github.com/google/cadvisor v0.47.2 h1:lOS3Yprk88AIUi260eKYmTC4pKWAFkXV6Xev5jfCIP8=
--github.com/google/cadvisor v0.47.2/go.mod h1:iJdTjcjyKHjLCf7OSTzwP5GxdfrkPusw2x5bwGvuLUw=
- github.com/google/cel-go v0.14.0 h1:LFobwuUDslWUHdQ48SXVXvQgPH2X1XVhsgOGNioAEZ4=
- github.com/google/cel-go v0.14.0/go.mod h1:YzWEoI07MC/a/wj9in8GeVatqfypkldgBlwXh9bCwqY=
- github.com/google/gnostic v0.6.9 h1:ZK/5VhkoX835RikCHpSUJV9a+S3e1zLh59YnyWeBW+0=
-@@ -336,23 +173,15 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
+-github.com/google/cadvisor v0.47.3 h1:5XKTHBduWlBjmgw07uwEiC+Xa/FRd0MZI37oqlTagO0=
+-github.com/google/cadvisor v0.47.3/go.mod h1:iJdTjcjyKHjLCf7OSTzwP5GxdfrkPusw2x5bwGvuLUw=
+ github.com/google/cel-go v0.16.1 h1:3hZfSNiAU3KOiNtxuFXVp5WFy4hf/Ly3Sa4/7F8SXNo=
+ github.com/google/cel-go v0.16.1/go.mod h1:HXZKzB0LXqer5lHHgfWAnlYwJaQBDKMjxjulNQzhwhY=
+ github.com/google/gnostic-models v0.6.8 h1:yo/ABAfM5IMRsS1VnXjTBvUb61tFIHozhlYvRgGre9I=
+@@ -343,23 +169,15 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
  github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
  github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
  github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -529,7 +540,7 @@ index e4bfc8112..9e710477c 100644
  github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
  github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
  github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
-@@ -360,34 +189,17 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
+@@ -367,34 +185,17 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
  github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
  github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
  github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
@@ -564,7 +575,7 @@ index e4bfc8112..9e710477c 100644
  github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
  github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
  github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0/go.mod h1:hgWBS7lorOAVIJEQMi4ZsPv9hVvWI6+ch50m39Pf2Ks=
-@@ -395,40 +207,20 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2 h1:gDLXvp5S9izjldquuoAhDzccbsk
+@@ -402,40 +203,20 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2 h1:gDLXvp5S9izjldquuoAhDzccbsk
  github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.2/go.mod h1:7pdNwVWBBHGiCxa9lAszqCJMbfTISJ7oMftp8+UGV08=
  github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
  github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -603,9 +614,9 @@ index e4bfc8112..9e710477c 100644
 -github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 -github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
  github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
- github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
  github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-@@ -437,189 +229,80 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+@@ -443,185 +224,72 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
  github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
  github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
  github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
@@ -625,8 +636,6 @@ index e4bfc8112..9e710477c 100644
 -github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 -github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 -github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
- github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
- github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 -github.com/moby/ipvs v1.1.0 h1:ONN4pGaZQgAx+1Scz5RvWV4Q7Gb+mvfRh3NsPS+1XQQ=
 -github.com/moby/ipvs v1.1.0/go.mod h1:4VJMWuf098bsUMmZEiD4Tjk/O7mOn3l1PTD3s4OoYAs=
 -github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
@@ -654,17 +663,15 @@ index e4bfc8112..9e710477c 100644
 -github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 -github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 -github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
- github.com/onsi/ginkgo/v2 v2.9.7 h1:06xGQy5www2oN160RtEZoTvnP2sPhEfePYmCDc2szss=
-+github.com/onsi/ginkgo/v2 v2.9.7/go.mod h1:cxrmXWykAwTwhQsJOPfdIDiJ+l2RYq7U8hFU+M/1uw0=
- github.com/onsi/gomega v1.27.7 h1:fVih9JD6ogIiHUN6ePK7HJidyEDpWGVB5mzM7cWNXoU=
-+github.com/onsi/gomega v1.27.7/go.mod h1:1p8OOlwo2iUUDsHnOrjE5UKYJ+e3W8eQ3qSlRahPmr4=
+ github.com/onsi/ginkgo/v2 v2.9.4 h1:xR7vG4IXt5RWx6FfIjyAtsoMAtnc3C/rFXBBd2AjZwE=
+ github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=
  github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
  github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 -github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
 -github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 -github.com/opencontainers/runc v1.1.4/go.mod h1:1J5XiS+vdZ3wCyZybsuxXZWGrgSr8fFJHLXuG2PsnNg=
--github.com/opencontainers/runc v1.1.6 h1:XbhB8IfG/EsnhNvZtNdLB0GBw92GYEFvKlhaJk9jUgA=
--github.com/opencontainers/runc v1.1.6/go.mod h1:CbUumNnWCuTGFukNXahoo/RFBZvDAgRh/smNYNOhA50=
+-github.com/opencontainers/runc v1.1.7 h1:y2EZDS8sNng4Ksf0GUYNhKbTShZJPJg1FiXJNH/uoCk=
+-github.com/opencontainers/runc v1.1.7/go.mod h1:CbUumNnWCuTGFukNXahoo/RFBZvDAgRh/smNYNOhA50=
 -github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 -github.com/opencontainers/runtime-spec v1.0.3-0.20200929063507-e6143ca7d51d/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 -github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
@@ -685,14 +692,16 @@ index e4bfc8112..9e710477c 100644
 -github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 -github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 -github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
- github.com/prometheus/client_golang v1.14.0 h1:nJdhIvne2eSX/XRAFV9PcvFFRbrjbcTUj0VP62TMhnw=
- github.com/prometheus/client_golang v1.14.0/go.mod h1:8vpkKitgIVNcqrRBWh1C4TIUQgYNtG/XQE4E/Zae36Y=
+-github.com/prometheus/client_golang v1.14.0/go.mod h1:8vpkKitgIVNcqrRBWh1C4TIUQgYNtG/XQE4E/Zae36Y=
+ github.com/prometheus/client_golang v1.16.0 h1:yk/hx9hDbrGHovbci4BY+pRMfSuuat626eFsHb7tmT8=
+ github.com/prometheus/client_golang v1.16.0/go.mod h1:Zsulrv/L9oM40tJ7T815tM89lFEugiJ9HzIqaAx4LKc=
 -github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 -github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
  github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 -github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
- github.com/prometheus/client_model v0.3.0 h1:UBgGFHqYdG/TPFD1B1ogZywDqEkwp3fBMvqdiQ7Xew4=
- github.com/prometheus/client_model v0.3.0/go.mod h1:LDGWKZIo7rky3hgvBe+caln+Dr3dPggB5dvjtD7w9+w=
+-github.com/prometheus/client_model v0.3.0/go.mod h1:LDGWKZIo7rky3hgvBe+caln+Dr3dPggB5dvjtD7w9+w=
+ github.com/prometheus/client_model v0.4.0 h1:5lQXD3cAg1OXBf4Wq03gTrXHeaV0TQvGfUooCfx1yqY=
+ github.com/prometheus/client_model v0.4.0/go.mod h1:oMQmHW1/JoDwqLtg57MGgP/Fb1CJEYF2imWWhWtMkYU=
 -github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 -github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 -github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
@@ -700,8 +709,8 @@ index e4bfc8112..9e710477c 100644
 -github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=
 -github.com/prometheus/common v0.32.1/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
 -github.com/prometheus/common v0.37.0/go.mod h1:phzohg0JFMnBEFGxTDbfu3QyL5GI8gTQJFhYO5B3mfA=
- github.com/prometheus/common v0.42.0 h1:EKsfXEYo4JpWMHH5cg+KOUWeuJSov1Id8zGR8eeI1YM=
- github.com/prometheus/common v0.42.0/go.mod h1:xBwqVerjNdUDjgODMpudtOMwlOwf2SaTr1yjz4b7Zbc=
+ github.com/prometheus/common v0.44.0 h1:+5BrQJwiBB9xsMygAB3TNvpQKOwlkc25LbISbrdOOfY=
+ github.com/prometheus/common v0.44.0/go.mod h1:ofAIvZbQ1e/nugmZGz4/qCb9Ap1VoSTIO7x0VV9VvuY=
 -github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 -github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 -github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
@@ -709,21 +718,22 @@ index e4bfc8112..9e710477c 100644
 -github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 -github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 -github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
- github.com/prometheus/procfs v0.9.0 h1:wzCHvIvM5SxWqYvwgVL7yJY8Lz3PKn49KQtpgMYJfhI=
- github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB/chUwxUZY=
+ github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+PymziUAg=
+ github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 -github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 -github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
  github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
  github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
- github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
+ github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 -github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021 h1:if3/24+h9Sq6eDx8UUz1SO9cT9tizyIsATfB7b4D3tc=
 -github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021/go.mod h1:DM5xW0nvfNNm2uytzsvhI3OnX8uzaRAg8UX/CnDqbto=
 -github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
  github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 -github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 -github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
--github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646 h1:RpforrEYXWkmGwJHIGnLZ3tTWStkjVVstwzNGqxX2Ds=
 -github.com/seccomp/libseccomp-golang v0.9.2-0.20220502022130-f33da4d89646/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
+-github.com/seccomp/libseccomp-golang v0.10.0 h1:aA4bp+/Zzi0BnWZ2F1wgNBs5gTpm+na2rWM6M9YjLpY=
+-github.com/seccomp/libseccomp-golang v0.10.0/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
 -github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 -github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 -github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
@@ -747,7 +757,6 @@ index e4bfc8112..9e710477c 100644
  github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
  github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 -github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
- github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
  github.com/stoewer/go-strcase v1.3.0 h1:g0eASXYtp+yvN9fK8sH94oCIk0fau9uV1/ZdJ0AVEzs=
  github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
  github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -764,9 +773,8 @@ index e4bfc8112..9e710477c 100644
  github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
  github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
  github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
--github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
- github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
- github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+ github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+ github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 -github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635 h1:kdXcSzyDtseVEc4yCz2qF8ZrQvIDBJLl4S1c3GCXmoI=
 -github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 -github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -777,13 +785,10 @@ index e4bfc8112..9e710477c 100644
 -github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
 -github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 -github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
--github.com/vishvananda/netns v0.0.2 h1:Cn05BRLm+iRP/DZxyVSsfVyrzgjDbwHwkVt38qvXnNI=
--github.com/vishvananda/netns v0.0.2/go.mod h1:yitZXdAVI+yPFSb4QUe+VW3vOVl4PZPNcBgbPxAtJxw=
+-github.com/vishvananda/netns v0.0.4 h1:Oeaw1EM2JMxD51g9uhtC0D7erkIjgmj8+JZc26m1YX8=
+-github.com/vishvananda/netns v0.0.4/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 -github.com/vmware/govmomi v0.30.6 h1:O3tjSwQBy0XwI5uK1/yVIfQ1LP9bAECEDUfifnyGs9U=
 -github.com/vmware/govmomi v0.30.6/go.mod h1:epgoslm97rLECMV4D+08ORzUBEU7boFSepKjt7AYVGg=
- github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
- github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
- github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
  github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
 -github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 -github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
@@ -794,10 +799,10 @@ index e4bfc8112..9e710477c 100644
  github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 -github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 -go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
- go.etcd.io/bbolt v1.3.6 h1:/ecaJf0sk1l4l6V4awd65v2C3ILy7MSj+s/x1ADCIMU=
- go.etcd.io/etcd/api/v3 v3.5.7 h1:sbcmosSVesNrWOJ58ZQFitHMdncusIifYcrBfwrlJSY=
- go.etcd.io/etcd/api/v3 v3.5.7/go.mod h1:9qew1gCdDDLu+VwmeG+iFpL+QlpHTo7iubavdVDgCAA=
-@@ -636,17 +319,10 @@ go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
+ go.etcd.io/bbolt v1.3.7 h1:j+zJOnnEjF/kyHlDDgGnVL/AIqIJPq8UoB2GSNfkUfQ=
+ go.etcd.io/etcd/api/v3 v3.5.9 h1:4wSsluwyTbGGmyjJktOf3wFQoTBIURXHnq9n/G/JQHs=
+ go.etcd.io/etcd/api/v3 v3.5.9/go.mod h1:uyAal843mC8uUVSLWz6eHa/d971iDGnCRpmKd2Z+X8k=
+@@ -638,17 +306,10 @@ go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
  go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
  go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
  go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -815,7 +820,7 @@ index e4bfc8112..9e710477c 100644
  go.opentelemetry.io/otel v1.14.0 h1:/79Huy8wbf5DnIPhemGB+zEPVwnN6fuQybr/SRXa6hM=
  go.opentelemetry.io/otel v1.14.0/go.mod h1:o4buv+dJzx8rohcUeRmWUZhqupFvzWis188WlggnNeU=
  go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.14.0 h1:/fXHZHGvro6MVqV34fJzDhi7sHGpX3Ej/Qjmfn003ho=
-@@ -664,31 +340,22 @@ go.opentelemetry.io/otel/trace v1.14.0/go.mod h1:8avnQLK+CG77yNLUae4ea2JDQ6iT+go
+@@ -666,32 +327,22 @@ go.opentelemetry.io/otel/trace v1.14.0/go.mod h1:8avnQLK+CG77yNLUae4ea2JDQ6iT+go
  go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
  go.opentelemetry.io/proto/otlp v0.19.0 h1:IVN6GR+mhC4s5yfcTbmzHYODqvWAp3ZedA2SJPI1Nnw=
  go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
@@ -839,6 +844,7 @@ index e4bfc8112..9e710477c 100644
  golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
  golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
  golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+-golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 -golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 -golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 -golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
@@ -847,7 +853,7 @@ index e4bfc8112..9e710477c 100644
  golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
  golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
  golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-@@ -715,8 +382,6 @@ golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHl
+@@ -718,8 +369,6 @@ golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHl
  golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRuDixDT3tpyyb+LUpUlRWLxfhWrs=
  golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
  golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
@@ -856,7 +862,7 @@ index e4bfc8112..9e710477c 100644
  golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
  golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
  golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
-@@ -725,23 +390,16 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
+@@ -728,25 +377,16 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
  golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
  golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -864,6 +870,8 @@ index e4bfc8112..9e710477c 100644
 -golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
  golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 -golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+-golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
+-golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
  golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
  golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 -golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -880,7 +888,7 @@ index e4bfc8112..9e710477c 100644
  golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
  golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
  golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-@@ -760,45 +418,16 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
+@@ -765,44 +405,15 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
  golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
  golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
  golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -894,7 +902,6 @@ index e4bfc8112..9e710477c 100644
  golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 -golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 -golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
- golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 -golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 -golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 -golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
@@ -923,10 +930,10 @@ index e4bfc8112..9e710477c 100644
 -golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
  golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 -golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
- golang.org/x/oauth2 v0.7.0 h1:qe6s0zUXlPX80/dITx3440hWZ7GwMwgDDyrSGTPJG/g=
- golang.org/x/oauth2 v0.7.0/go.mod h1:hPLQkd9LyjfXTiRohC/41GhcFqxisoUQ99sCUOHO9x4=
+ golang.org/x/oauth2 v0.8.0 h1:6dkIjl3j3LtZ/O3sTgZTMsLKSftL/B8Zgq4huOIIUu8=
+ golang.org/x/oauth2 v0.8.0/go.mod h1:yr7u4HXZRm1R1kBWqr/xKNqewf0plRYoB7sla+BCIXE=
  golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-@@ -810,33 +439,22 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
+@@ -814,33 +425,22 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
  golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
  golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -960,7 +967,7 @@ index e4bfc8112..9e710477c 100644
  golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
  golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
  golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-@@ -849,54 +467,17 @@ golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7w
+@@ -853,53 +453,16 @@ golang.org/x/sys v0.0.0-20200501052902-10377860bb8e/go.mod h1:h1NjWce9XRLGQEsW7w
  golang.org/x/sys v0.0.0-20200511232937-7e40ca221e25/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
  golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
  golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -981,7 +988,7 @@ index e4bfc8112..9e710477c 100644
 -golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 -golang.org/x/sys v0.0.0-20210324051608-47abb6519492/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
  golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
- golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+-golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
  golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 -golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 -golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1002,7 +1009,6 @@ index e4bfc8112..9e710477c 100644
 -golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 -golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
--golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 -golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 -golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
  golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
@@ -1015,23 +1021,21 @@ index e4bfc8112..9e710477c 100644
  golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=
  golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=
  golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-@@ -904,21 +485,15 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+@@ -907,13 +470,7 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
  golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 -golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
  golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
- golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 -golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 -golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 -golang.org/x/text v0.5.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 -golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
--golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
--golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
-+golang.org/x/text v0.15.0 h1:h1V/4gjBv8v9cjcR6+AR5+/cIYK5N/WAgiv4xlsEtAk=
-+golang.org/x/text v0.15.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+ golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+ golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
  golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
- golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+@@ -921,7 +478,6 @@ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxb
  golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
  golang.org/x/time v0.3.0 h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=
  golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -1039,7 +1043,7 @@ index e4bfc8112..9e710477c 100644
  golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
  golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
  golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
-@@ -930,7 +505,6 @@ golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBn
+@@ -933,7 +489,6 @@ golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBn
  golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
  golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
  golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
@@ -1047,7 +1051,7 @@ index e4bfc8112..9e710477c 100644
  golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
  golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
  golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-@@ -962,19 +536,8 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
+@@ -965,21 +520,9 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
  golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
  golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
  golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
@@ -1065,9 +1069,11 @@ index e4bfc8112..9e710477c 100644
 -golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 -golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
  golang.org/x/tools v0.16.1 h1:TLyB3WofjdOEepBHAU20JdNC1Zbg87elYofWYAY5oZA=
+-golang.org/x/tools v0.16.1/go.mod h1:kYVVN6I1mBNoB1OX+noeBjbRk4IUEPa7JJ+TJMEooJ0=
  golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
  golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-@@ -996,22 +559,6 @@ google.golang.org/api v0.24.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0M
+ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+@@ -1000,22 +543,6 @@ google.golang.org/api v0.24.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0M
  google.golang.org/api v0.28.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0MncE=
  google.golang.org/api v0.29.0/go.mod h1:Lcubydp8VUV7KeIHD9z2Bys/sm/vGKnG1UHuDBSrHWM=
  google.golang.org/api v0.30.0/go.mod h1:QGmEvQ87FHZNiUVJkT14jQNYJ4ZJjdRF23ZXz5138Fc=
@@ -1090,7 +1096,7 @@ index e4bfc8112..9e710477c 100644
  google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
  google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
  google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
-@@ -1050,36 +597,8 @@ google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7Fc
+@@ -1054,35 +581,7 @@ google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7Fc
  google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
  google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
  google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -1122,12 +1128,11 @@ index e4bfc8112..9e710477c 100644
 -google.golang.org/genproto v0.0.0-20210924002016-3dee208752a0/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 -google.golang.org/genproto v0.0.0-20211021150943-2b146023228c/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
  google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
- google.golang.org/genproto v0.0.0-20220107163113-42d7afdf6368/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 -google.golang.org/genproto v0.0.0-20220502173005-c8bf987b8c21/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
- google.golang.org/genproto v0.0.0-20230525234025-438c736192d0 h1:x1vNwUhVOcsYoKyEGCZBH694SBmmBjA2EfauFVEI2+M=
- google.golang.org/genproto v0.0.0-20230525234025-438c736192d0/go.mod h1:9ExIQyXL5hZrHzQceCwuSYwZZ5QZBazOcprJ5rgs3lY=
- google.golang.org/genproto/googleapis/api v0.0.0-20230525234020-1aefcd67740a h1:HiYVD+FGJkTo+9zj1gqz0anapsa1JxjiSrN+BJKyUmE=
-@@ -1088,7 +607,6 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20230525234030-28d5490b6b19 h1:
+ google.golang.org/genproto v0.0.0-20230526161137-0005af68ea54 h1:9NWlQfY2ePejTmfwUH1OWwmznFa+0kKcHGPDvcPza9M=
+ google.golang.org/genproto v0.0.0-20230526161137-0005af68ea54/go.mod h1:zqTuNwFlFRsw5zIts5VnzLQxSRqh+CGOTVMlYbY0Eyk=
+ google.golang.org/genproto/googleapis/api v0.0.0-20230525234035-dd9d682886f9 h1:m8v1xLLLzMe1m5P+gCTF8nJB9epwZQUBERm20Oy1poQ=
+@@ -1091,7 +590,6 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20230525234030-28d5490b6b19 h1:
  google.golang.org/genproto/googleapis/rpc v0.0.0-20230525234030-28d5490b6b19/go.mod h1:66JfowdXAEgad5O9NnYcsNPLCPZJD++2L9X0PCMODrA=
  google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
  google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
@@ -1135,7 +1140,7 @@ index e4bfc8112..9e710477c 100644
  google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
  google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
  google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
-@@ -1099,25 +617,12 @@ google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKa
+@@ -1102,25 +600,12 @@ google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKa
  google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
  google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
  google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
@@ -1161,7 +1166,7 @@ index e4bfc8112..9e710477c 100644
  google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
  google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
  google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
-@@ -1131,34 +636,21 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
+@@ -1134,42 +619,26 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
  google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
  google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
  google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
@@ -1172,7 +1177,7 @@ index e4bfc8112..9e710477c 100644
 -gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
  gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
  gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
- gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
  gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
  gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
  gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
@@ -1196,7 +1201,6 @@ index e4bfc8112..9e710477c 100644
  gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
  gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
  gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-@@ -1166,8 +658,6 @@ gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C
  gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
  gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
  gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
@@ -1205,56 +1209,53 @@ index e4bfc8112..9e710477c 100644
  honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
  honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
  honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
-@@ -1185,43 +675,30 @@ k8s.io/client-go v0.27.14 h1:5KwfSakOTQFRlPru2Ql/wp1URjPgzoP7QpTlEH9a+ys=
- k8s.io/client-go v0.27.14/go.mod h1:cy+p3ijvbPQpdcwg01qnHBmkYDtbOatNC83anA9y18g=
- k8s.io/cloud-provider v0.27.14 h1:tsHiHnUFA5okl1eki6QBRFnJl2NLpsoA/t0K8eC941k=
- k8s.io/cloud-provider v0.27.14/go.mod h1:jmqo9UdtKLZaj8yBiR0YJkKCtnke413DGVodJjo5+BU=
+@@ -1189,22 +658,16 @@ k8s.io/client-go v0.28.10 h1:y+mvUei3+RU0rE7r2BZFA2ApTAsXSN1glGs4QfULLt4=
+ k8s.io/client-go v0.28.10/go.mod h1:JLwjCWhQhvm1F4J+7YAr9WVhSRNmfkRofPWU43m8LZk=
+ k8s.io/cloud-provider v0.28.10 h1:rCPhtwRly52b/4K0AK1UcGXonqvqHLI3loT3p85sNBg=
+ k8s.io/cloud-provider v0.28.10/go.mod h1:Uf8MWMkOG3LRRoooGjmnmCS0DyB80yTu1VAEzcQ94qc=
 -k8s.io/cloud-provider-aws v1.27.0 h1:PF8YrH8QcN6JoXB3Xxlaz84SBDYMPunJuCc0cPuCWXA=
 -k8s.io/cloud-provider-aws v1.27.0/go.mod h1:9vUb5mnVnReSRDBWcBxB1b0HOeEc472iOPmrnwpN9SA=
- k8s.io/component-base v0.27.14 h1:Pdl5bL1TX/MtXsIwUtSctccgZRmrao6GCV3+qfxw0Qs=
- k8s.io/component-base v0.27.14/go.mod h1:eiXBPnqBoczGNS09AtEWxN3Bpj4mI32FGb54S+JAcPg=
- k8s.io/component-helpers v0.27.14 h1:uO/SQIJxhI1UcPD0iwPfZX2ISeZFUZix8pKrQYVs1wY=
- k8s.io/component-helpers v0.27.14/go.mod h1:/gPO2va7MZIX7761AzuaJJu4Ydc1RuhQ28khAwkI7tY=
- k8s.io/controller-manager v0.27.14 h1:ajt3D5DlDT9oVHiJFq+pFdMEqSw44TDv8g+hm7/wNVU=
- k8s.io/controller-manager v0.27.14/go.mod h1:b83fITjwCK2eokwxkQNh90w75AssBoXApgwHwYVnDiM=
--k8s.io/cri-api v0.27.14 h1:cliTAhn5VpM5UDh2xsjsHVm4dG1y5k8Z0ZM5uqVwL4Q=
--k8s.io/cri-api v0.27.14/go.mod h1:l7yoWCx1cRtQ5HV+1Z53qvEH9BFlZatkjvN5dhsG5iY=
- k8s.io/csi-translation-lib v0.27.14 h1:0/I2rHyMpVf6mkfVaSR3QJbothIxsKGHTdLxAJSvmzc=
- k8s.io/csi-translation-lib v0.27.14/go.mod h1:Nbix3IfgemhYnf8ZgrCm0d6uTD/nQmTFB+ophYtJxi0=
- k8s.io/dynamic-resource-allocation v0.27.14 h1:Ea5CSb+RCT1oOuHAVgKwRUyp/xMiTnXAtrbf9cRno2k=
- k8s.io/dynamic-resource-allocation v0.27.14/go.mod h1:4jDyGg40iO4jVsPKNhyQ9+9QO0vlo+5T4jAAKxHbhTY=
+ k8s.io/component-base v0.28.10 h1:q2GEIfUOeVTzAVawbLsl2HVJ40aEYMmMgo61ACwJt2A=
+ k8s.io/component-base v0.28.10/go.mod h1:6NORKNW2SWoximcDE8GZlO0nXVtyVfiM5R5xSVNTRK8=
+ k8s.io/component-helpers v0.28.10 h1:9VWe9/yw9/5mtXRuPMavu543n7Hn669+h5UFPWD0iaM=
+ k8s.io/component-helpers v0.28.10/go.mod h1:rkykkUC93BO9sOWf/EdLEVh6ibw8lq3twCSNIGrNdYo=
+ k8s.io/controller-manager v0.28.10 h1:bSweMCvh88y57G7lb1+NvqrAhfIH/V59CBBWEYyw7G4=
+ k8s.io/controller-manager v0.28.10/go.mod h1:DiItjXeUuokURg1HOxydFw0kbqEwMCNhhutz/EnonZU=
+-k8s.io/cri-api v0.28.10 h1:K5SMbREFibKwvCFiFIeHwjaAMjOQSKuuvj4uMR86Gac=
+-k8s.io/cri-api v0.28.10/go.mod h1:8/bPK3T4irPoj3LjriQc1TAIheeN2yWXR3mz+8jNZ8U=
+ k8s.io/csi-translation-lib v0.28.10 h1:qxSM8WoGg6EMYsI/BrlGsP7XminLQZLXkwJNiY6kGhA=
+ k8s.io/csi-translation-lib v0.28.10/go.mod h1:KLe1tGLhunZ7HJ41a+hbf4b5sZ7vj5NEj3R/D73x5g0=
+ k8s.io/dynamic-resource-allocation v0.28.10 h1:nUnewOgLaE98TS4B8JNvI6A1hYPY4CpwpET+ov52Vwc=
+ k8s.io/dynamic-resource-allocation v0.28.10/go.mod h1:lRM/w30SRsStfKmOnJBojfHN0Blgsy0oRJNz3glHwXs=
 -k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 -k8s.io/klog/v2 v2.80.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
- k8s.io/klog/v2 v2.90.1 h1:m4bYOKall2MmOiRaR1J+We67Do7vm9KiQVlT96lnHUw=
- k8s.io/klog/v2 v2.90.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
- k8s.io/kms v0.27.14 h1:HLfZcj5qga7VdGY/H5gLtTB8Pwc4YHPsLKIP79zDvIc=
- k8s.io/kms v0.27.14/go.mod h1:t8WjiIvumUEBubinXDN73rMOGT8T8kexBVww8ikAnHw=
- k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f h1:2kWPakN3i/k81b0gvD5C5FJ2kxm1WrQFanWchyKuqGg=
- k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f/go.mod h1:byini6yhqGC14c3ebc/QwanvYwhuMWF6yz2F8uwW8eg=
--k8s.io/kube-proxy v0.27.14 h1:ixv0x2Bp0JiJXo1GMoG8yOGIWq04IDYAM2aJ7+sYSb0=
--k8s.io/kube-proxy v0.27.14/go.mod h1:Kf2uhDJvOUeeVqVN6mH/Q6+y+1yea5RvcxUXyJTnGGQ=
- k8s.io/kube-scheduler v0.27.14 h1:BmRs7czAGz3BrXzwfYKGvKVsf8iNIlRZIhQpTygqWKM=
- k8s.io/kube-scheduler v0.27.14/go.mod h1:pON1f+xMXSte1NgVjiCCe8TjonWD2OIzMGnoUGFv2tc=
--k8s.io/kubectl v0.27.14 h1:CWY4q+QrXfqP7njUwJ4MNU1DN+A5F/G5LUbpw/G1O1U=
--k8s.io/kubectl v0.27.14/go.mod h1:wOp4/WGv+ZjjdDLTJAQ639hw7xrKkXWD9LZP7P0fahI=
- k8s.io/kubelet v0.27.14 h1:qcdpj7ZnLK/TfBxJ1WAMkY8M+Mmt4iDWtKVf06jbw6s=
- k8s.io/kubelet v0.27.14/go.mod h1:mXpJmQ/YnpThAo0U7PRaiIcG3qDTX4kAyeV+7TE3IzY=
- k8s.io/kubernetes v1.27.14 h1:NGTkI7LdqxFjkKRwO10HXKJIbPT78MRoVYmxaWVWYDo=
- k8s.io/kubernetes v1.27.14/go.mod h1:T4toI2XSWG5FJoq/H8q9eFYPymAxe/k4UnaC00uPnMs=
--k8s.io/legacy-cloud-providers v0.27.14 h1:tRZTgKxjR3B0bLGCuVK/ef47vTWDDpVfI9sLuOwaeMQ=
--k8s.io/legacy-cloud-providers v0.27.14/go.mod h1:ZGWANc6IYqoK4JC6QNXfkPOK2Jw8VD/WhhmTog7oBgw=
- k8s.io/mount-utils v0.27.14 h1:RYqDuQxbIJuIGxiRhFiv9SbQ151XSPSII0zGfTYU+LI=
- k8s.io/mount-utils v0.27.14/go.mod h1:bBE748kmEaM5B38hXaPJjlVeoAtHxHg/aizoiqm+6OI=
+ k8s.io/klog/v2 v2.100.1 h1:7WCHKK6K8fNhTqfBhISHQ97KrnJNFZMcQvKp7gP/tmg=
+ k8s.io/klog/v2 v2.100.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=
+ k8s.io/kms v0.28.10 h1:rjP2HWXeMF6p5dnSosVGiYhhMYkVkCE2wVRxkqiUiAM=
+@@ -1213,17 +676,12 @@ k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9 h1:LyMgNKD2P8Wn1iAwQU5Ohx
+ k8s.io/kube-openapi v0.0.0-20230717233707-2695361300d9/go.mod h1:wZK2AVp1uHCp4VamDVgBP2COHZjqD1T68Rf0CM3YjSM=
+ k8s.io/kube-scheduler v0.28.10 h1:818f9tHQWlnpARBtx1/yidmFqyN42vZE0hNzMf1Rf+c=
+ k8s.io/kube-scheduler v0.28.10/go.mod h1:Zs/VItGVb3DGOGzCw2tnZIbEa1eCu39x1xYUvUtnJDU=
+-k8s.io/kubectl v0.28.10 h1:ljlWrQVqKZspYESo4u570s3/BbnhiJ2z5LspzIKRSDM=
+-k8s.io/kubectl v0.28.10/go.mod h1:A1imFpT+xfaRkf+jN1yGHkAnq7hukF74i2ny/iXjbHc=
+ k8s.io/kubelet v0.28.10 h1:HoXMtQ86e8rGxuunEl+gtqcwXKSbW/pwShedoEBB+XQ=
+ k8s.io/kubelet v0.28.10/go.mod h1:TOshivjtPcQl+YGobMYgDffqdkuZ9h2/Dc7FOoVK4D4=
+ k8s.io/kubernetes v1.28.10 h1:QYofnL3gNbarVLOVbOKkyrZc6iA0rLGj69azDZLTbNs=
+ k8s.io/kubernetes v1.28.10/go.mod h1:chlmcCDBnOA/y+572cw8dO0Rci1wiA8bm5+zhPdFLCk=
+-k8s.io/legacy-cloud-providers v0.28.10 h1:kb0/GybmqXjbV8HGa5uvdDKXeiYKC1u69crOV65PY1w=
+-k8s.io/legacy-cloud-providers v0.28.10/go.mod h1:z1D9yTWsH9TByDv/PSCL9RtZO6KhE2+APO/oDSgIcsE=
+ k8s.io/mount-utils v0.28.10 h1:8XfdlJaWTxvvu5CfdNa7I/vU+378Z2thzIbIlovLYzo=
+ k8s.io/mount-utils v0.28.10/go.mod h1:ZxAFXgKzcAyi3VTd2pKFlZFswl9Q/cveJ5aptdjQOuc=
 -k8s.io/utils v0.0.0-20211116205334-6203023598ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
  k8s.io/utils v0.0.0-20230406110748-d93618cff8a2 h1:qY1Ad8PODbnymg2pRbkyMT/ylpTrCM8P2RJ0yroCyIk=
  k8s.io/utils v0.0.0-20230406110748-d93618cff8a2/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
  rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
-@@ -1229,8 +706,6 @@ rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
+@@ -1231,8 +689,6 @@ rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
  rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
  sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.1.2 h1:trsWhjU5jZrx6UvFu4WzQDrN7Pga4a7Qg+zcfcj64PA=
  sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.1.2/go.mod h1:+qG7ISXqCDVVcyO8hLn12AKVYYUjM7ftlqsqmrhMZE0=
--sigs.k8s.io/cloud-provider-azure v1.27.5 h1:D/xONxiecBrWw+45YiygUryntb6MAoMNUsHYH/Lg1hc=
--sigs.k8s.io/cloud-provider-azure v1.27.5/go.mod h1:kpbVqvl78SN95q4sE3AAj0SW96JxtCDm0Z4+8Q1lBOY=
+-sigs.k8s.io/cloud-provider-azure v1.26.2 h1://Yr95O53fcY/sakPvXdekCW4o2QKhfs1kNtipR7LpE=
+-sigs.k8s.io/cloud-provider-azure v1.26.2/go.mod h1:9m8BqB9ubr94uWWgbIY8TyUmHhsE2UEKdAZZG8O/ymc=
  sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
  sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
  sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=

--- a/projects/kubernetes/autoscaler/1-29/CHECKSUMS
+++ b/projects/kubernetes/autoscaler/1-29/CHECKSUMS
@@ -1,2 +1,2 @@
-4e6d2a05e3edcb21d677f3c00defd5d1c724b56d316ac85176faf412e9d4ac7e  _output/1-29/bin/autoscaler/linux-amd64/cluster-autoscaler
-4a55028ab68fb28e7440660bf3ebb48db442e683af5f5bd5ca48b13a251491e1  _output/1-29/bin/autoscaler/linux-arm64/cluster-autoscaler
+a9ec3e00f1301bff71b57c5ddadd6e64aa65a795cd2f4859d98f6b606b8169c3  _output/1-29/bin/autoscaler/linux-amd64/cluster-autoscaler
+fed931734adf3edaa20efe2067195ca4790815e9638005522c7d58afd324a6f5  _output/1-29/bin/autoscaler/linux-arm64/cluster-autoscaler

--- a/projects/kubernetes/autoscaler/1-29/GIT_TAG
+++ b/projects/kubernetes/autoscaler/1-29/GIT_TAG
@@ -1,1 +1,1 @@
-cluster-autoscaler-1.29.2
+cluster-autoscaler-1.29.3

--- a/projects/kubernetes/autoscaler/1-29/patches/0002-Update-go.mod-Dependencies.patch
+++ b/projects/kubernetes/autoscaler/1-29/patches/0002-Update-go.mod-Dependencies.patch
@@ -1,6 +1,6 @@
-From af1498a2c01ed0f246fa8a88fcf2bc0b736f5e7d Mon Sep 17 00:00:00 2001
+From 5558d75eacff974027309c27ac46228b18c70bcb Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
-Date: Wed, 31 Jan 2024 18:48:20 +0000
+Date: Tue, 11 Jun 2024 00:33:20 +0000
 Subject: [PATCH] Update go.mod Dependencies
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH] Update go.mod Dependencies
  2 files changed, 10 insertions(+), 861 deletions(-)
 
 diff --git a/cluster-autoscaler/go.mod b/cluster-autoscaler/go.mod
-index 5f69669b1..5c4e37bdf 100644
+index caa38fd16..6214b6d57 100644
 --- a/cluster-autoscaler/go.mod
 +++ b/cluster-autoscaler/go.mod
 @@ -3,93 +3,44 @@ module k8s.io/autoscaler/cluster-autoscaler
@@ -41,27 +41,27 @@ index 5f69669b1..5c4e37bdf 100644
 -	github.com/satori/go.uuid v1.2.0
  	github.com/spf13/pflag v1.0.5
  	github.com/stretchr/testify v1.8.4
--	golang.org/x/crypto v0.16.0
--	golang.org/x/net v0.19.0
+-	golang.org/x/crypto v0.21.0
+-	golang.org/x/net v0.23.0
 -	golang.org/x/oauth2 v0.10.0
--	golang.org/x/sys v0.15.0
+-	golang.org/x/sys v0.18.0
 -	google.golang.org/api v0.126.0
  	google.golang.org/grpc v1.58.3
  	google.golang.org/protobuf v1.33.0
 -	gopkg.in/gcfg.v1 v1.2.3
  	gopkg.in/yaml.v2 v2.4.0
- 	k8s.io/api v0.29.3
- 	k8s.io/apimachinery v0.29.3
- 	k8s.io/apiserver v0.29.3
- 	k8s.io/client-go v0.29.3
- 	k8s.io/cloud-provider v0.29.3
+ 	k8s.io/api v0.29.5
+ 	k8s.io/apimachinery v0.29.5
+ 	k8s.io/apiserver v0.29.5
+ 	k8s.io/client-go v0.29.5
+ 	k8s.io/cloud-provider v0.29.5
 -	k8s.io/cloud-provider-aws v1.27.0
- 	k8s.io/code-generator v0.29.3
- 	k8s.io/component-base v0.29.3
- 	k8s.io/component-helpers v0.29.3
+ 	k8s.io/code-generator v0.29.5
+ 	k8s.io/component-base v0.29.5
+ 	k8s.io/component-helpers v0.29.5
  	k8s.io/klog/v2 v2.110.1
--	k8s.io/kubelet v0.29.3
- 	k8s.io/kubernetes v1.29.3
+-	k8s.io/kubelet v0.29.5
+ 	k8s.io/kubernetes v1.29.5
 -	k8s.io/legacy-cloud-providers v0.0.0
  	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 -	sigs.k8s.io/cloud-provider-azure v1.28.0
@@ -176,14 +176,14 @@ index 5f69669b1..5c4e37bdf 100644
  	go.uber.org/atomic v1.10.0 // indirect
  	go.uber.org/multierr v1.11.0 // indirect
  	go.uber.org/zap v1.24.0 // indirect
-+	golang.org/x/crypto v0.16.0 // indirect
++	golang.org/x/crypto v0.21.0 // indirect
  	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // indirect
  	golang.org/x/mod v0.14.0 // indirect
-+	golang.org/x/net v0.19.0 // indirect
++	golang.org/x/net v0.23.0 // indirect
 +	golang.org/x/oauth2 v0.10.0 // indirect
  	golang.org/x/sync v0.5.0 // indirect
-+	golang.org/x/sys v0.15.0 // indirect
- 	golang.org/x/term v0.15.0 // indirect
++	golang.org/x/sys v0.18.0 // indirect
+ 	golang.org/x/term v0.18.0 // indirect
  	golang.org/x/text v0.14.0 // indirect
  	golang.org/x/time v0.3.0 // indirect
 @@ -181,21 +112,20 @@ require (
@@ -193,16 +193,16 @@ index 5f69669b1..5c4e37bdf 100644
 -	gopkg.in/warnings.v0 v0.1.2 // indirect
  	gopkg.in/yaml.v3 v3.0.1 // indirect
  	k8s.io/apiextensions-apiserver v0.0.0 // indirect
- 	k8s.io/controller-manager v0.29.3 // indirect
--	k8s.io/cri-api v0.29.3 // indirect
+ 	k8s.io/controller-manager v0.29.5 // indirect
+-	k8s.io/cri-api v0.29.5 // indirect
  	k8s.io/csi-translation-lib v0.27.0 // indirect
  	k8s.io/dynamic-resource-allocation v0.0.0 // indirect
  	k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 // indirect
- 	k8s.io/kms v0.29.3 // indirect
+ 	k8s.io/kms v0.29.5 // indirect
  	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
  	k8s.io/kube-scheduler v0.0.0 // indirect
 -	k8s.io/kubectl v0.28.0 // indirect
-+	k8s.io/kubelet v0.29.3 // indirect
++	k8s.io/kubelet v0.29.5 // indirect
  	k8s.io/mount-utils v0.26.0-alpha.0 // indirect
  	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0 // indirect
  	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
@@ -211,7 +211,7 @@ index 5f69669b1..5c4e37bdf 100644
  
  replace github.com/aws/aws-sdk-go/service/eks => github.com/aws/aws-sdk-go/service/eks v1.38.49
 diff --git a/cluster-autoscaler/go.sum b/cluster-autoscaler/go.sum
-index af8dab894..d9bf36c4f 100644
+index 603a95829..60b39d502 100644
 --- a/cluster-autoscaler/go.sum
 +++ b/cluster-autoscaler/go.sum
 @@ -1,242 +1,52 @@
@@ -846,8 +846,8 @@ index af8dab894..d9bf36c4f 100644
 -golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 -golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 -golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
- golang.org/x/crypto v0.16.0 h1:mMMrFzRSCF0GvB7Ne27XVtVAaXLrPmgPC7/v0tkwHaY=
- golang.org/x/crypto v0.16.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
+ golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
+ golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
 -golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 -golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 -golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -930,8 +930,8 @@ index af8dab894..d9bf36c4f 100644
 -golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 -golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 -golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
- golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
- golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
+ golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
+ golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 -golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 -golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 -golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -1025,14 +1025,14 @@ index af8dab894..d9bf36c4f 100644
 -golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 -golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 -golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
- golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
- golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+ golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
+ golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
  golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 -golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 -golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 -golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
- golang.org/x/term v0.15.0 h1:y/Oo/a/q3IXu26lQgl04j/gjuBDOBlx7X6Om1j2CPW4=
- golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=
+ golang.org/x/term v0.18.0 h1:FcHjZXDMxI8mM3nwhX9HlKop4C0YQvCVCdwYl2wOtE8=
+ golang.org/x/term v0.18.0/go.mod h1:ILwASektA3OnRv7amZ1xhE/KTR+u50pbXfZ03+6Nx58=
 -golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
  golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 -golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1297,28 +1297,28 @@ index af8dab894..d9bf36c4f 100644
 -honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 -honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 -honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
- k8s.io/api v0.29.3 h1:2ORfZ7+bGC3YJqGpV0KSDDEVf8hdGQ6A03/50vj8pmw=
- k8s.io/api v0.29.3/go.mod h1:y2yg2NTyHUUkIoTC+phinTnEa3KFM6RZ3szxt014a80=
- k8s.io/apiextensions-apiserver v0.29.3 h1:9HF+EtZaVpFjStakF4yVufnXGPRppWFEQ87qnO91YeI=
-@@ -1114,8 +347,6 @@ k8s.io/client-go v0.29.3 h1:R/zaZbEAxqComZ9FHeQwOh3Y1ZUs7FaHKZdQtIc2WZg=
- k8s.io/client-go v0.29.3/go.mod h1:tkDisCvgPfiRpxGnOORfkljmS+UrW+WtXAy2fTvXJB0=
- k8s.io/cloud-provider v0.29.3 h1:y39hNq0lrPD1qmqQ2ykwMJGeWF9LsepVkR2a4wskwLc=
- k8s.io/cloud-provider v0.29.3/go.mod h1:daDV1WkAO6pTrdsn7v8TpN/q9n75ExUC4RJDl7vlPKk=
+ k8s.io/api v0.29.5 h1:levS+umUigHCfI3riD36pMY1vQEbrzh4r1ivVWAhHaI=
+ k8s.io/api v0.29.5/go.mod h1:7b18TtPcJzdjk7w5zWyIHgoAtpGeRvGGASxlS7UZXdQ=
+ k8s.io/apiextensions-apiserver v0.29.5 h1:njDywexhE6n+1NEl3A4axT0TMQHREnndrk3/ztdWcNE=
+@@ -1114,8 +347,6 @@ k8s.io/client-go v0.29.5 h1:nlASXmPQy190qTteaVP31g3c/wi2kycznkTP7Sv1zPc=
+ k8s.io/client-go v0.29.5/go.mod h1:aY5CnqUUvXYccJhm47XHoPcRyX6vouHdIBHaKZGTbK4=
+ k8s.io/cloud-provider v0.29.5 h1:xzgnKrXK8NgMVBGCAZmupzA5WALLTTQkGgg36k/Zey4=
+ k8s.io/cloud-provider v0.29.5/go.mod h1:cKT9OzdMUK2/2rF3dWOD/w6Oqg/X4MTxrNVv4GTappQ=
 -k8s.io/cloud-provider-aws v1.27.0 h1:PF8YrH8QcN6JoXB3Xxlaz84SBDYMPunJuCc0cPuCWXA=
 -k8s.io/cloud-provider-aws v1.27.0/go.mod h1:9vUb5mnVnReSRDBWcBxB1b0HOeEc472iOPmrnwpN9SA=
- k8s.io/code-generator v0.29.3 h1:m7E25/t9R9NvejspO2zBdyu+/Gl0Z5m7dCRc680KS14=
- k8s.io/code-generator v0.29.3/go.mod h1:x47ofBhN4gxYFcxeKA1PYXeaPreAGaDN85Y/lNUsPoM=
- k8s.io/component-base v0.29.3 h1:Oq9/nddUxlnrCuuR2K/jp6aflVvc0uDvxMzAWxnGzAo=
-@@ -1124,15 +355,12 @@ k8s.io/component-helpers v0.29.3 h1:1dqZswuZgT2ZMixYeORyCUOAApXxgsvjVSgfoUT+P4o=
- k8s.io/component-helpers v0.29.3/go.mod h1:yiDqbRQrnQY+sPju/bL7EkwDJb6LVOots53uZNMZBos=
- k8s.io/controller-manager v0.29.3 h1:pvm3mirypgW7kM6dHRk6O5ANZj4bZTWirfk5gO6RlCo=
- k8s.io/controller-manager v0.29.3/go.mod h1:RNxpf0d1WAo59sOLd32isWJP0oZ7Zxr+q4VEEaSq4gk=
--k8s.io/cri-api v0.29.3 h1:ppKSui+hhTJW774Mou6x+/ealmzt2jmTM0vsEQVWrjI=
--k8s.io/cri-api v0.29.3/go.mod h1:3X7EnhsNaQnCweGhQCJwKNHlH7wHEYuKQ19bRvXMoJY=
- k8s.io/csi-translation-lib v0.29.3 h1:GNYCE0f86K3Xkyrk7WKKwQZkJrum6QQapbOzYxZv6Mg=
- k8s.io/csi-translation-lib v0.29.3/go.mod h1:snAzieA58/oiQXQZr27b0+b6/3+ZzitwI+57cUsMKKQ=
- k8s.io/dynamic-resource-allocation v0.29.3 h1:0HxniFIOZetPe/yCiD+KQwr+po+6vEdX4HNasGNoe8k=
- k8s.io/dynamic-resource-allocation v0.29.3/go.mod h1:zzQgamG51zBd5NSF+k9WgmMuavHYdNGEBsohNoO2E1A=
+ k8s.io/code-generator v0.29.5 h1:WqSdBPVV1B3jsPnKtPS39U02zj6Q7+FsjhAj1EPBJec=
+ k8s.io/code-generator v0.29.5/go.mod h1:7TYnI0dYItL2cKuhhgPSuF3WED9uMdELgbVXFfn/joE=
+ k8s.io/component-base v0.29.5 h1:Ptj8AzG+p8c2a839XriHwxakDpZH9uvIgYz+o1agjg8=
+@@ -1124,15 +355,12 @@ k8s.io/component-helpers v0.29.5 h1:aDwzJoQWK4zreZPKun6H2c3QIwy1F1G5hMU5YR1s8yA=
+ k8s.io/component-helpers v0.29.5/go.mod h1:5Hwtbhs8I9DdVvV8Lh2cKaHbGuqgqqE18iO5XyFzGVE=
+ k8s.io/controller-manager v0.29.5 h1:KOzas+Az8egEsTIajKdjVmlY0MzvAaYDREmo7+Kyyzg=
+ k8s.io/controller-manager v0.29.5/go.mod h1:WXsnVH7yjXG6jyjEQ/B0DTe71m1tC+TohTjt6/9RErs=
+-k8s.io/cri-api v0.29.5 h1:0gw14xvI1c4CZUX4zERaozgtdmnKb2xAV2FEbLh9Lxo=
+-k8s.io/cri-api v0.29.5/go.mod h1:A6pdbjzML2xi9B0Clqn5qt1HJ3Ik12x2j+jv/TkqjRE=
+ k8s.io/csi-translation-lib v0.29.5 h1:G02zVnVYNZI3fHynzU3XumNsbHrtWMQT2MfT2dXKkIk=
+ k8s.io/csi-translation-lib v0.29.5/go.mod h1:eI0qGZiaqCebVq13wTlfN5VKmAqNcF+GyDeJYIZGQ3s=
+ k8s.io/dynamic-resource-allocation v0.29.5 h1:Kbdh0CzPj3KzYaE/0lVvnig8mJ/fvs1EzeURCnFn9Gk=
+ k8s.io/dynamic-resource-allocation v0.29.5/go.mod h1:f+5PcSZyLg6LvHyWyqBAW9nP6HJ9wBD7wruD1/GrI/o=
  k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01 h1:pWEwq4Asjm4vjW7vcsmijwBhOr1/shsbSYiWXmNGlks=
  k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 -k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
@@ -1327,18 +1327,18 @@ index af8dab894..d9bf36c4f 100644
  k8s.io/klog/v2 v2.110.1/go.mod h1:YGtd1984u+GgbuZ7e08/yBuAfKLSO0+uR1Fhi6ExXjo=
 @@ -1142,25 +370,16 @@ k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 h1:aVUu9fTY98ivBPKR9Y5w/A
  k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00/go.mod h1:AsvuZPBlUDVuCdzJ87iajxtXuR9oktsTctW/R9wwouA=
- k8s.io/kube-scheduler v0.29.3 h1:2JKNfkReDHS33Ase2aejcvH6qHLi3KPmS2ejaHXE4YQ=
- k8s.io/kube-scheduler v0.29.3/go.mod h1:1NLHViSwFFddWHH4U9UGD57clINAtje/PEs6PjOYQZg=
--k8s.io/kubectl v0.29.3 h1:RuwyyIU42MAISRIePaa8Q7A3U74Q9P4MoJbDFz9o3us=
--k8s.io/kubectl v0.29.3/go.mod h1:yCxfY1dbwgVdEt2zkJ6d5NNLOhhWgTyrqACIoFhpdd4=
- k8s.io/kubelet v0.29.3 h1:X9h0ZHzc+eUeNTaksbN0ItHyvGhQ7Z0HPjnQD2oHdwU=
- k8s.io/kubelet v0.29.3/go.mod h1:jDiGuTkFOUynyBKzOoC1xRSWlgAZ9UPcTYeFyjr6vas=
- k8s.io/kubernetes v1.29.3 h1:EuOAKN4zpiP+kBx/0e9yS5iBkPSyLml19juOqZxBtDw=
- k8s.io/kubernetes v1.29.3/go.mod h1:CP+Z+S9haxyB7J+nV6ywYry4dqlphArPXjcc0CsBVXc=
--k8s.io/legacy-cloud-providers v0.29.3 h1:w0rwQT39ML4jo0ieqc1HMkoMJ7PkBohQUCvfwSLVwe8=
--k8s.io/legacy-cloud-providers v0.29.3/go.mod h1:IFA6hqla2IgCPD14aF5uQ8+gXtqRiCLln7Khguu2idw=
- k8s.io/mount-utils v0.29.3 h1:iEcqPP7Vv8UClH8nnMfovtmy/04fIloRW9JuSXykoZ0=
- k8s.io/mount-utils v0.29.3/go.mod h1:9IWJTMe8tG0MYMLEp60xK9GYVeCdA3g4LowmnVi+t9Y=
+ k8s.io/kube-scheduler v0.29.5 h1:/Ik/zwSfU6RhszHUlksepSlD459Q50k7d7gw/kEoWHs=
+ k8s.io/kube-scheduler v0.29.5/go.mod h1:ywlq53FMsoQLSkSftOk6UPHx+R+eoL+GQJPeJcYouGU=
+-k8s.io/kubectl v0.29.5 h1:Y41B5AhRKMfDVKgFkS5vHKX43aHVch6+QIszCborERc=
+-k8s.io/kubectl v0.29.5/go.mod h1:/bxZpurdrKZFz/sa7jlLy1S8IxSiWhJCoA+DhLp7/T4=
+ k8s.io/kubelet v0.29.5 h1:tYYyc2JcrDt8jFYTsKpgcIpp+S5a/nm85CY4liosprw=
+ k8s.io/kubelet v0.29.5/go.mod h1:eWJR0OtRRkLwKEYjsQXcTyTZlSfgR3Py1xJVFa0ISTk=
+ k8s.io/kubernetes v1.29.5 h1:G+i73mlMcmqRge1STYospiN8X9FYHGeBOer/e2uGJ1k=
+ k8s.io/kubernetes v1.29.5/go.mod h1:28sDhcb87LX5z3GWAKYmLrhrifxi4W9bEWua4DRTIvk=
+-k8s.io/legacy-cloud-providers v0.29.5 h1:X4nHog973iRQO8ITxZ75kZtz9dhj0dqgEhCApSaK2j0=
+-k8s.io/legacy-cloud-providers v0.29.5/go.mod h1:YdZBxeySnjCkLjgDOxBsXlKvqfjNvNpSCIf5fJWH2ic=
+ k8s.io/mount-utils v0.29.5 h1:sY11J+CgXTzC2yWBjv7h+qOPykhMPRgichPCNFThMwk=
+ k8s.io/mount-utils v0.29.5/go.mod h1:SHUMR9n3b6tLgEmlyT36cL6fV6Sjwa5CJhc0guCXvb0=
  k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSnlTLKgpAAttJvpI=
  k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 -rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/projects/kubernetes/autoscaler/1-30/ATTRIBUTION.txt
+++ b/projects/kubernetes/autoscaler/1-30/ATTRIBUTION.txt
@@ -125,52 +125,52 @@ https://github.com/grpc/grpc-go
 ** gopkg.in/yaml.v2; version v2.4.0 --
 https://gopkg.in/yaml.v2
 
-** k8s.io/api; version v0.30.0 --
+** k8s.io/api; version v0.30.1 --
 https://github.com/kubernetes/api
 
-** k8s.io/apiextensions-apiserver/pkg/features; version v0.30.0 --
+** k8s.io/apiextensions-apiserver/pkg/features; version v0.30.1 --
 https://github.com/kubernetes/apiextensions-apiserver
 
-** k8s.io/apimachinery/pkg; version v0.30.0 --
+** k8s.io/apimachinery/pkg; version v0.30.1 --
 https://github.com/kubernetes/apimachinery
 
-** k8s.io/apiserver; version v0.30.0 --
+** k8s.io/apiserver; version v0.30.1 --
 https://github.com/kubernetes/apiserver
 
-** k8s.io/autoscaler/cluster-autoscaler; version cluster-autoscaler-1.30.0 --
+** k8s.io/autoscaler/cluster-autoscaler; version cluster-autoscaler-1.30.1 --
 https://github.com/kubernetes/autoscaler
 
 ** k8s.io/autoscaler/cluster-autoscaler/apis/provisioningrequest; version v0.0.0-20240522143750-cf606a1400d6 --
 https://github.com/kubernetes/autoscaler
 
-** k8s.io/client-go; version v0.30.0 --
+** k8s.io/client-go; version v0.30.1 --
 https://github.com/kubernetes/client-go
 
-** k8s.io/cloud-provider; version v0.30.0 --
+** k8s.io/cloud-provider; version v0.30.1 --
 https://github.com/kubernetes/cloud-provider
 
-** k8s.io/code-generator; version v0.30.0 --
+** k8s.io/code-generator; version v0.30.1 --
 https://github.com/kubernetes/code-generator
 
-** k8s.io/component-base; version v0.30.0 --
+** k8s.io/component-base; version v0.30.1 --
 https://github.com/kubernetes/component-base
 
-** k8s.io/component-helpers; version v0.30.0 --
+** k8s.io/component-helpers; version v0.30.1 --
 https://github.com/kubernetes/component-helpers
 
-** k8s.io/controller-manager; version v0.30.0 --
+** k8s.io/controller-manager; version v0.30.1 --
 https://github.com/kubernetes/controller-manager
 
-** k8s.io/csi-translation-lib; version v0.30.0 --
+** k8s.io/csi-translation-lib; version v0.30.1 --
 https://github.com/kubernetes/csi-translation-lib
 
-** k8s.io/dynamic-resource-allocation; version v0.30.0 --
+** k8s.io/dynamic-resource-allocation; version v0.30.1 --
 https://github.com/kubernetes/dynamic-resource-allocation
 
 ** k8s.io/klog/v2; version v2.120.1 --
 https://github.com/kubernetes/klog
 
-** k8s.io/kms; version v0.30.0 --
+** k8s.io/kms; version v0.30.1 --
 https://github.com/kubernetes/kms
 
 ** k8s.io/kube-openapi/pkg; version v0.0.0-20240228011516-70dd3763d340 --
@@ -185,16 +185,16 @@ https://github.com/kubernetes/kube-openapi
 ** k8s.io/kube-openapi/pkg/validation/strfmt; version v0.0.0-20240228011516-70dd3763d340 --
 https://github.com/kubernetes/kube-openapi
 
-** k8s.io/kube-scheduler; version v0.30.0 --
+** k8s.io/kube-scheduler; version v0.30.1 --
 https://github.com/kubernetes/kube-scheduler
 
-** k8s.io/kubelet/pkg/apis; version v0.30.0 --
+** k8s.io/kubelet/pkg/apis; version v0.30.1 --
 https://github.com/kubernetes/kubelet
 
-** k8s.io/kubernetes/pkg; version v1.30.0 --
+** k8s.io/kubernetes/pkg; version v1.30.1 --
 https://github.com/kubernetes/kubernetes
 
-** k8s.io/mount-utils; version v0.30.0 --
+** k8s.io/mount-utils; version v0.30.1 --
 https://github.com/kubernetes/mount-utils
 
 ** k8s.io/utils; version v0.0.0-20230726121419-3b25d923346b --
@@ -1003,7 +1003,7 @@ https://golang.org/x/text
 ** golang.org/x/time/rate; version v0.3.0 --
 https://golang.org/x/time
 
-** k8s.io/apimachinery/third_party/forked/golang; version v0.30.0 --
+** k8s.io/apimachinery/third_party/forked/golang; version v0.30.1 --
 https://github.com/kubernetes/apimachinery
 
 Copyright (c) 2009 The Go Authors. All rights reserved.

--- a/projects/kubernetes/autoscaler/1-30/CHECKSUMS
+++ b/projects/kubernetes/autoscaler/1-30/CHECKSUMS
@@ -1,2 +1,2 @@
-f3511b0b131bd8457305b2af2d9f17c66189d8babdd0867be08fc2227edaca49  _output/1-30/bin/autoscaler/linux-amd64/cluster-autoscaler
-901078d2e9103ff7af6863d066d39588a8822c521ca87e9bf792f355c6bb599b  _output/1-30/bin/autoscaler/linux-arm64/cluster-autoscaler
+153fe7f5c13a575bb7ccf137b2f1a010aa58f705a9c88028dd078bbad1fe326a  _output/1-30/bin/autoscaler/linux-amd64/cluster-autoscaler
+bc017c040ca73a0c88f4e8b27079eb3538f9b0dd6e1423f189b448a75103b15a  _output/1-30/bin/autoscaler/linux-arm64/cluster-autoscaler

--- a/projects/kubernetes/autoscaler/1-30/GIT_TAG
+++ b/projects/kubernetes/autoscaler/1-30/GIT_TAG
@@ -1,1 +1,1 @@
-cluster-autoscaler-1.30.0
+cluster-autoscaler-1.30.1

--- a/projects/kubernetes/autoscaler/1-30/patches/0003-Update-go.mod-Dependencies.patch
+++ b/projects/kubernetes/autoscaler/1-30/patches/0003-Update-go.mod-Dependencies.patch
@@ -1,6 +1,6 @@
-From 85e2d6d3087a9fce18fbca22b6be3b9adbdf9a43 Mon Sep 17 00:00:00 2001
+From a9b2b787a36869d1a6910f4d40e8baf24a436c3c Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
-Date: Fri, 24 May 2024 23:10:03 +0000
+Date: Tue, 11 Jun 2024 00:50:30 +0000
 Subject: [PATCH] Update go.mod Dependencies
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH] Update go.mod Dependencies
  2 files changed, 15 insertions(+), 867 deletions(-)
 
 diff --git a/cluster-autoscaler/go.mod b/cluster-autoscaler/go.mod
-index 36e134235..eb0f167ca 100644
+index e13b898f3..6df52e904 100644
 --- a/cluster-autoscaler/go.mod
 +++ b/cluster-autoscaler/go.mod
 @@ -5,90 +5,41 @@ go 1.22.0
@@ -47,19 +47,19 @@ index 36e134235..eb0f167ca 100644
  	google.golang.org/protobuf v1.33.0
 -	gopkg.in/gcfg.v1 v1.2.3
  	gopkg.in/yaml.v2 v2.4.0
- 	k8s.io/api v0.30.0
- 	k8s.io/apimachinery v0.30.0
- 	k8s.io/apiserver v0.30.0
+ 	k8s.io/api v0.30.1
+ 	k8s.io/apimachinery v0.30.1
+ 	k8s.io/apiserver v0.30.1
 -	k8s.io/autoscaler/cluster-autoscaler/apis v0.0.0-00010101000000-000000000000
 +	k8s.io/autoscaler/cluster-autoscaler/apis v0.0.0-20240522143750-cf606a1400d6
- 	k8s.io/client-go v0.30.0
- 	k8s.io/cloud-provider v0.30.0
+ 	k8s.io/client-go v0.30.1
+ 	k8s.io/cloud-provider v0.30.1
 -	k8s.io/cloud-provider-aws v1.27.0
- 	k8s.io/component-base v0.30.0
- 	k8s.io/component-helpers v0.30.0
+ 	k8s.io/component-base v0.30.1
+ 	k8s.io/component-helpers v0.30.1
  	k8s.io/klog/v2 v2.120.1
--	k8s.io/kubelet v0.30.0
- 	k8s.io/kubernetes v1.30.0
+-	k8s.io/kubelet v0.30.1
+ 	k8s.io/kubernetes v1.30.1
 -	k8s.io/legacy-cloud-providers v0.0.0
  	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 -	sigs.k8s.io/cloud-provider-azure v1.28.0
@@ -191,17 +191,17 @@ index 36e134235..eb0f167ca 100644
 -	gopkg.in/warnings.v0 v0.1.2 // indirect
  	gopkg.in/yaml.v3 v3.0.1 // indirect
  	k8s.io/apiextensions-apiserver v0.0.0 // indirect
- 	k8s.io/code-generator v0.30.0 // indirect
- 	k8s.io/controller-manager v0.30.0 // indirect
--	k8s.io/cri-api v0.30.0 // indirect
+ 	k8s.io/code-generator v0.30.1 // indirect
+ 	k8s.io/controller-manager v0.30.1 // indirect
+-	k8s.io/cri-api v0.30.1 // indirect
  	k8s.io/csi-translation-lib v0.27.0 // indirect
  	k8s.io/dynamic-resource-allocation v0.0.0 // indirect
  	k8s.io/gengo/v2 v2.0.0-20240228010128-51d4e06bde70 // indirect
- 	k8s.io/kms v0.30.0 // indirect
+ 	k8s.io/kms v0.30.1 // indirect
  	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
  	k8s.io/kube-scheduler v0.0.0 // indirect
 -	k8s.io/kubectl v0.28.0 // indirect
-+	k8s.io/kubelet v0.30.0 // indirect
++	k8s.io/kubelet v0.30.1 // indirect
  	k8s.io/mount-utils v0.26.0-alpha.0 // indirect
  	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.29.0 // indirect
  	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
@@ -211,13 +211,13 @@ index 36e134235..eb0f167ca 100644
  
  replace github.com/aws/aws-sdk-go/service/eks => github.com/aws/aws-sdk-go/service/eks v1.38.49
 @@ -263,5 +195,3 @@ replace k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation
- replace k8s.io/kms => k8s.io/kms v0.30.0
+ replace k8s.io/kms => k8s.io/kms v0.30.1
  
- replace k8s.io/endpointslice => k8s.io/endpointslice v0.30.0
+ replace k8s.io/endpointslice => k8s.io/endpointslice v0.30.1
 -
 -replace k8s.io/autoscaler/cluster-autoscaler/apis => ./apis
 diff --git a/cluster-autoscaler/go.sum b/cluster-autoscaler/go.sum
-index 6a221515d..d80d6176b 100644
+index 6086c5e99..a3ce50890 100644
 --- a/cluster-autoscaler/go.sum
 +++ b/cluster-autoscaler/go.sum
 @@ -1,240 +1,52 @@
@@ -1288,54 +1288,54 @@ index 6a221515d..d80d6176b 100644
 -honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 -honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 -honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
- k8s.io/api v0.30.0 h1:siWhRq7cNjy2iHssOB9SCGNCl2spiF1dO3dABqZ8niA=
- k8s.io/api v0.30.0/go.mod h1:OPlaYhoHs8EQ1ql0R/TsUgaRPhpKNxIMrKQfWUp8QSE=
- k8s.io/apiextensions-apiserver v0.30.0 h1:jcZFKMqnICJfRxTgnC4E+Hpcq8UEhT8B2lhBcQ+6uAs=
-@@ -1090,12 +320,12 @@ k8s.io/apimachinery v0.30.0 h1:qxVPsyDM5XS96NIh9Oj6LavoVFYff/Pon9cZeDIkHHA=
- k8s.io/apimachinery v0.30.0/go.mod h1:iexa2somDaxdnj7bha06bhb43Zpa6eWH8N8dbqVjTUc=
- k8s.io/apiserver v0.30.0 h1:QCec+U72tMQ+9tR6A0sMBB5Vh6ImCEkoKkTDRABWq6M=
- k8s.io/apiserver v0.30.0/go.mod h1:smOIBq8t0MbKZi7O7SyIpjPsiKJ8qa+llcFCluKyqiY=
+ k8s.io/api v0.30.1 h1:kCm/6mADMdbAxmIh0LBjS54nQBE+U4KmbCfIkF5CpJY=
+ k8s.io/api v0.30.1/go.mod h1:ddbN2C0+0DIiPntan/bye3SW3PdwLa11/0yqwvuRrJM=
+ k8s.io/apiextensions-apiserver v0.30.1 h1:4fAJZ9985BmpJG6PkoxVRpXv9vmPUOVzl614xarePws=
+@@ -1090,12 +320,12 @@ k8s.io/apimachinery v0.30.1 h1:ZQStsEfo4n65yAdlGTfP/uSHMQSoYzU/oeEbkmF7P2U=
+ k8s.io/apimachinery v0.30.1/go.mod h1:iexa2somDaxdnj7bha06bhb43Zpa6eWH8N8dbqVjTUc=
+ k8s.io/apiserver v0.30.1 h1:BEWEe8bzS12nMtDKXzCF5Q5ovp6LjjYkSp8qOPk8LZ8=
+ k8s.io/apiserver v0.30.1/go.mod h1:i87ZnQ+/PGAmSbD/iEKM68bm1D5reX8fO4Ito4B01mo=
 +k8s.io/autoscaler/cluster-autoscaler/apis v0.0.0-20240522143750-cf606a1400d6 h1:OsGwGK6reG7TFANiQAKfYqjuYvagxHudVhVW2nom5DU=
 +k8s.io/autoscaler/cluster-autoscaler/apis v0.0.0-20240522143750-cf606a1400d6/go.mod h1:LPhCVj3E5Lp9W6HGVlW664m/X+KN2firfF3wtBBji54=
- k8s.io/client-go v0.30.0 h1:sB1AGGlhY/o7KCyCEQ0bPWzYDL0pwOZO4vAtTSh/gJQ=
- k8s.io/client-go v0.30.0/go.mod h1:g7li5O5256qe6TYdAMyX/otJqMhIiGgTapdLchhmOaY=
- k8s.io/cloud-provider v0.30.0 h1:hz1MXkFjsyO167sRZVchXEi2YYMQ6kolBi79nuICjzw=
- k8s.io/cloud-provider v0.30.0/go.mod h1:iyVcGvDfmZ7m5cliI9TTHj0VTjYDNpc/K71Gp6hukjU=
+ k8s.io/client-go v0.30.1 h1:uC/Ir6A3R46wdkgCV3vbLyNOYyCJ8oZnjtJGKfytl/Q=
+ k8s.io/client-go v0.30.1/go.mod h1:wrAqLNs2trwiCH/wxxmT/x3hKVH9PuV0GGW0oDoHVqc=
+ k8s.io/cloud-provider v0.30.1 h1:OslHpog97zG9Kr7/vV1ki8nLKq8xTPUkN/kepCxBqKI=
+ k8s.io/cloud-provider v0.30.1/go.mod h1:1uZp+FSskXQoeAAIU91/XCO8X/9N1U3z5usYeSLT4MI=
 -k8s.io/cloud-provider-aws v1.27.0 h1:PF8YrH8QcN6JoXB3Xxlaz84SBDYMPunJuCc0cPuCWXA=
 -k8s.io/cloud-provider-aws v1.27.0/go.mod h1:9vUb5mnVnReSRDBWcBxB1b0HOeEc472iOPmrnwpN9SA=
- k8s.io/code-generator v0.30.0 h1:3VUVqHvWFSVSm9kqL/G6kD4ZwNdHF6J/jPyo3Jgjy3k=
- k8s.io/code-generator v0.30.0/go.mod h1:mBMZhfRR4IunJUh2+7LVmdcWwpouCH5+LNPkZ3t/v7Q=
- k8s.io/component-base v0.30.0 h1:cj6bp38g0ainlfYtaOQuRELh5KSYjhKxM+io7AUIk4o=
-@@ -1104,15 +334,12 @@ k8s.io/component-helpers v0.30.0 h1:xbJtNCfSM4SB/Tz5JqCKDZv4eT5LVi/AWQ1VOxhmStU=
- k8s.io/component-helpers v0.30.0/go.mod h1:68HlSwXIumMKmCx8cZe1PoafQEYh581/sEpxMrkhmX4=
- k8s.io/controller-manager v0.30.0 h1:jqqT8cK0Awdy0IfT0yuqYIRmwskbdzH5AEZqkuhEVMs=
- k8s.io/controller-manager v0.30.0/go.mod h1:suM1r/pxUuk2ij5Bbm7W9kBLrFujXuzIboNuWK5AfRA=
--k8s.io/cri-api v0.30.0 h1:hZqh3vH5JZdqeAyhD9nPXSbT6GDgrtPJkPiIzhWKVhk=
--k8s.io/cri-api v0.30.0/go.mod h1://4/umPJSW1ISNSNng4OwjpkvswJOQwU8rnkvO8P+xg=
- k8s.io/csi-translation-lib v0.30.0 h1:pEe6jshNVE4od2AdgYlsAtiKP/MH+NcsBbUPA/dWA6U=
- k8s.io/csi-translation-lib v0.30.0/go.mod h1:5TT/awOiKEX+8CcbReVYJyddT7xqlFrp3ChE9e45MyU=
- k8s.io/dynamic-resource-allocation v0.30.0 h1:CLMe/tsqOmIsR336A8vP4vGsdccfgMeUM2ksbxG5pyM=
- k8s.io/dynamic-resource-allocation v0.30.0/go.mod h1:ltnb2UxylJw3MHeUIcXtIsxX23/4oHAY4Hr44I4RzZU=
+ k8s.io/code-generator v0.30.1 h1:ZsG++q5Vt0ScmKCeLhynUuWgcwFGg1Hl1AGfatqPJBI=
+ k8s.io/code-generator v0.30.1/go.mod h1:hFgxRsvOUg79mbpbVKfjJvRhVz1qLoe40yZDJ/hwRH4=
+ k8s.io/component-base v0.30.1 h1:bvAtlPh1UrdaZL20D9+sWxsJljMi0QZ3Lmw+kmZAaxQ=
+@@ -1104,15 +334,12 @@ k8s.io/component-helpers v0.30.1 h1:/UcxSLzZ0owluTE2WMDrFfZl2L+WVXKdYYYm68qnH7U=
+ k8s.io/component-helpers v0.30.1/go.mod h1:b1Xk27UJ3p/AmPqDx7khrnSxrdwQy9gTP7O1y6MZ6rg=
+ k8s.io/controller-manager v0.30.1 h1:vrpfinHQWGf40U08Zmrt+QxK/2yTgjJl/9DKtjaB1gI=
+ k8s.io/controller-manager v0.30.1/go.mod h1:8rTEPbn8LRKC/vS+If+JAKBfsftCfTMaF8/n4SJC+PQ=
+-k8s.io/cri-api v0.30.1 h1:AUM78wiC56B1WJ2c795AS0IG5T57CkEdkn0IuC+miAE=
+-k8s.io/cri-api v0.30.1/go.mod h1://4/umPJSW1ISNSNng4OwjpkvswJOQwU8rnkvO8P+xg=
+ k8s.io/csi-translation-lib v0.30.1 h1:fIBtNMQjyr7HFv3xGSSH9cWOQS1K1kIBmZ1zRsHuVKs=
+ k8s.io/csi-translation-lib v0.30.1/go.mod h1:l0HrIBIxUKRvqnNWqn6AXTYgUa2mAFLT6bjo1lU+55U=
+ k8s.io/dynamic-resource-allocation v0.30.1 h1:Orv5t34/PMUxi57Fgzr3UpeWUvp5RmM3HWeQKqzTnyw=
+ k8s.io/dynamic-resource-allocation v0.30.1/go.mod h1:l1kPvmIhxAysEHqW0lGjSIRvansWSpq27wCuqCccP6E=
  k8s.io/gengo/v2 v2.0.0-20240228010128-51d4e06bde70 h1:NGrVE502P0s0/1hudf8zjgwki1X/TByhmAoILTarmzo=
  k8s.io/gengo/v2 v2.0.0-20240228010128-51d4e06bde70/go.mod h1:VH3AT8AaQOqiGjMF9p0/IM1Dj+82ZwjfxUP1IxaHE+8=
 -k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
  k8s.io/klog/v2 v2.120.1 h1:QXU6cPEOIslTGvZaXvFWiP9VKyeet3sawzTOvdXb4Vw=
  k8s.io/klog/v2 v2.120.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
- k8s.io/kms v0.30.0 h1:ZlnD/ei5lpvUlPw6eLfVvH7d8i9qZ6HwUQgydNVks8g=
+ k8s.io/kms v0.30.1 h1:gEIbEeCbFiaN2tNfp/EUhFdGr5/CSj8Eyq6Mkr7cCiY=
 @@ -1121,25 +348,16 @@ k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 h1:BZqlfIlq5YbRMFko6/PM7F
  k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340/go.mod h1:yD4MZYeKMBwQKVht279WycxKyM84kkAx2DPrTXaeb98=
- k8s.io/kube-scheduler v0.30.0 h1:wr2bcKy9MoN0VlfiM66KHYsgUXPJYhtr3b6LiVmKc94=
- k8s.io/kube-scheduler v0.30.0/go.mod h1:C/yQb0WrPsxAA3LGwh+HB4sY5RMbH+2UMfdDpEQNR30=
--k8s.io/kubectl v0.30.0 h1:xbPvzagbJ6RNYVMVuiHArC1grrV5vSmmIcSZuCdzRyk=
--k8s.io/kubectl v0.30.0/go.mod h1:zgolRw2MQXLPwmic2l/+iHs239L49fhSeICuMhQQXTI=
- k8s.io/kubelet v0.30.0 h1:/pqHVR2Rn8ExCpn211wL3pMtqRFpcBcJPl4+1INbIMk=
- k8s.io/kubelet v0.30.0/go.mod h1:WukdKqbQxnj+csn3K8XOKeX7Sh60J/da25IILjvvB5s=
- k8s.io/kubernetes v1.30.0 h1:u3Yw8rNlo2NDSGaDpoxoHXLPQnEu1tfqHATKOJe94HY=
- k8s.io/kubernetes v1.30.0/go.mod h1:yPbIk3MhmhGigX62FLJm+CphNtjxqCvAIFQXup6RKS0=
--k8s.io/legacy-cloud-providers v0.30.0 h1:TdaWbGlLuAVtoKQx98PZn1D3I1JH1hf3SFR4nAzu6oI=
--k8s.io/legacy-cloud-providers v0.30.0/go.mod h1:DOdF7dbVxvdprMF748oKkDcNWq/YhM+PKp7usT0D1MI=
- k8s.io/mount-utils v0.30.0 h1:EceYTNYVabfpdtIAHC4KgMzoZkm1B8ovZ1J666mYZQI=
- k8s.io/mount-utils v0.30.0/go.mod h1:9sCVmwGLcV1MPvbZ+rToMDnl1QcGozy+jBPd0MsQLIo=
+ k8s.io/kube-scheduler v0.30.1 h1:bH7Ie+gSDHas0BVjtdEY87zGLCPA2WMZ+TV4/7lqXg0=
+ k8s.io/kube-scheduler v0.30.1/go.mod h1:nAiJHoSyc3/XBUGE24MYcoSiDMuUhabmKVD0KTjQdus=
+-k8s.io/kubectl v0.30.1 h1:sHFIRI3oP0FFZmBAVEE8ErjnTyXDPkBcvO88mH9RjuY=
+-k8s.io/kubectl v0.30.1/go.mod h1:7j+L0Cc38RYEcx+WH3y44jRBe1Q1jxdGPKkX0h4iDq0=
+ k8s.io/kubelet v0.30.1 h1:6gS1gWjrefUGfC/9n0ITOzxnKyt89FfkIhom70Bola4=
+ k8s.io/kubelet v0.30.1/go.mod h1:5IUeAt3YlIfLNdT/YfRuCCONfEefm7qfcqz81b002Z8=
+ k8s.io/kubernetes v1.30.1 h1:XlqS6KslLEA5mQzLK2AJrhr4Z1m8oJfkhHiWJ5lue+I=
+ k8s.io/kubernetes v1.30.1/go.mod h1:yPbIk3MhmhGigX62FLJm+CphNtjxqCvAIFQXup6RKS0=
+-k8s.io/legacy-cloud-providers v0.30.1 h1:QGoeW4C7TQdsuMagqmzUVYhh7m0r4tyzgtmxU0iubqo=
+-k8s.io/legacy-cloud-providers v0.30.1/go.mod h1:cYPg6vX/fH4lp6smtN/QKRWPuJPDRWqIp1JOVs674zc=
+ k8s.io/mount-utils v0.30.1 h1:4HEFqo2bzRjCHHXRu7yQh6tvpMnplwWaqhuU7oE3710=
+ k8s.io/mount-utils v0.30.1/go.mod h1:9sCVmwGLcV1MPvbZ+rToMDnl1QcGozy+jBPd0MsQLIo=
  k8s.io/utils v0.0.0-20230726121419-3b25d923346b h1:sgn3ZU783SCgtaSJjpcVVlRqd6GSnlTLKgpAAttJvpI=
  k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 -rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/projects/kubernetes/autoscaler/README.md
+++ b/projects/kubernetes/autoscaler/README.md
@@ -1,10 +1,10 @@
 ## **Kubernetes Cluster Autoscaler**
 ![1.25 Version](https://img.shields.io/badge/1--25%20version-cluster--autoscaler--1.25.3-blue)
 ![1.26 Version](https://img.shields.io/badge/1--26%20version-cluster--autoscaler--1.26.8-blue)
-![1.27 Version](https://img.shields.io/badge/1--27%20version-cluster--autoscaler--1.27.7-blue)
-![1.28 Version](https://img.shields.io/badge/1--28%20version-cluster--autoscaler--1.28.4-blue)
-![1.29 Version](https://img.shields.io/badge/1--29%20version-cluster--autoscaler--1.29.2-blue)
-![1.30 Version](https://img.shields.io/badge/1--30%20version-cluster--autoscaler--1.30.0-blue)
+![1.27 Version](https://img.shields.io/badge/1--27%20version-cluster--autoscaler--1.27.8-blue)
+![1.28 Version](https://img.shields.io/badge/1--28%20version-cluster--autoscaler--1.28.5-blue)
+![1.29 Version](https://img.shields.io/badge/1--29%20version-cluster--autoscaler--1.29.3-blue)
+![1.30 Version](https://img.shields.io/badge/1--30%20version-cluster--autoscaler--1.30.1-blue)
 ![Build Status](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiL0tWckptdkxsZEd1cXNiNTBncjRNVU5oekpZRlBkTDNBcFVvZkFOVHZwbTBKUm91QkR6RVN4QlhJWk42cXF3L29FMmdnTXUrVndiay8zVUQ0YjJsc21vPSIsIml2UGFyYW1ldGVyU3BlYyI6Ik1Gd2UwbmRXVWxSRTMvUHQiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=main)
 
 [Autoscaler](https://github.com/kubernetes/autoscaler) defines the cluster autoscaler.


### PR DESCRIPTION
This change bumps autoscaler to latest version for release branches 1-27,1-28,1-29 and 1-30. It also adds a patch for branch 1-28 to update the go mod dependencies to remove any package that's not used by provider cluster-api to reduce our risk to vulnerabilities. During the 1-28 [bump](https://github.com/aws/eks-anywhere-build-tooling/pull/3130) we had not updated the helm-chart to latest version and this change also addresses the helm chart bump for release branch 1-28. 

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
