### PR TITLE
Exclude GitHub Helm chart release tags

### DIFF
--- a/tools/version-tracker/pkg/github/github.go
+++ b/tools/version-tracker/pkg/github/github.go
@@ -142,6 +142,9 @@ func GetLatestRevision(client *github.Client, org, repo, currentRevision string,
 
 		for _, tag := range allTags {
 			tagName := *tag.Name
+			if strings.Contains(tagName, "chart") || strings.Contains(tagName, "helm") {
+				continue
+			}
 			if org == "kubernetes" && repo == "autoscaler" {
 				if !strings.HasPrefix(tagName, "cluster-autoscaler-") {
 					continue


### PR DESCRIPTION
When determining the latest GitHub release, we need to filter out GitHub releases corresponding to Helm charts. This check is not exhaustive but works for the projects we currently maintain.
### Before
```console
$ RELEASE_BRANCH=1-30 bin/version-tracker display --project kubernetes/cloud-provider-vsphere
ORGANIZATION  REPOSITORY              CURRENT VERSION  LATEST VERSION            
kubernetes    cloud-provider-vsphere  v1.30.0          vsphere-cpi-chart-1.30.1
```

### After
```console
$ RELEASE_BRANCH=1-30 bin/version-tracker display --project kubernetes/cloud-provider-vsphere
ORGANIZATION  REPOSITORY              CURRENT VERSION  LATEST VERSION  
kubernetes    cloud-provider-vsphere  v1.30.0          v1.30.1 
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
