### PR TITLE
Set IMAGE_BUILD_ARGS in tinkerbell tink Makefile

### DIFF
--- a/projects/tinkerbell/tink/Makefile
+++ b/projects/tinkerbell/tink/Makefile
@@ -17,6 +17,14 @@ BUILDSPEC_1_VARS_VALUES=IMAGE_PLATFORMS
 BUILDSPEC_1_ARCH_TYPES=LINUX_CONTAINER ARM_CONTAINER
 BUILDSPEC_2_DEPENDS_ON_OVERRIDE=tinkerbell_tink_linux_amd64 tinkerbell_tink_linux_arm64
 
+# we need to set IMAGE_BUILD_ARGS here even though its the same as the default. 
+# it is set in Common.mk on the images target (https://github.com/aws/eks-anywhere-build-tooling/blob/8b6d6d66974e881b22e3c9c8ea29adc26f7df5fd/Common.mk#L799)
+# and the combine-images target (https://github.com/aws/eks-anywhere-build-tooling/blob/8b6d6d66974e881b22e3c9c8ea29adc26f7df5fd/Common.mk#L846)
+# since combine-images has images as prereq target, the ?= does not really behavior as one might expect.
+# the images target being the actual action, its version of the set takes prioirty and resets to empty
+# setting it explicitly to empty here takes allows the combine-images override to take proirty
+IMAGE_BUILD_ARGS=
+
 # Since we build the arm and amd binaries on difference instances in codebuild
 # we do not want to delete missing files when s3 sync-ing from local to the bucket
 # since this would clobber the other build's artifacts


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We need to set IMAGE_BUILD_ARGS in the Makefile to empty. Since combine-images has images as prereq target, the ?= does not really behavior as one might expect and resets to empty causing build failures.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

