### PR TITLE
Add dhcp relay images to tinkerbell tink repo

### DIFF
--- a/projects/tinkerbell/tink/Help.mk
+++ b/projects/tinkerbell/tink/Help.mk
@@ -27,10 +27,18 @@ tink-controller/images/amd64: ## Builds/pushes `tink-controller/images/amd64`
 tink-server/images/amd64: ## Builds/pushes `tink-server/images/amd64`
 tink-worker/images/amd64: ## Builds/pushes `tink-worker/images/amd64`
 nginx/images/amd64: ## Builds/pushes `nginx/images/amd64`
+tink-relay/images/amd64: ## Builds/pushes `tink-relay/images/amd64`
+tink-relay-init/images/amd64: ## Builds/pushes `tink-relay-init/images/amd64`
 tink-controller/images/push: ## Builds/pushes `tink-controller/images/push`
 tink-server/images/push: ## Builds/pushes `tink-server/images/push`
 tink-worker/images/push: ## Builds/pushes `tink-worker/images/push`
 nginx/images/push: ## Builds/pushes `nginx/images/push`
+tink-relay/images/push: ## Builds/pushes `tink-relay/images/push`
+tink-relay-init/images/push: ## Builds/pushes `tink-relay-init/images/push`
+
+##@ Fetch Binary Targets
+_output/dependencies/linux-amd64/eksa/isc-projects/dhcp: ## Fetch `_output/dependencies/linux-amd64/eksa/isc-projects/dhcp`
+_output/dependencies/linux-arm64/eksa/isc-projects/dhcp: ## Fetch `_output/dependencies/linux-arm64/eksa/isc-projects/dhcp`
 
 ##@ Checksum Targets
 checksums: ## Update checksums file based on currently built binaries.

--- a/projects/tinkerbell/tink/Makefile
+++ b/projects/tinkerbell/tink/Makefile
@@ -7,12 +7,17 @@ REPO_OWNER=tinkerbell
 BASE_IMAGE_NAME?=eks-distro-minimal-base
 DOCKERFILE_FOLDER=./docker/linux/$(IMAGE_NAME)
 
+PROJECT_DEPENDENCIES=eksa/isc-projects/dhcp
+BUILDSPEC_DEPENDS_ON_OVERRIDE=isc_projects_dhcp_linux_amd64 isc_projects_dhcp_linux_arm64
+
 TINK_CONTROLLER_IMAGE_COMPONENT=tinkerbell/tink/tink-controller
 TINK_SERVER_IMAGE_COMPONENT=tinkerbell/tink/tink-server
 TINK_WORKER_IMAGE_COMPONENT=tinkerbell/tink/tink-worker
 NGINX_IMAGE_COMPONENT=tinkerbell/tink/nginx
+TINK_RELAY_IMAGE_COMPONENT=tinkerbell/tink/tink-relay
+TINK_RELAY_INIT_IMAGE_COMPONENT=tinkerbell/tink/tink-relay-init
 
-IMAGE_NAMES=tink-controller tink-server tink-worker nginx
+IMAGE_NAMES=tink-controller tink-server tink-worker nginx tink-relay tink-relay-init
 
 BINARY_TARGET_FILES=tink-controller tink-server tink-worker
 SOURCE_PATTERNS=./cmd/tink-controller ./cmd/tink-server ./cmd/tink-worker
@@ -33,6 +38,9 @@ create-manifests: tarballs | $$(ENABLE_DOCKER)
 	@build/create_manifests.sh $(REPO) $(ARTIFACTS_PATH) $(IMAGE_REPO) $(TINK_SERVER_IMAGE_COMPONENT) ${TINK_CONTROLLER_IMAGE_COMPONENT} $(IMAGE_TAG) $(GOLANG_VERSION)
 
 nginx/images/%: BASE_IMAGE_NAME=eks-distro-minimal-base-nginx
+tink-relay/images/%: BASE_IMAGE_NAME=eks-distro-minimal-base-glibc
+tink-relay-init/images/%: BASE_IMAGE_NAME=eks-distro-minimal-base-nsenter
+
 
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block

--- a/projects/tinkerbell/tink/docker/linux/tink-relay-init/Dockerfile
+++ b/projects/tinkerbell/tink/docker/linux/tink-relay-init/Dockerfile
@@ -1,0 +1,18 @@
+ARG BASE_IMAGE # https://gallery.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-nsenter
+ARG BUILDER_IMAGE
+
+FROM $BUILDER_IMAGE as builder
+
+WORKDIR /newroot
+
+RUN set -x && \
+    install_binary /usr/sbin/awk /usr/bin/nmap /usr/bin/head /usr/sbin/ip /usr/bin/echo && \
+    install_rpm bash && \
+    cleanup "deps"
+
+ARG TARGETARCH
+ARG TARGETOS
+
+FROM $BASE_IMAGE
+
+COPY --from=builder /newroot /

--- a/projects/tinkerbell/tink/docker/linux/tink-relay/Dockerfile
+++ b/projects/tinkerbell/tink/docker/linux/tink-relay/Dockerfile
@@ -1,0 +1,23 @@
+ARG BASE_IMAGE # https://gallery.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-glibc
+ARG BUILDER_IMAGE
+
+FROM $BUILDER_IMAGE as builder
+
+WORKDIR /newroot
+
+RUN set -x && \
+    enable_extra docker && \
+    install_binary /usr/bin/docker-init && \
+    cleanup "deps"
+
+FROM $BASE_IMAGE
+
+ARG TARGETARCH
+ARG TARGETOS
+
+COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksa/isc-projects/dhcp/dhcrelay /usr/sbin
+COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksa/isc-projects/dhcp/LICENSES /DHCP_LICENSES
+
+COPY --from=builder /newroot /
+
+ENTRYPOINT ["/usr/bin/docker-init", "--", "dhcrelay", "-d"]

--- a/projects/tinkerbell/tink/docker/linux/tink-server/Dockerfile
+++ b/projects/tinkerbell/tink/docker/linux/tink-server/Dockerfile
@@ -6,9 +6,8 @@ FROM $BUILDER_IMAGE as wget-builder
 WORKDIR /newroot
 
 RUN set -x && \
-    clean_install "wget" && \
-    remove_package "bash coreutils gawk info sed grep" && \
-    cleanup "wget"
+    install_binary /usr/bin/wget && \
+    cleanup "deps"
 
 FROM $BASE_IMAGE
 

--- a/release/staging-build.yml
+++ b/release/staging-build.yml
@@ -746,6 +746,9 @@ batch:
           PROJECT_PATH: projects/tinkerbell/rufio
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/tinkerbell.rufio
     - identifier: tinkerbell_tink
+      depend-on:
+        - isc_projects_dhcp_linux_amd64
+        - isc_projects_dhcp_linux_arm64
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add Dockerfiles for dhcp-relay and relay-init images and updates the Makefiles to add targets to build these images. We need to add these images to enable dhcp-relay with the tink-stack.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

