### PR TITLE
Allow project upgrades on release branch

### DIFF
--- a/tools/version-tracker/pkg/commands/listprojects/listprojects.go
+++ b/tools/version-tracker/pkg/commands/listprojects/listprojects.go
@@ -21,6 +21,12 @@ func Run() error {
 		return fmt.Errorf("retrieving current working directory: %v", err)
 	}
 
+	// Check if branch name environment variable has been set.
+	branchName, ok := os.LookupEnv(constants.BranchNameEnvVar)
+	if !ok {
+		branchName = constants.MainBranchName
+	}
+
 	// Get base repository owner environment variable if set.
 	baseRepoOwner := os.Getenv(constants.BaseRepoOwnerEnvvar)
 	if baseRepoOwner == "" {
@@ -29,7 +35,7 @@ func Run() error {
 
 	// Clone the eks-anywhere-build-tooling repository.
 	buildToolingRepoPath := filepath.Join(cwd, constants.BuildToolingRepoName)
-	_, _, err = git.CloneRepo(fmt.Sprintf(constants.BuildToolingRepoURL, baseRepoOwner), buildToolingRepoPath, "")
+	_, _, err = git.CloneRepo(fmt.Sprintf(constants.BuildToolingRepoURL, baseRepoOwner), buildToolingRepoPath, "", branchName)
 	if err != nil {
 		return fmt.Errorf("cloning build-tooling repo: %v", err)
 	}

--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -6,6 +6,7 @@ import (
 
 // Constants used across the version-tracker source code.
 const (
+	BranchNameEnvVar                        = "BRANCH_NAME"
 	BaseRepoOwnerEnvvar                     = "BASE_REPO_OWNER"
 	HeadRepoOwnerEnvvar                     = "HEAD_REPO_OWNER"
 	GitHubTokenEnvvar                       = "GITHUB_TOKEN"
@@ -42,7 +43,7 @@ const (
 	GithubPerPage                           = 100
 	datetimeFormat                          = "%Y-%m-%dT%H:%M:%SZ"
 	MainBranchName                          = "main"
-	BaseRepoHeadRevision                    = "refs/remotes/origin/main"
+	BaseRepoHeadRevisionPattern             = "refs/remotes/origin/%s"
 	EKSDistroUpgradePullRequestBody         = `This PR bumps EKS Distro releases to the latest available release versions.
 
 /hold

--- a/tools/version-tracker/pkg/github/github.go
+++ b/tools/version-tracker/pkg/github/github.go
@@ -97,7 +97,7 @@ func GetFileContents(client *github.Client, org, repo, filePath, ref string) ([]
 }
 
 // GetLatestRevision returns the latest revision (GitHub release or tag) for a given GitHub repository.
-func GetLatestRevision(client *github.Client, org, repo, currentRevision string, isTrackedUsingCommitHash, releaseBranched bool) (string, bool, error) {
+func GetLatestRevision(client *github.Client, org, repo, currentRevision, branchName string, isTrackedUsingCommitHash, releaseBranched bool) (string, bool, error) {
 	logger.V(6).Info(fmt.Sprintf("Getting latest revision for [%s/%s] repository", org, repo))
 	var currentRevisionCommit, latestRevision string
 	needsUpgrade := false
@@ -158,7 +158,13 @@ func GetLatestRevision(client *github.Client, org, repo, currentRevision string,
 			if releaseBranched {
 				releaseBranch := os.Getenv(constants.ReleaseBranchEnvvar)
 				releaseNumber := strings.Split(releaseBranch, "-")[1]
-				tagRegex := regexp.MustCompile(fmt.Sprintf(`^v?1.%s.\d$`, releaseNumber))
+				tagRegex := regexp.MustCompile(fmt.Sprintf(`^v?1.%s.\d+$`, releaseNumber))
+				if !tagRegex.MatchString(tagNameForSemver) {
+					continue
+				}
+			}
+			if branchName != constants.MainBranchName {
+				tagRegex := regexp.MustCompile(fmt.Sprintf(`^v%d.%d.\d+`, currentRevisionSemver.Major, currentRevisionSemver.Minor))
 				if !tagRegex.MatchString(tagNameForSemver) {
 					continue
 				}


### PR DESCRIPTION
This PR adds logic to perform project upgrades on branches other than main. This will be used to upgrade projects on release branches such as `release-0.19`, `release-0.20` etc, where the latest GitHub patch release will be considered for each project instead of the absolute latest GitHub release. The branch name is obtained from the `BRANCH_NAME` environment variable, and if there's no such variable set, it uses `main` as the branch.
## Testing
### Upgrades on main branch (target version is absolute latest minor or major version)
```console
$ BRANCH_NAME=main bin/version-tracker display --project goharbor/harbor        
ORGANIZATION  REPOSITORY  CURRENT VERSION  LATEST VERSION  
goharbor      harbor      v2.10.2          v2.11.0 
```

### Upgrades on release branch (target version is latest patch release for the same minor version)
```console
$ BRANCH_NAME=release-0.19 bin/version-tracker display --project goharbor/harbor
ORGANIZATION  REPOSITORY  CURRENT VERSION  LATEST VERSION  
goharbor      harbor      v2.9.1           v2.9.4 
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
