### PR TITLE
Use unsigned URL for Nutanix source RHEL images

### DIFF
--- a/projects/kubernetes-sigs/image-builder/Makefile
+++ b/projects/kubernetes-sigs/image-builder/Makefile
@@ -260,7 +260,7 @@ $(REDHAT_CONFIG_TARGET):
 		jq --null-input \
 			--arg rhel_username "$(RHSM_USERNAME)" \
 			--arg rhel_password "$(RHSM_PASSWORD)" \
-			--arg image_url "$$(aws s3 presign redhat-iso-pdx/$(REDHAT_$(IMAGE_OS_VERSION)_SEMVER)/rhel-$(REDHAT_$(IMAGE_OS_VERSION)_SEMVER)-x86_64-kvm.qcow2)" \
+			--arg image_url "https://redhat-iso-pdx.s3.us-west-2.amazonaws.com/$(REDHAT_$(IMAGE_OS_VERSION)_SEMVER)/rhel-$(REDHAT_$(IMAGE_OS_VERSION)_SEMVER)-x86_64-kvm.qcow2" \
 			'{"rhel_username": $$rhel_username, "rhel_password": $$rhel_password, "image_url": $$image_url}' > $@; \
 	else \
 		jq --null-input \


### PR DESCRIPTION
Use unsigned URL for Nutanix source RHEL images.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
