### PR TITLE
only search for nongolang licenses in root

### DIFF
--- a/build/lib/common.sh
+++ b/build/lib/common.sh
@@ -237,7 +237,7 @@ function build::non-golang::gather_licenses(){
 function build::non-golang::copy_licenses(){
   local -r source_dir="$1"
   local -r destination_dir="$2"
-  (cd $source_dir; find . \( -name "*COPYING*" -o -name "*COPYRIGHT*" -o -name "*LICEN[C|S]E*" -o -name "*NOTICE*" \)) |
+  (cd $source_dir; find . -maxdepth 1 \( -name "*COPYING*" -o -name "*COPYRIGHT*" -o -name "*LICEN[C|S]E*" -o -name "*NOTICE*" \)) |
   while read file
   do
     license_dest=$destination_dir/$(dirname $file)

--- a/projects/torvalds/linux/Makefile
+++ b/projects/torvalds/linux/Makefile
@@ -3,7 +3,7 @@ GIT_TAG=$(shell cat GIT_TAG)
 
 REPO=linux
 REPO_OWNER=torvalds
-REPO_SPARSE_CHECKOUT=tools lib/bootconfig.c include/linux/bootconfig.h
+REPO_SPARSE_CHECKOUT=COPYING tools lib/bootconfig.c include/linux/bootconfig.h
 
 SIMPLE_CREATE_BINARIES=false
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The gather-nongolang-licenses was introduced for helm charts, and then later used for the linux build.  The intention is to make sure our produced artifacts, including charts, have the proper upstream license included.  What we were doing makes sense, however, we end up including all the licenses in the `vendor` directory(s).  This we def do not to include all these.  The problem here is the chart ends up getting put into a secret and the recent update to cert manager puts it over the size limit.

This changes the find to only look in the root directory, which should be all we need for the helm repos. I checked each build to ensure we were getting a license file for each helm chart.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
