### PR TITLE
Retrieve Go version for local-path-provisioner project from Dockerfile

### DIFF
--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -174,11 +174,6 @@ var (
 			Extract:                  true,
 			TrimLeadingVersionPrefix: true,
 		},
-		"rancher/local-path-provisioner": {
-			AssetName:  "local-path-provisioner-amd64",
-			BinaryName: "local-path-provisioner-amd64",
-			Extract:    false,
-		},
 		"replicatedhq/troubleshoot": {
 			AssetName:  "support-bundle_linux_amd64.tar.gz",
 			BinaryName: "support-bundle",
@@ -272,6 +267,10 @@ var (
 		"prometheus/prometheus": {
 			SourceOfTruthFile:     ".promu.yml",
 			GoVersionSearchString: `version: (1\.\d\d)`,
+		},
+		"rancher/local-path-provisioner": {
+			SourceOfTruthFile:     "Dockerfile.dapper",
+			GoVersionSearchString: `golang:(1\.\d\d)`,
 		},
 		"tinkerbell/boots": {
 			SourceOfTruthFile:     "go.mod",


### PR DESCRIPTION
The `rancher/local-path-provisioner` project did not publish release binary assets for their latest release, so the upgrade job was failing. Hence we are using the project Dockerfile to determine the Go version used to build the binary.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
