### PR TITLE
Use IAM instance profile for EKS-A admin AMI build

### DIFF
--- a/projects/aws/eks-a-admin-image/eks-a-admin-snow.pkr.hcl
+++ b/projects/aws/eks-a-admin-image/eks-a-admin-snow.pkr.hcl
@@ -9,8 +9,9 @@ packer {
 }
 
 source "amazon-ebs" "amazonlinux2" {
-  ami_name      = "${local.image_name}"
-  instance_type = "t3.xlarge"
+  ami_name             = "${local.image_name}"
+  instance_type        = "t3.xlarge"
+  iam_instance_profile = "eksa-imagebuilder-instance-profile"
   // with t3.micro 48 min
   // with t3.large 45 min
   // with t3.xlarge 40 min


### PR DESCRIPTION
Use IAM instance profile for EKS-A admin AMI build to establish SSM connections.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
