### PR TITLE
adds ova validation to check kubelet version

### DIFF
--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -113,7 +113,8 @@ CONVERT_TO_UPSTREAM_TARGET=$(strip \
 
 # ex: $(ARTIFACTS_PATH)/ubuntu/2004/ova/ubuntu.ova, $(ARTIFACTS_PATH)/bottlerocket/1/raw/bottlerocket.img.gz
 FINAL_IMAGE_DIR=$(ARTIFACTS_PATH)/$(IMAGE_OS_DIR)/$(IMAGE_FORMAT)$(FIRMWARE_PATH_SUFFIX)
-FINAL_IMAGE_PATH=$(FINAL_IMAGE_DIR)/$(IMAGE_OS).$(call EXT_FROM_FORMAT,$(IMAGE_FORMAT),$(IMAGE_OS))
+FINAL_IMAGE_FILE_NAME=$(IMAGE_OS).$(call EXT_FROM_FORMAT,$(IMAGE_FORMAT),$(IMAGE_OS))
+FINAL_IMAGE_PATH=$(FINAL_IMAGE_DIR)/$(FINAL_IMAGE_FILE_NAME)
 
 BOTTLEROCKET_AMI_RELEASE_VERSION=$(and $(RELEASE_BRANCH),$(shell yq e ".$(RELEASE_BRANCH).ami-release-version" $(MAKE_ROOT)/BOTTLEROCKET_RELEASES))
 BOTTLEROCKET_OVA_RELEASE_VERSION=$(and $(RELEASE_BRANCH),$(shell yq e ".$(RELEASE_BRANCH).ova-release-version" $(MAKE_ROOT)/BOTTLEROCKET_RELEASES))
@@ -280,7 +281,9 @@ fake-%: PACKER_LOG_PATH=$(ARTIFACTS_PATH)/$(subst -,/,$(basename $(*F)))/packer.
 fake-%: IMAGE_FORMAT=$(word 3,$(subst -, ,$(word 1,$(subst ., ,$*))))
 fake-%: | $$(ENABLE_LOGGING)
 	@touch $(PACKER_LOG_PATH)
-	@if [[ "$(IMAGE_FORMAT)" != "nutanix" ]]; then \
+	@if [[ "$(IMAGE_FORMAT)" == "ova" ]]; then \
+		build/make_fake_image.sh $(@) $(FULL_OUTPUT_DIR)/config/kubernetes.json; \
+	elif [[ "$(IMAGE_FORMAT)" != "nutanix" ]]; then \
 		touch $(@); \
 	fi
 
@@ -343,6 +346,11 @@ build-%: IMAGE_OS_VERSION=$(word 3,$(subst -, ,$*))
 build-%: IMAGE_OS_FIRMWARE=$(word 4,$(subst -, ,$*))
 build-%: validate-supported-image-% setup-packer-configs-% $(if $(filter ami,$(IMAGE_FORMAT)),setup-ami-share,) | $$(ENABLE_LOGGING)
 	@PACKER_VAR_FILES="$(PACKER_VAR_FILES)" $(MAKE) -C $(IMAGE_BUILDER_DIR) $(call CONVERT_TO_UPSTREAM_TARGET,validate-$(IMAGE_FORMAT)-$(IMAGE_OS_WITH_VER)$(if $(IMAGE_OS_FIRMWARE),-$(IMAGE_OS_FIRMWARE),))
+
+validate-ova-kubelet:
+	@echo -e $(call TARGET_START_LOG)
+	build/validate_ova_kubelet.sh $(ARTIFACTS_PATH)/$(FINAL_IMAGE_FILE_NAME) $(RELEASE_BRANCH) $(FULL_OUTPUT_DIR)/config/kubernetes.json
+	@echo -e $(call TARGET_END_LOG)
 #########################################################
 
 ######################## IMAGE BUILDER TARGETS #######################
@@ -424,8 +432,9 @@ validate-dependency-versions-%:
 s3-artifacts-%: $$(FINAL_IMAGE_PATH) | $$(ENABLE_LOGGING)
 	@$(MAKE) -C $(MAKE_ROOT) s3-artifacts ARTIFACTS_PATH=$(ARTIFACTS_PATH_IMAGE_FORMAT) IMAGE_FORMAT=$(IMAGE_FORMAT) IMAGE_OS=$(IMAGE_OS) IMAGE_OS_VERSION=$(IMAGE_OS_VERSION)
 
+upload-artifacts-%: TARGETS=$(if $(filter ova,$(IMAGE_FORMAT)),validate-ova-kubelet,) upload-artifacts
 upload-artifacts-%: s3-artifacts-% | $$(ENABLE_LOGGING)
-	@$(MAKE) -C $(MAKE_ROOT) upload-artifacts ARTIFACTS_PATH=$(ARTIFACTS_PATH_IMAGE_FORMAT) ARTIFACTS_UPLOAD_PATH=$(ARTIFACTS_UPLOAD_PATH_IMAGE_FORMAT) IMAGE_FORMAT=$(IMAGE_FORMAT) IMAGE_OS=$(IMAGE_OS) IMAGE_OS_VERSION=$(IMAGE_OS_VERSION)
+	@$(MAKE) -C $(MAKE_ROOT) $(TARGETS) ARTIFACTS_PATH=$(ARTIFACTS_PATH_IMAGE_FORMAT) ARTIFACTS_UPLOAD_PATH=$(ARTIFACTS_UPLOAD_PATH_IMAGE_FORMAT) IMAGE_FORMAT=$(IMAGE_FORMAT) IMAGE_OS=$(IMAGE_OS) IMAGE_OS_VERSION=$(IMAGE_OS_VERSION)
 
 #######################################################################
 

--- a/projects/kubernetes-sigs/image-builder/build/make_fake_image.sh
+++ b/projects/kubernetes-sigs/image-builder/build/make_fake_image.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+OVA_PATH="$1"
+KUBERNETES_PACKER_CONFIG="$2"
+
+MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+source "${MAKE_ROOT}/../../../build/lib/common.sh"
+
+TMP_FOLDER="$MAKE_ROOT/_output/tmp"
+BIN_FOLDER="$MAKE_ROOT/_output/.bin"
+ZIP="$BIN_FOLDER/7zz"
+
+mkdir -p $BIN_FOLDER $TMP_FOLDER
+
+if [ ! -f "$ZIP" ]; then
+    build::common::echo_and_run curl -L https://www.7-zip.org/a/7z2406-linux-$([ "x86_64" = "$(uname -m)" ] && echo x64 || echo arm64).tar.xz  | tar -xJ -C $BIN_FOLDER 7zz
+fi
+
+EXPECTED_VERSION="$(jq -r '.kubernetes_semver' $KUBERNETES_PACKER_CONFIG)"
+
+FAKE_KUBELET=$TMP_FOLDER/fake-ova/vmdk/usr/bin/kubelet
+mkdir -p $(dirname $FAKE_KUBELET)
+
+cat <<EOF > $FAKE_KUBELET
+#!/usr/bin/env bash
+echo "Kuberentes $EXPECTED_VERSION"
+EOF
+
+chmod +x $FAKE_KUBELET
+
+build::common::echo_and_run $ZIP a $TMP_FOLDER/fake-ova/disk-1.7z $TMP_FOLDER/fake-ova/vmdk/*
+build::common::echo_and_run mv $TMP_FOLDER/fake-ova/disk-1.7z $TMP_FOLDER/fake-ova/disk-1.vmdk
+rm -rf $TMP_FOLDER/fake-ova/vmdk
+build::common::echo_and_run tar cf $OVA_PATH -C $TMP_FOLDER/fake-ova .
+
+rm -rf $TMP_FOLDER

--- a/projects/kubernetes-sigs/image-builder/build/validate_ova_kubelet.sh
+++ b/projects/kubernetes-sigs/image-builder/build/validate_ova_kubelet.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+OVA_PATH="$1"
+RELEASE_BRANCH="$2"
+KUBERNETES_PACKER_CONFIG="$3"
+
+MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+source "${MAKE_ROOT}/../../../build/lib/common.sh"
+
+if [ ! -f "$OVA_PATH" ]; then
+    echo "ERROR: $OVA_PATH does not exist!"
+    exit 1
+fi
+
+TMP_FOLDER="$MAKE_ROOT/_output/tmp"
+BIN_FOLDER="$MAKE_ROOT/_output/.bin"
+ZIP="$BIN_FOLDER/7zz"
+
+mkdir -p $BIN_FOLDER $TMP_FOLDER
+
+if [ ! -f "$ZIP" ]; then
+    build::common::echo_and_run curl -L https://www.7-zip.org/a/7z2406-linux-$([ "x86_64" = "$(uname -m)" ] && echo x64 || echo arm64).tar.xz  | tar -xJ -C $BIN_FOLDER 7zz
+fi
+
+VMDK="$(tar --wildcards -tf $OVA_PATH '*.vmdk')"
+build::common::echo_and_run tar -C $TMP_FOLDER -xf $OVA_PATH $VMDK
+
+build::common::echo_and_run $ZIP -y -o$TMP_FOLDER e $TMP_FOLDER/$VMDK usr/bin/kubelet > /dev/null
+
+EXPECTED_VERSION="$(jq -r '.kubernetes_semver' $KUBERNETES_PACKER_CONFIG)"
+ACTUAL_VERSION="$($TMP_FOLDER/kubelet --version)"
+
+if [[ $ACTUAL_VERSION != *"$EXPECTED_VERSION"* ]]; then
+    echo "ERROR: kubelet version unexpected!"
+    echo "expected: $EXPECTED_VERSION, actual: $ACTUAL_VERSION"
+    exit 1
+fi
+
+echo "kubelet version matches, expected: $EXPECTED_VERSION, actual: $ACTUAL_VERSION"
+
+rm -rf $TMP_FOLDER


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We ran into a case where the image build somehow produced a 1.27 image with 1.25 artifacts in it.  Based on the logs we could find root cause why this happened.  We are thinking it could be something on the vsphere export side.  Adding this should at least tell us during the build if something strange like this happens again.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
