### PR TITLE
Include branch name for bottlerocket releases

### DIFF
--- a/tools/version-tracker/pkg/commands/upgrade/upgrade.go
+++ b/tools/version-tracker/pkg/commands/upgrade/upgrade.go
@@ -386,7 +386,7 @@ func Run(upgradeOptions *types.UpgradeOptions) error {
 				if len(updatedBRFiles) > 0 {
 					updatedFiles = append(updatedFiles, updatedBRFiles...)
 					if len(updatedFiles) == len(updatedBRFiles) {
-						headBranchName = "update-bottlerocket-releases"
+						headBranchName = fmt.Sprintf("update-bottlerocket-releases-%s", branchName)
 						commitMessage = "Bump Bottlerocket versions to latest release"
 						pullRequestBody = fmt.Sprintf(constants.BottlerocketUpgradePullRequestBody, currentBottlerocketVersion, latestBottlerocketVersion)
 					} else {


### PR DESCRIPTION
*Description of changes:*
Project upgrades on release branches was added in https://github.com/aws/eks-anywhere-build-tooling/pull/3275. This PR includes the build tooling branch name in the `kubernetes-sigs/image-builder` project for bottlerocket releases version bump branch as a follow-up to https://github.com/aws/eks-anywhere-build-tooling/pull/3483.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
