### PR TITLE
Update RHEL8 ISO to 8.10, simplify RHEL config generation

### DIFF
--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -248,28 +248,28 @@ setup-ami-share: | $$(ENABLE_LOGGING)
 setup-packer-configs-%: $(GIT_PATCH_TARGET) | ensure-jq ensure-yq $$(ENABLE_LOGGING)
 	@build/setup_packer_configs.sh $(RELEASE_BRANCH) $(IMAGE_FORMAT) $(IMAGE_OS) $(ARTIFACTS_BUCKET) $(FINAL_IMAGE_DIR) $(ADDITIONAL_PAUSE_$(RELEASE_BRANCH)_FROM) $(LATEST) $(IMAGE_BUILDER_DIR) $(IMAGE_OS_DIR) $(IMAGE_OS_VERSION)
 
-REDHAT_8_VERSION=8.4
-REDHAT_9_VERSION=9.3
-REDHAT_8_ISO_CHECKSUM=ea5f349d492fed819e5086d351de47261c470fc794f7124805d176d69ddf1fcd
-REDHAT_9_ISO_CHECKSUM=5c802147aa58429b21e223ee60e347e850d6b0d8680930c4ffb27340ffb687a8
-NUTANIX_REDHAT_8_VERSION=8.8
-NUTANIX_REDHAT_9_VERSION=9.3
+REDHAT_8_SEMVER=8.10
+REDHAT_9_SEMVER=9.4
+REDHAT_8_ISO_CHECKSUM=9b3c8e31bc2cdd2de9cf96abb3726347f5840ff3b176270647b3e66639af291b
+REDHAT_9_ISO_CHECKSUM=398561d7b66f1a4bf23664f4aa8f2cfbb3641aa2f01a320068e86bd1fc0e9076
+REDHAT_8_KMOD_RPM=kmod-megaraid_sas-07.727.03.00-1.el8_10.elrepo.x86_64.rpm
+REDHAT_9_KMOD_RPM=kmod-megaraid_sas-07.727.03.00-1.el9_4.elrepo.x86_64.rpm
 
 $(REDHAT_CONFIG_TARGET):
 	@if [[ "$(IMAGE_FORMAT)" == "nutanix" ]]; then \
 		jq --null-input \
 			--arg rhel_username "$(RHSM_USERNAME)" \
 			--arg rhel_password "$(RHSM_PASSWORD)" \
-			--arg image_url "$(if $(filter 9,$(IMAGE_OS_VERSION)),https://redhat-iso-pdx.s3.us-west-2.amazonaws.com/$(NUTANIX_REDHAT_9_VERSION)/rhel-$(NUTANIX_REDHAT_9_VERSION).qcow2,https://redhat-iso-pdx.s3.us-west-2.amazonaws.com/$(NUTANIX_REDHAT_8_VERSION)/rhel-$(NUTANIX_REDHAT_8_VERSION).qcow2)" \
+			--arg image_url "$$(aws s3 presign redhat-iso-pdx/$(REDHAT_$(IMAGE_OS_VERSION)_SEMVER)/rhel-$(REDHAT_$(IMAGE_OS_VERSION)_SEMVER)-x86_64-kvm.qcow2)" \
 			'{"rhel_username": $$rhel_username, "rhel_password": $$rhel_password, "image_url": $$image_url}' > $@; \
 	else \
 		jq --null-input \
 			--arg rhel_username "$(RHSM_USERNAME)" \
 			--arg rhel_password "$(RHSM_PASSWORD)" \
