### PR TITLE
fixes release branch check for older kube versions

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -1034,7 +1034,8 @@ check-for-supported-release-branch:
 	elif [ -d $(MAKE_ROOT)/$(RELEASE_BRANCH) ]; then \
 		echo "Supported version to build"; \
 		exit 0; \
-	elif { [ "false" == "$(BINARIES_ARE_RELEASE_BRANCHED)" ] || [ -z "$(BINARY_TARGET_FILES)" ]; } && [ "true" == "$$(yq e ".releases[] | select(.branch==\"$(RELEASE_BRANCH)\") | has(\"branch\")" $(BASE_DIRECTORY)/EKSD_LATEST_RELEASES)" ]; then \
+	elif { [ "false" == "$(BINARIES_ARE_RELEASE_BRANCHED)" ] || [ -z "$(BINARY_TARGET_FILES)" ]; } && \
+		{ [ "true" == "$$(yq e ".releases[] | select(.branch==\"$(RELEASE_BRANCH)\") | has(\"branch\")" $(BASE_DIRECTORY)/EKSD_LATEST_RELEASES)" ] && grep $(RELEASE_BRANCH) $(BASE_DIRECTORY)/release/SUPPORTED_RELEASE_BRANCHES &> /dev/null; }; then \
 		echo "Supported version to build"; \
 		exit 0; \
 	else \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We added this check for cases where newer branches, like main, supported newer versions of kube than previous release branches. In those cases we want builds for say 1.30 to be skipped on release-0.19 which does not support 1.30

This adds support for checking the supported list so we can not build 1.25 on main, but still build it on release-0.19

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
