### PR TITLE
Skip project upgrade for packages on release branches

### DIFF
--- a/tools/version-tracker/pkg/commands/upgrade/upgrade.go
+++ b/tools/version-tracker/pkg/commands/upgrade/upgrade.go
@@ -70,6 +70,12 @@ func Run(upgradeOptions *types.UpgradeOptions) error {
 	}
 	client := gogithub.NewTokenClient(context.Background(), githubToken)
 
+	// Skip project upgrade if it is in the packages list and branch is not main
+	if branchName != constants.MainBranchName && slices.Contains(constants.UpstreamPackagesProjects, projectName) {
+		logger.Info(fmt.Sprintf("Skipping upgrade for project %s on %s branch", projectName, branchName))
+		return nil
+	}
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("retrieving current working directory: %v", err)

--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -307,4 +307,22 @@ var (
 	CiliumImageDirectories = []string{"cilium", "operator-generic", "cilium-chart"}
 
 	ProjectsSupportingPrereleaseTags = []string{"kubernetes-sigs/cluster-api-provider-cloudstack"}
+
+	// These projects will be upgraded only on main and won't be triggered on release branches.
+	UpstreamPackagesProjects = []string{
+		"aquasecurity/harbor-scanner-trivy",
+		"aquasecurity/trivy",
+		"aws-containers/hello-eks-anywhere",
+		"aws-observability/aws-otel-collector",
+		"distribution/distribution",
+		"emissary-ingress/emissary",
+		"goharbor/harbor",
+		"kubernetes/autoscaler",
+		"kubernetes/cloud-provider-aws",
+		"kubernetes-sigs/metrics-server",
+		"metallb/metallb",
+		"prometheus/node_exporter",
+		"prometheus/prometheus",
+		"redis/redis",
+	}
 )


### PR DESCRIPTION
*Description of changes:*
Packages presubmits are made to run only on main in https://github.com/aws/eks-anywhere-prow-jobs/pull/402 as the packages are build/release only off of main in codebuild. This PR skips upgrading the packages projects on branches other than main.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
