### PR TITLE
Include branch name for kubernetes-sigs/image-builder project

### DIFF
--- a/tools/version-tracker/pkg/commands/upgrade/upgrade.go
+++ b/tools/version-tracker/pkg/commands/upgrade/upgrade.go
@@ -390,7 +390,7 @@ func Run(upgradeOptions *types.UpgradeOptions) error {
 						commitMessage = "Bump Bottlerocket versions to latest release"
 						pullRequestBody = fmt.Sprintf(constants.BottlerocketUpgradePullRequestBody, currentBottlerocketVersion, latestBottlerocketVersion)
 					} else {
-						headBranchName = fmt.Sprintf("update-%s-%s-and-bottlerocket", projectOrg, projectRepo)
+						headBranchName = fmt.Sprintf("update-%s-%s-and-bottlerocket-%s", projectOrg, projectRepo, branchName)
 						commitMessage = fmt.Sprintf("Bump %s and Bottlerocket versions to latest release", projectName)
 						pullRequestBody = fmt.Sprintf(constants.CombinedImageBuilderBottlerocketUpgradePullRequestBody, currentRevision, latestRevision, currentBottlerocketVersion, latestBottlerocketVersion)
 					}
@@ -429,7 +429,7 @@ func Run(upgradeOptions *types.UpgradeOptions) error {
 		if err != nil {
 			return fmt.Errorf("pushing updated project version files for [%s] project: %v", projectName, err)
 		}
-		
+
 		// Update the title of the pull request depending on the base branch name.
 		title := commitMessage
 		if baseBranchName != constants.MainBranchName {


### PR DESCRIPTION
*Description of changes:*
Project upgrades on release branches was added in [#2375](https://github.com/aws/eks-anywhere-build-tooling/pull/3275). This PR includes the build tooling branch name in the `kubernetes-sigs/image-builder` project version bump branch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