-			--arg iso_url "$(if $(filter 9,$(IMAGE_OS_VERSION)),$$(aws s3 presign redhat-iso-pdx/$(REDHAT_9_VERSION)/rhel-$(REDHAT_9_VERSION)-x86_64-dvd.iso),$$(aws s3 presign redhat-iso-pdx/$(REDHAT_8_VERSION)/rhel-$(REDHAT_8_VERSION)-x86_64-dvd.iso))" \
-			--arg extra_rpms "$(if $(filter raw,$(IMAGE_FORMAT)),$$(aws s3 presign redhat-iso-pdx/8.4/rpms/kmod-megaraid_sas-07.719.06.00_el8.4-1.x86_64.rpm),)" \
+			--arg iso_url "$$(aws s3 presign redhat-iso-pdx/$(REDHAT_$(IMAGE_OS_VERSION)_SEMVER)/rhel-$(REDHAT_$(IMAGE_OS_VERSION)_SEMVER)-x86_64-dvd.iso)" \
+			--arg extra_rpms "$(if $(filter raw,$(IMAGE_FORMAT)),$$(aws s3 presign redhat-iso-pdx/$(REDHAT_$(IMAGE_OS_VERSION)_SEMVER)/rpms/$(REDHAT_$(IMAGE_OS_VERSION)_KMOD_RPM)),)" \
 			--arg iso_checksum_type "sha256" \
-			--arg iso_checksum "$(if $(filter 9,$(IMAGE_OS_VERSION)),$(REDHAT_9_ISO_CHECKSUM),$(REDHAT_8_ISO_CHECKSUM))" \
+			--arg iso_checksum "$(REDHAT_$(IMAGE_OS_VERSION)_ISO_CHECKSUM)" \
 			'{"rhel_username": $$rhel_username, "rhel_password": $$rhel_password, "iso_url": $$iso_url, "iso_checksum_type": $$iso_checksum_type, "iso_checksum": $$iso_checksum, "extra_rpms": $$extra_rpms}' > $@; \
 	fi
 ##############################################################

