### PR TITLE
Image-builder Patch: Remove swap partition when building RHEL-9 efi image

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
@@ -1,7 +1,7 @@
 From fee1ec598f39c164271fb3435fe2a4bdfd0758be Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:05:13 -0800
-Subject: [PATCH 1/8] OVA improvements
+Subject: [PATCH 1/9] OVA improvements
 
 - Create /etc/pki/tls/certs dir as part of image-builds
 - Tweak Product info in OVF

--- a/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
@@ -1,7 +1,7 @@
 From 0f638ec1810420ebda7a00d606d97420629a721d Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 18:36:56 -0800
-Subject: [PATCH 2/8] EKS-D support and changes
+Subject: [PATCH 2/9] EKS-D support and changes
 
 - Add goss validations for EKS-D artifacts
 - Add etcdadm and etcd.tar.gz to image for unstacked etcd support

--- a/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
@@ -1,7 +1,7 @@
 From f8a4415c676b1289092ed10f8151288178fdc7d0 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Feb 2023 01:39:15 -0800
-Subject: [PATCH 3/8] Snow AMI support
+Subject: [PATCH 3/9] Snow AMI support
 
 ---
  images/capi/packer/ami/packer.json | 12 ++++++++++--

--- a/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22.04-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22.04-support-and-improvements.patch
@@ -1,7 +1,7 @@
 From a177aee3c9bcc91607d93d74eb9d9422f4e81a12 Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Fri, 23 Jun 2023 10:50:08 -0500
-Subject: [PATCH 4/8] Ubuntu 22.04 support and improvements
+Subject: [PATCH 4/9] Ubuntu 22.04 support and improvements
 
 - adds support for raw ubuntu 22.04 builds
 - Ubuntu switch to offline-install when mirrors are unavailable

--- a/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
@@ -1,7 +1,7 @@
 From 97730ad7b5d8ee0ef52dc1f80198e848b1fb0c96 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 6 Dec 2022 15:42:02 -0600
-Subject: [PATCH 5/8] RHEL support and improvements
+Subject: [PATCH 5/9] RHEL support and improvements
 
 - Fix redhat 9 cloud-init feature flags bug
 - Fix ensure iptables present for rhel

--- a/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-improvements.patch
@@ -1,7 +1,7 @@
 From 123a579a9e3fff49f12e7d5c826a8de7aa9af810 Mon Sep 17 00:00:00 2001
 From: Ilya Alekseyev <ilya.alekseyev@nutanix.com>
 Date: Wed, 11 Oct 2023 22:07:22 -0400
-Subject: [PATCH 6/8] Nutanix improvements
+Subject: [PATCH 6/9] Nutanix improvements
 
 - Fetch Nutanix RHEL source image URL from environment
 - Force-delete Nutanix builder VMs on failure

--- a/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
@@ -1,7 +1,7 @@
 From 7ea8c11ec8d93ee553c824a6d8a5d51bad06bb55 Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
 Date: Mon, 21 Aug 2023 18:40:07 -0500
-Subject: [PATCH 7/8] adds retries and timeout to packer image-builder
+Subject: [PATCH 7/9] adds retries and timeout to packer image-builder
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0008-Networking-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0008-Networking-improvements.patch
@@ -1,7 +1,7 @@
 From 16ab7b4d9dabd1dd782e0696c5052d0a4cc6778c Mon Sep 17 00:00:00 2001
 From: Taylor Neyland <tneyla@amazon.com>
 Date: Wed, 19 Jul 2023 12:51:30 -0500
-Subject: [PATCH 8/8] Networking improvements
+Subject: [PATCH 8/9] Networking improvements
 
 - Disable UDP offload service for Redhat and Ubuntu
 - Default Flatcar version to avoid pulling from internet on every make

--- a/projects/kubernetes-sigs/image-builder/patches/0009-Remove-swap-partition-from-RHEL-9-EFI.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0009-Remove-swap-partition-from-RHEL-9-EFI.patch
@@ -1,0 +1,25 @@
+From 41217c1738f44f5cd3809e3ba01b000443617649 Mon Sep 17 00:00:00 2001
+From: Shizhao Liu <lshizhao@amazon.com>
+Date: Thu, 8 Aug 2024 15:29:43 -0700
+Subject: [PATCH 9/9] Remove swap partition from RHEL 9 efi image
+
+---
+ images/capi/packer/raw/linux/rhel/http/9/ks-efi.cfg | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/images/capi/packer/raw/linux/rhel/http/9/ks-efi.cfg b/images/capi/packer/raw/linux/rhel/http/9/ks-efi.cfg
+index c2f7daa1f..a4b03b6eb 100644
+--- a/images/capi/packer/raw/linux/rhel/http/9/ks-efi.cfg
++++ b/images/capi/packer/raw/linux/rhel/http/9/ks-efi.cfg
+@@ -34,7 +34,6 @@ zerombr
+ clearpart --all --initlabel --drives=sda
+ part / --fstype="ext4" --grow --asprimary --label=slash --ondisk=sda
+ part /boot/efi --fstype="efi" --ondisk=sda --size=200 --fsoptions="umask=0077,shortname=winnt"
+-part swap --fstype="swap" --ondisk=sda --size=100
+ part /boot --fstype="ext4" --ondisk=sda --size=1024
+ 
+ # Reboot after successful installation
+-- 
+2.45.2
+
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Rhel 9 EFI image has a partition with swap enabled https://github.com/kubernetes-sigs/image-builder/blob/main/images/capi/packer/raw/linux/rhel/http/9/ks-efi.cfg#L37
when using this image to create EKS-A cluster the kubelet cannot start due to the swap partition. 

This PR patches the rhel9 ks-efi.cfg file by removing the swap partition from ks-efi.cfg

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
