### PR TITLE
Fix nginx image and nginx.conf files

### DIFF
--- a/projects/tinkerbell/charts/helm/patches/0001-Load-stream-model-for-nginx-and-update-http2-command.patch
+++ b/projects/tinkerbell/charts/helm/patches/0001-Load-stream-model-for-nginx-and-update-http2-command.patch
@@ -1,0 +1,35 @@
+From bb2527578cca77908f80981c3f871a1faec3b193 Mon Sep 17 00:00:00 2001
+From: Ahree Hong <ahreeh@amazon.com>
+Date: Thu, 13 Jun 2024 11:20:37 -0700
+Subject: [PATCH 1/2] Load stream model for nginx and update http2 command
+
+Signed-off-by: Ahree Hong <ahreeh@amazon.com>
+---
+ tinkerbell/stack/templates/nginx-configmap.yaml | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tinkerbell/stack/templates/nginx-configmap.yaml b/tinkerbell/stack/templates/nginx-configmap.yaml
+index 37f5be0..4b65e86 100644
+--- a/tinkerbell/stack/templates/nginx-configmap.yaml
++++ b/tinkerbell/stack/templates/nginx-configmap.yaml
+@@ -8,6 +8,7 @@ metadata:
+   namespace: {{ .Release.Namespace | quote }}
+ data:
+   nginx.conf: |
++    load_module /usr/lib64/nginx/modules/ngx_stream_module.so;
+     worker_processes 1;
+     events {
+         worker_connections  1024;
+@@ -42,8 +43,7 @@ data:
+       }
+ 
+       server {
+-        listen {{ .Values.tink.server.service.port }};
+-        http2 on;
++        listen {{ .Values.tink.server.service.port }} http2;
+         location / {
+           proxy_set_header X-Real-IP $remote_addr;
+           proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+-- 
+2.45.0
+

--- a/projects/tinkerbell/charts/helm/patches/0002-Use-smee-default-values-for-flags-when-running-in-ho.patch
+++ b/projects/tinkerbell/charts/helm/patches/0002-Use-smee-default-values-for-flags-when-running-in-ho.patch
@@ -1,7 +1,7 @@
 From 5198bcda3023b34381b0c0b9eb33de4a5604184c Mon Sep 17 00:00:00 2001
 From: Ahree Hong <ahreeh@amazon.com>
 Date: Wed, 12 Jun 2024 15:01:44 -0700
-Subject: [PATCH 1/1] Use smee default values for flags when running in
+Subject: [PATCH 2/2] Use smee default values for flags when running in
  hostNetwork=true mode
 
 Signed-off-by: Ahree Hong <ahreeh@amazon.com>

--- a/projects/tinkerbell/tink/docker/linux/nginx/Dockerfile
+++ b/projects/tinkerbell/tink/docker/linux/nginx/Dockerfile
@@ -4,7 +4,7 @@ ARG BUILDER_IMAGE
 FROM $BUILDER_IMAGE as builder
 
 RUN set -x && \
-    install_binary /usr/bin/awk && \
+    install_binary /usr/sbin/awk && \
     install_rpm nginx-mod-stream && \
     cleanup "deps"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix downloading awk, as it was not found in the current nginx image.
Also added a patch to the nginx.conf in the tinkerbell chart to fix residual errors coming from using our nginx image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

