### PR TITLE
Revert tink-server Dockerfile to use clean_install

### DIFF
--- a/projects/tinkerbell/tink/docker/linux/tink-server/Dockerfile
+++ b/projects/tinkerbell/tink/docker/linux/tink-server/Dockerfile
@@ -6,8 +6,9 @@ FROM $BUILDER_IMAGE as wget-builder
 WORKDIR /newroot
 
 RUN set -x && \
-    install_binary /usr/bin/wget && \
-    cleanup "deps"
+    clean_install "wget" && \
+    remove_package "bash coreutils gawk info sed grep" && \
+    cleanup "wget"
 
 FROM $BASE_IMAGE
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Tink builds started failing due to a seg fault after a change to the tink-server Dockerfile. Reverting the tink-server Dockerfile to how it was before.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.