### PR TITLE
Image-builder patch: remove swap partition from RHEL 9 EFI

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
@@ -1,7 +1,7 @@
 From 0c49c7f34ffe3c0dc2e250052769e50b3e38318c Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:05:13 -0800
-Subject: [PATCH 1/9] OVA improvements
+Subject: [PATCH 1/10] OVA improvements
 
 - Create /etc/pki/tls/certs dir as part of image-builds
 - Tweak Product info in OVF

--- a/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
@@ -1,7 +1,7 @@
 From 1745d557fc248a561cbb6d4cc59fb03998887edd Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 18:36:56 -0800
-Subject: [PATCH 2/9] EKS-D support and changes
+Subject: [PATCH 2/10] EKS-D support and changes
 
 - Add goss validations for EKS-D artifacts
 - Add etcdadm and etcd.tar.gz to image for unstacked etcd support

--- a/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
@@ -1,7 +1,7 @@
 From 6072e18479fb898575a68c541824fccd0405c4d6 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Feb 2023 01:39:15 -0800
-Subject: [PATCH 3/9] Snow AMI support
+Subject: [PATCH 3/10] Snow AMI support
 
 ---
  images/capi/packer/ami/packer.json | 12 ++++++++++--

--- a/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22.04-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22.04-support-and-improvements.patch
@@ -1,7 +1,7 @@
 From f2be9e8cdbe6d7d5f7694c12c0f7d30559ddb0a9 Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Fri, 23 Jun 2023 10:50:08 -0500
-Subject: [PATCH 4/9] Ubuntu 22.04 support and improvements
+Subject: [PATCH 4/10] Ubuntu 22.04 support and improvements
 
 - adds support for raw ubuntu 22.04 builds
 - Ubuntu switch to offline-install when mirrors are unavailable

--- a/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
@@ -1,7 +1,7 @@
 From b932fe0357bf1bedcf8a5c66656ee23437f449ae Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 6 Dec 2022 15:42:02 -0600
-Subject: [PATCH 5/9] RHEL support and improvements
+Subject: [PATCH 5/10] RHEL support and improvements
 
 - Fix redhat 9 cloud-init feature flags bug
 - Fix ensure iptables present for rhel

--- a/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-improvements.patch
@@ -1,7 +1,7 @@
 From 2bfd6156b09f3c8b2905f661df7ff78159c3bb6e Mon Sep 17 00:00:00 2001
 From: Ilya Alekseyev <ilya.alekseyev@nutanix.com>
 Date: Wed, 11 Oct 2023 22:07:22 -0400
-Subject: [PATCH 6/9] Nutanix improvements
+Subject: [PATCH 6/10] Nutanix improvements
 
 - Fetch Nutanix RHEL source image URL from environment
 - Force-delete Nutanix builder VMs on failure

--- a/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
@@ -1,7 +1,7 @@
 From e7dbec26c7421808069d3f267dd609dddb9b0c1f Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
 Date: Mon, 21 Aug 2023 18:40:07 -0500
-Subject: [PATCH 7/9] adds retries and timeout to packer image-builder
+Subject: [PATCH 7/10] adds retries and timeout to packer image-builder
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0008-Networking-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0008-Networking-improvements.patch
@@ -1,7 +1,7 @@
 From 8594d0cc856eb8c996ab16b67824d4823092d17a Mon Sep 17 00:00:00 2001
 From: Taylor Neyland <tneyla@amazon.com>
 Date: Wed, 19 Jul 2023 12:51:30 -0500
-Subject: [PATCH 8/9] Networking improvements
+Subject: [PATCH 8/10] Networking improvements
 
 - Disable UDP offload service for Redhat and Ubuntu
 - Default Flatcar version to avoid pulling from internet on every make

--- a/projects/kubernetes-sigs/image-builder/patches/0009-Revert-fix-Update-preseed-and-cloud-init-to-use-CD-f.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0009-Revert-fix-Update-preseed-and-cloud-init-to-use-CD-f.patch
@@ -1,7 +1,7 @@
 From abc210afa806908f12f293238245f4f68788d8d1 Mon Sep 17 00:00:00 2001
 From: Saurabh Parekh <sjparekh@amazon.com>
 Date: Fri, 9 Aug 2024 00:03:17 -0700
-Subject: [PATCH 9/9] =?UTF-8?q?Revert=20"fix:=20=F0=9F=90=9B=20Update=20pr?=
+Subject: [PATCH 9/10] =?UTF-8?q?Revert=20"fix:=20=F0=9F=90=9B=20Update=20pr?=
  =?UTF-8?q?eseed=20and=20cloud-init=20to=20use=20CD=20for=20boot=20files"?=
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/projects/kubernetes-sigs/image-builder/patches/0010-Remove-swap-partition-in-rhel9-efi.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0010-Remove-swap-partition-in-rhel9-efi.patch
@@ -1,0 +1,24 @@
+From 4c2cc2feb56c6e2c5a86226ff7bab0f8e66cd38d Mon Sep 17 00:00:00 2001
+From: Shizhao Liu <lshizhao@amazon.com>
+Date: Fri, 9 Aug 2024 09:50:31 -0700
+Subject: [PATCH 10/10] Image-builder patch: remove swap partition from RHEL 9 EFI
+
+---
+ images/capi/packer/raw/linux/rhel/http/9/ks-efi.cfg | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/images/capi/packer/raw/linux/rhel/http/9/ks-efi.cfg b/images/capi/packer/raw/linux/rhel/http/9/ks-efi.cfg
+index c2f7daa1f..a4b03b6eb 100644
+--- a/images/capi/packer/raw/linux/rhel/http/9/ks-efi.cfg
++++ b/images/capi/packer/raw/linux/rhel/http/9/ks-efi.cfg
+@@ -34,7 +34,6 @@ zerombr
+ clearpart --all --initlabel --drives=sda
+ part / --fstype="ext4" --grow --asprimary --label=slash --ondisk=sda
+ part /boot/efi --fstype="efi" --ondisk=sda --size=200 --fsoptions="umask=0077,shortname=winnt"
+-part swap --fstype="swap" --ondisk=sda --size=100
+ part /boot --fstype="ext4" --ondisk=sda --size=1024
+ 
+ # Reboot after successful installation
+-- 
+2.45.2
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Rhel 9 EFI image has a partition with swap enabled https://github.com/kubernetes-sigs/image-builder/blob/main/images/capi/packer/raw/linux/rhel/http/9/ks-efi.cfg#L37
when using this image to create EKS-A cluster the kubelet cannot start due to the swap partition.

This PR patches the rhel9 ks-efi.cfg file by removing the swap partition from ks-efi.cfg


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
