### PR TITLE
Switch to t3.micro instances for raw image build presubmits

### DIFF
--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -10,7 +10,7 @@ IMAGE_NAMES=
 
 IMAGE_BUILDER_DIR=$(REPO)/images/capi
 RAW_IMAGE_BUILD_AMI?=ami-095413544ce52437d
-RAW_IMAGE_BUILD_INSTANCE_TYPE?=t2.micro
+RAW_IMAGE_BUILD_INSTANCE_TYPE?=t3.micro
 RAW_IMAGE_BUILD_KEY_NAME?=raw-image-build
 
 # in the case of ubuntu ova builds we support either default bios or efi mode, for efi we put in a different output folder: $(ARTIFACTS_PATH)/ubuntu/2004/ova/efi/ubuntu.ova


### PR DESCRIPTION
Switch to t3.micro instances for raw image build presubmits.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
