### PR TITLE
Add buildspec file for tink project

### DIFF
--- a/projects/tinkerbell/tink/buildspecs/batch-build.yml
+++ b/projects/tinkerbell/tink/buildspecs/batch-build.yml
@@ -1,0 +1,10 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+    - ./build/lib/setup.sh
+
+  build:
+    commands:
+    - if $(make check-project-path-exists) && make check-for-release-branch-skip -C $PROJECT_PATH; then make release -C $PROJECT_PATH; fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
CDK changes have been made to the tinkerbell/tink project to run as batch builds. In order to ensure the builds don't break in previous releases, we need to add this build spec file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