--- a/projects/kubernetes-sigs/image-builder/README.md
+++ b/projects/kubernetes-sigs/image-builder/README.md
@@ -44,6 +44,7 @@ EKS-A CLI project uses these images as the node image when constructing workload
 1. Update the version at the top of this Readme.
 1. Ensure [REQUIRED_DEPENDENCY_VERSIONS.yaml](./REQUIRED_DEPENDENCY_VERSIONS.yaml) is updated, by running `make update-dependency-versions`, with the newly required python/ansible/packer/plugins versions. Uses these versions to update the [builder-base](https://github.com/aws/eks-distro-build-tooling/blob/main/builder-base/versions.yaml)
     which will need to be done before presubmits will pass. Before merging, also update the ECImageBuilder recipe in the build account and generate a new AMI we use for raw image builds.
+1. Ensure that the RHEL 8 and RHEL 9 semvers and the `kmod-megaraid` RPMs in the Makefile are updated. This will require uploading the corresponding ISO and QCOW2 images and RPM to the `redhat-iso-pdx` S3 bucket.
 1. Monitor node image builds and e2e tests as updates to this project can potentially break cluster create and update process.
 
 ### RedHat Satellite Support

--- a/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
@@ -1,4 +1,4 @@
-From 96dd990d39a10e2e5ba1aba4a3bba7aadc818414 Mon Sep 17 00:00:00 2001
+From fee1ec598f39c164271fb3435fe2a4bdfd0758be Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:05:13 -0800
 Subject: [PATCH 1/8] OVA improvements

--- a/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
@@ -1,7 +1,7 @@
-From 8d8f24162036f78f8a91a5f76b73ec23278a120e Mon Sep 17 00:00:00 2001
+From 0f638ec1810420ebda7a00d606d97420629a721d Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 18:36:56 -0800
-Subject: [PATCH 2/2] EKS-D support and changes
+Subject: [PATCH 2/8] EKS-D support and changes
 
 - Add goss validations for EKS-D artifacts
 - Add etcdadm and etcd.tar.gz to image for unstacked etcd support

--- a/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
@@ -1,4 +1,4 @@
-From 7bbf912b6f798557439a70bcbdcabb5ca4623134 Mon Sep 17 00:00:00 2001
+From f8a4415c676b1289092ed10f8151288178fdc7d0 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Feb 2023 01:39:15 -0800
 Subject: [PATCH 3/8] Snow AMI support

--- a/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22.04-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22.04-support-and-improvements.patch
@@ -1,4 +1,4 @@
-From f1f58b4a3f1a4accdbbc061d271b58370fbb787f Mon Sep 17 00:00:00 2001
+From a177aee3c9bcc91607d93d74eb9d9422f4e81a12 Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Fri, 23 Jun 2023 10:50:08 -0500
 Subject: [PATCH 4/8] Ubuntu 22.04 support and improvements

--- a/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
@@ -1,10 +1,8 @@
-From 7dd33c1ba11d0e198f17e45baa1933865b940fd1 Mon Sep 17 00:00:00 2001
+From 97730ad7b5d8ee0ef52dc1f80198e848b1fb0c96 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 6 Dec 2022 15:42:02 -0600
 Subject: [PATCH 5/8] RHEL support and improvements
 
-- Exclude kernel and cloud-init from yum updates
-- Patch cloud-init systemd unit to wait for network manager online
 - Fix redhat 9 cloud-init feature flags bug
 - Fix ensure iptables present for rhel
 - disable gpg for extra rpms
@@ -16,13 +14,10 @@ Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---
  images/capi/ansible/roles/node/tasks/main.yml |  3 +
  .../capi/ansible/roles/node/tasks/redhat.yml  | 32 +++++++
- .../cloud-init.service.d/boot-order.conf      |  2 +
- .../ansible/roles/providers/tasks/main.yml    | 15 ++++
- .../capi/ansible/roles/setup/tasks/redhat.yml | 84 +++++++++++++++++++
+ .../capi/ansible/roles/setup/tasks/redhat.yml | 83 +++++++++++++++++++
  images/capi/packer/config/ansible-args.json   |  2 +-
- 6 files changed, 137 insertions(+), 1 deletion(-)
+ 4 files changed, 119 insertions(+), 1 deletion(-)
  create mode 100644 images/capi/ansible/roles/node/tasks/redhat.yml
- create mode 100644 images/capi/ansible/roles/providers/files/etc/systemd/system/cloud-init.service.d/boot-order.conf
 
 diff --git a/images/capi/ansible/roles/node/tasks/main.yml b/images/capi/ansible/roles/node/tasks/main.yml
 index 408c9d769..e92919353 100644
@@ -77,43 +72,8 @@ index 000000000..b2133b6f1
 +    state: absent
 +  loop: "{{ old_kernels }}"
 \ No newline at end of file
-diff --git a/images/capi/ansible/roles/providers/files/etc/systemd/system/cloud-init.service.d/boot-order.conf b/images/capi/ansible/roles/providers/files/etc/systemd/system/cloud-init.service.d/boot-order.conf
-new file mode 100644
-index 000000000..e1059e3eb
---- /dev/null
-+++ b/images/capi/ansible/roles/providers/files/etc/systemd/system/cloud-init.service.d/boot-order.conf
-@@ -0,0 +1,2 @@
-+[Unit]
-+After=NetworkManager-wait-online.service
-\ No newline at end of file
-diff --git a/images/capi/ansible/roles/providers/tasks/main.yml b/images/capi/ansible/roles/providers/tasks/main.yml
-index 33f8ae6eb..503943cec 100644
---- a/images/capi/ansible/roles/providers/tasks/main.yml
-+++ b/images/capi/ansible/roles/providers/tasks/main.yml
-@@ -81,6 +81,21 @@
-     mode: "0644"
-   when: ansible_os_family != "Flatcar"
- 
-+- name: Creates unit file directory for cloud-init
-+  file:
-+    path: /etc/systemd/system/cloud-init.service.d
-+    state: directory
-+  when: ansible_os_family == "RedHat"
-+
-+- name: Create cloud-init boot order drop in file
-+  copy:
-+    dest: /etc/systemd/system/cloud-init.service.d/boot-order.conf
-+    src: etc/systemd/system/cloud-init.service.d/boot-order.conf
-+    owner: root
-+    group: root
-+    mode: "0755"
-+  when: ansible_os_family == "RedHat"
-+
- # Some OS might disable cloud-final service on boot (rhel 7).
- # Enable all cloud-init services on boot.
- - name: Make sure all cloud init services are enabled
 diff --git a/images/capi/ansible/roles/setup/tasks/redhat.yml b/images/capi/ansible/roles/setup/tasks/redhat.yml
-index 5716fff78..5ab43bed9 100644
+index 5716fff78..c1fc46769 100644
 --- a/images/capi/ansible/roles/setup/tasks/redhat.yml
 +++ b/images/capi/ansible/roles/setup/tasks/redhat.yml
 @@ -22,6 +22,74 @@
@@ -191,15 +151,7 @@ index 5716fff78..5ab43bed9 100644
  
  - name: Perform dnf clean
    ansible.builtin.command: /usr/bin/yum -y clean all
-@@ -45,6 +113,7 @@
-   ansible.builtin.yum:
-     name: "*"
-     state: latest
-+    exclude: cloud-init*
-     lock_timeout: 60
- 
- - name: Install baseline dependencies
-@@ -58,3 +127,18 @@
+@@ -58,3 +126,18 @@
      name: "{{ extra_rpms.split() }}"
      state: present
      lock_timeout: 60

--- a/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-improvements.patch
@@ -1,4 +1,4 @@
-From 0bbac99ce398812f96dffbe2cb0991587b617e3d Mon Sep 17 00:00:00 2001
+From 123a579a9e3fff49f12e7d5c826a8de7aa9af810 Mon Sep 17 00:00:00 2001
 From: Ilya Alekseyev <ilya.alekseyev@nutanix.com>
 Date: Wed, 11 Oct 2023 22:07:22 -0400
 Subject: [PATCH 6/8] Nutanix improvements

--- a/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
@@ -1,4 +1,4 @@
-From 746d2c799760508d11c991bceab1b3f593830889 Mon Sep 17 00:00:00 2001
+From 7ea8c11ec8d93ee553c824a6d8a5d51bad06bb55 Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
 Date: Mon, 21 Aug 2023 18:40:07 -0500
 Subject: [PATCH 7/8] adds retries and timeout to packer image-builder
@@ -44,7 +44,7 @@ index bab9c2bde..7b3298826 100644
    "vmx_version": "15",
    "vnc_bind_address": "127.0.0.1",
 diff --git a/images/capi/packer/ova/packer-node.json b/images/capi/packer/ova/packer-node.json
-index ab50f6e22..debb04643 100644
+index d95c44a3c..54e518181 100644
 --- a/images/capi/packer/ova/packer-node.json
 +++ b/images/capi/packer/ova/packer-node.json
 @@ -19,8 +19,9 @@

--- a/projects/kubernetes-sigs/image-builder/patches/0008-Networking-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0008-Networking-improvements.patch
@@ -1,4 +1,4 @@
-From 0c2d5a9045384c28233b1e6cb8a66c583918eace Mon Sep 17 00:00:00 2001
+From 16ab7b4d9dabd1dd782e0696c5052d0a4cc6778c Mon Sep 17 00:00:00 2001
 From: Taylor Neyland <tneyla@amazon.com>
 Date: Wed, 19 Jul 2023 12:51:30 -0500
 Subject: [PATCH 8/8] Networking improvements


### PR DESCRIPTION
* Update RHEL8 to 8.10 for CI builds
* Update RHEL9 to 9.4 for CI builds
* Use same RHEL versions for all hypervisors
* Use separate `kmod-megaraid` RPMs for RHEL 8 and 9


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
