### PR TITLE
Add patch to revert using CD for preseed and cloud-init boot files

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
@@ -1,7 +1,7 @@
-From 1606de84034c8c2e8069e347c141c8ffebe0c896 Mon Sep 17 00:00:00 2001
+From 0c49c7f34ffe3c0dc2e250052769e50b3e38318c Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:05:13 -0800
-Subject: [PATCH 1/8] OVA improvements
+Subject: [PATCH 1/9] OVA improvements
 
 - Create /etc/pki/tls/certs dir as part of image-builds
 - Tweak Product info in OVF
@@ -74,5 +74,5 @@ index 96f389d61..34e1f80b8 100644
      "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
      "export_manifest": "none",
 -- 
-2.45.2
+2.46.0
 

--- a/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
@@ -1,7 +1,7 @@
-From 0e6b745476d48ea982445540475eb174a99e3d61 Mon Sep 17 00:00:00 2001
+From 1745d557fc248a561cbb6d4cc59fb03998887edd Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 18:36:56 -0800
-Subject: [PATCH 2/8] EKS-D support and changes
+Subject: [PATCH 2/9] EKS-D support and changes
 
 - Add goss validations for EKS-D artifacts
 - Add etcdadm and etcd.tar.gz to image for unstacked etcd support
@@ -316,5 +316,5 @@ index 1d52a5f98..29a3b34c2 100644
        "version": "{{user `goss_version`}}"
      }
 -- 
-2.45.2
+2.46.0
 

--- a/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
@@ -1,7 +1,7 @@
-From f818df3205ddfa0959219b12ba7fbdf67fc1abf5 Mon Sep 17 00:00:00 2001
+From 6072e18479fb898575a68c541824fccd0405c4d6 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Feb 2023 01:39:15 -0800
-Subject: [PATCH 3/8] Snow AMI support
+Subject: [PATCH 3/9] Snow AMI support
 
 ---
  images/capi/packer/ami/packer.json | 12 ++++++++++--
@@ -50,5 +50,5 @@ index 0bfbf32cd..33fcfd43a 100644
 +}
 \ No newline at end of file
 -- 
-2.45.2
+2.46.0
 

--- a/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22.04-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22.04-support-and-improvements.patch
@@ -1,7 +1,7 @@
-From 1f31e0fd207bea73491f997b2352fef5ae0e376e Mon Sep 17 00:00:00 2001
+From f2be9e8cdbe6d7d5f7694c12c0f7d30559ddb0a9 Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Fri, 23 Jun 2023 10:50:08 -0500
-Subject: [PATCH 4/8] Ubuntu 22.04 support and improvements
+Subject: [PATCH 4/9] Ubuntu 22.04 support and improvements
 
 - adds support for raw ubuntu 22.04 builds
 - Ubuntu switch to offline-install when mirrors are unavailable
@@ -361,5 +361,5 @@ index 000000000..9317900f5
 +  "shutdown_command": "shutdown -P now"
 +  }
 -- 
-2.45.2
+2.46.0
 

--- a/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
@@ -1,7 +1,7 @@
-From 03b68c311a99d861d09dd4f6cc90aadc84433410 Mon Sep 17 00:00:00 2001
+From b932fe0357bf1bedcf8a5c66656ee23437f449ae Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 6 Dec 2022 15:42:02 -0600
-Subject: [PATCH 5/8] RHEL support and improvements
+Subject: [PATCH 5/9] RHEL support and improvements
 
 - Fix redhat 9 cloud-init feature flags bug
 - Fix ensure iptables present for rhel
@@ -182,5 +182,5 @@ index 435797c65..e97099f63 100644
    "ansible_scp_extra_args": "{{env `ANSIBLE_SCP_EXTRA_ARGS`}}"
  }
 -- 
-2.45.2
+2.46.0
 

--- a/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-improvements.patch
@@ -1,7 +1,7 @@
-From 25bf770527fead68488db8f2418e41eb7a7b0b95 Mon Sep 17 00:00:00 2001
+From 2bfd6156b09f3c8b2905f661df7ff78159c3bb6e Mon Sep 17 00:00:00 2001
 From: Ilya Alekseyev <ilya.alekseyev@nutanix.com>
 Date: Wed, 11 Oct 2023 22:07:22 -0400
-Subject: [PATCH 6/8] Nutanix improvements
+Subject: [PATCH 6/9] Nutanix improvements
 
 - Fetch Nutanix RHEL source image URL from environment
 - Force-delete Nutanix builder VMs on failure
@@ -58,5 +58,5 @@ index b7dddb4f2..921a9729f 100644
    "shutdown_command": "shutdown -P now",
    "user_data": "I2Nsb3VkLWNvbmZpZwp1c2VyczoKICAtIG5hbWU6IGJ1aWxkZXIKICAgIHN1ZG86IFsnQUxMPShBTEwpIE5PUEFTU1dEOkFMTCddCmNocGFzc3dkOgogIGxpc3Q6IHwKICAgIGJ1aWxkZXI6YnVpbGRlcgogIGV4cGlyZTogRmFsc2UKc3NoX3B3YXV0aDogVHJ1ZQ=="
 -- 
-2.45.2
+2.46.0
 

--- a/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
@@ -1,7 +1,7 @@
-From c225b8694c0c56ee5fef788b19c711aab5d0e5d8 Mon Sep 17 00:00:00 2001
+From e7dbec26c7421808069d3f267dd609dddb9b0c1f Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
 Date: Mon, 21 Aug 2023 18:40:07 -0500
-Subject: [PATCH 7/8] adds retries and timeout to packer image-builder
+Subject: [PATCH 7/9] adds retries and timeout to packer image-builder
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---
@@ -202,5 +202,5 @@ index 3b61117df..29d18badd 100644
        "user": "builder"
      },
 -- 
-2.45.2
+2.46.0
 

--- a/projects/kubernetes-sigs/image-builder/patches/0008-Networking-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0008-Networking-improvements.patch
@@ -1,7 +1,7 @@
-From 37a5e0ce7a69745d75029429059bfbdcdc3e2105 Mon Sep 17 00:00:00 2001
+From 8594d0cc856eb8c996ab16b67824d4823092d17a Mon Sep 17 00:00:00 2001
 From: Taylor Neyland <tneyla@amazon.com>
 Date: Wed, 19 Jul 2023 12:51:30 -0500
-Subject: [PATCH 8/8] Networking improvements
+Subject: [PATCH 8/9] Networking improvements
 
 - Disable UDP offload service for Redhat and Ubuntu
 - Default Flatcar version to avoid pulling from internet on every make
@@ -125,5 +125,5 @@ index 46e524ee0..4e3f800b1 100644
 +    state: stopped
 +  when: ansible_distribution_version is version('22.04', '>=')
 -- 
-2.45.2
+2.46.0
 

--- a/projects/kubernetes-sigs/image-builder/patches/0009-Revert-fix-Update-preseed-and-cloud-init-to-use-CD-f.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0009-Revert-fix-Update-preseed-and-cloud-init-to-use-CD-f.patch
@@ -1,0 +1,182 @@
+From abc210afa806908f12f293238245f4f68788d8d1 Mon Sep 17 00:00:00 2001
+From: Saurabh Parekh <sjparekh@amazon.com>
+Date: Fri, 9 Aug 2024 00:03:17 -0700
+Subject: [PATCH 9/9] =?UTF-8?q?Revert=20"fix:=20=F0=9F=90=9B=20Update=20pr?=
+ =?UTF-8?q?eseed=20and=20cloud-init=20to=20use=20CD=20for=20boot=20files"?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This reverts commit e49a35f6ecd4f3eb10c53df610f83606e1c36ab4.
+---
+ images/capi/Dockerfile                      | 8 +++-----
+ images/capi/packer/ova/packer-node.json     | 4 ----
+ images/capi/packer/ova/photon-5.json        | 6 ++----
+ images/capi/packer/ova/ubuntu-2204-efi.json | 6 ++----
+ images/capi/packer/ova/ubuntu-2204.json     | 7 +++----
+ images/capi/packer/ova/ubuntu-2404-efi.json | 7 +++----
+ images/capi/packer/ova/ubuntu-2404.json     | 7 +++----
+ images/capi/scripts/ci-ova.sh               | 3 ---
+ 8 files changed, 16 insertions(+), 32 deletions(-)
+
+diff --git a/images/capi/Dockerfile b/images/capi/Dockerfile
+index fc83cf692..9514c03ae 100644
+--- a/images/capi/Dockerfile
++++ b/images/capi/Dockerfile
+@@ -31,11 +31,9 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+ 	wget \
+ 	qemu-system-x86 \
+ 	qemu-kvm \
+-	# Adding xorriso to create iso for mounting cd_drives which then can be used for bootstrapping node image
+-	xorriso \
+-	&& useradd -ms /bin/bash imagebuilder \
+-	&& apt-get purge --auto-remove -y \
+-	&& rm -rf /var/lib/apt/lists/*
++    && useradd -ms /bin/bash imagebuilder \
++    && apt-get purge --auto-remove -y \
++    && rm -rf /var/lib/apt/lists/*
+ 
+ ARG ARCH
+ ARG PASSED_IB_VERSION
+diff --git a/images/capi/packer/ova/packer-node.json b/images/capi/packer/ova/packer-node.json
+index 3d0c3ed11..54e518181 100644
+--- a/images/capi/packer/ova/packer-node.json
++++ b/images/capi/packer/ova/packer-node.json
+@@ -203,8 +203,6 @@
+         "{{user `boot_command_suffix`}}"
+       ],
+       "boot_wait": "{{user `boot_wait`}}",
+-      "cd_files": "{{user `cd_content_location`}}",
+-      "cd_label": "{{user `cd_label`}}",
+       "cdrom_type": "{{user `cdrom_type`}}",
+       "cluster": "{{user `cluster`}}",
+       "communicator": "ssh",
+@@ -486,8 +484,6 @@
+     "block_nouveau_loading": "true",
+     "build_timestamp": "{{timestamp}}",
+     "build_version": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
+-    "cd_files": "{{user `cd_content_location`}}",
+-    "cd_label": "{{user `cd_label`}}",
+     "cdrom_adapter_type": "ide",
+     "cdrom_type": "ide",
+     "cluster": "",
+diff --git a/images/capi/packer/ova/photon-5.json b/images/capi/packer/ova/photon-5.json
+index 612c552c0..82b5fa949 100644
+--- a/images/capi/packer/ova/photon-5.json
++++ b/images/capi/packer/ova/photon-5.json
+@@ -1,10 +1,8 @@
+ {
+   "boot_command_prefix": "<esc><wait> vmlinuz initrd=initrd.img root/dev/ram0 loglevel=3 photon.media=cdrom ks=",
+-  "boot_command_suffix": " insecure_installation=1<enter><wait>",
+-  "boot_media_path": "/dev/sr1:/5/ks.json",
++  "boot_command_suffix": "/5/ks.json insecure_installation=1<enter><wait>",
++  "boot_media_path": "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
+   "build_name": "photon-5",
+-  "cd_content_location": "./packer/ova/linux/{{user `distro_name`}}/http/*",
+-  "cd_label": "cidata",
+   "cdrom_type": "sata",
+   "distro_arch": "amd64",
+   "distro_name": "photon",
+diff --git a/images/capi/packer/ova/ubuntu-2204-efi.json b/images/capi/packer/ova/ubuntu-2204-efi.json
+index 1672a7409..ffd4bf6c8 100644
+--- a/images/capi/packer/ova/ubuntu-2204-efi.json
++++ b/images/capi/packer/ova/ubuntu-2204-efi.json
+@@ -1,15 +1,13 @@
+ {
+-  "boot_command_prefix": "c<wait>linux /casper/vmlinuz ipv6.disable={{ user `boot_disable_ipv6` }} --- autoinstall ds='nocloud;'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
++  "boot_command_prefix": "c<wait>linux /casper/vmlinuz ipv6.disable={{ user `boot_disable_ipv6` }} --- autoinstall ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/22.04.efi/'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
+   "boot_disable_ipv6": "0",
+   "boot_media_path": "/media/HTTP",
+   "build_name": "ubuntu-2204-efi",
+-  "cd_content_location": "./packer/ova/linux/{{user `distro_name`}}/http/{{user `distro_version`}}/*",
+-  "cd_label": "cidata",
+   "distro_arch": "amd64",
+   "distro_name": "ubuntu",
+   "distro_version": "22.04",
+   "firmware": "efi",
+-  "floppy_dirs": "",
++  "floppy_dirs": "./packer/ova/linux/{{user `distro_name`}}/http/",
+   "guest_os_type": "ubuntu-64",
+   "iso_checksum": "45f873de9f8cb637345d6e66a583762730bbea30277ef7b32c9c3bd6700a32b2",
+   "iso_checksum_type": "sha256",
+diff --git a/images/capi/packer/ova/ubuntu-2204.json b/images/capi/packer/ova/ubuntu-2204.json
+index 3b28a744f..e436d93b9 100644
+--- a/images/capi/packer/ova/ubuntu-2204.json
++++ b/images/capi/packer/ova/ubuntu-2204.json
+@@ -1,13 +1,12 @@
+ {
+-  "boot_command_prefix": "c<wait>linux /casper/vmlinuz ipv6.disable={{ user `boot_disable_ipv6` }} --- autoinstall ds='nocloud;'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
++  "boot_command_prefix": "c<wait>linux /casper/vmlinuz ipv6.disable={{ user `boot_disable_ipv6` }} --- autoinstall ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/22.04/'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
+   "boot_disable_ipv6": "0",
++  "boot_media_path": "/media/HTTP",
+   "build_name": "ubuntu-2204",
+-  "cd_content_location": "./packer/ova/linux/{{user `distro_name`}}/http/{{user `distro_version`}}/*",
+-  "cd_label": "cidata",
+   "distro_arch": "amd64",
+   "distro_name": "ubuntu",
+   "distro_version": "22.04",
+-  "floppy_dirs": "",
++  "floppy_dirs": "./packer/ova/linux/{{user `distro_name`}}/http/",
+   "guest_os_type": "ubuntu-64",
+   "iso_checksum": "45f873de9f8cb637345d6e66a583762730bbea30277ef7b32c9c3bd6700a32b2",
+   "iso_checksum_type": "sha256",
+diff --git a/images/capi/packer/ova/ubuntu-2404-efi.json b/images/capi/packer/ova/ubuntu-2404-efi.json
+index 104433dcb..a846d839e 100644
+--- a/images/capi/packer/ova/ubuntu-2404-efi.json
++++ b/images/capi/packer/ova/ubuntu-2404-efi.json
+@@ -1,14 +1,13 @@
+ {
+-  "boot_command_prefix": "c<wait>linux /casper/vmlinuz ipv6.disable={{ user `boot_disable_ipv6` }} --- autoinstall ds='nocloud;'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
++  "boot_command_prefix": "c<wait>linux /casper/vmlinuz ipv6.disable={{ user `boot_disable_ipv6` }} --- autoinstall ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/24.04.efi/'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
+   "boot_disable_ipv6": "0",
++  "boot_media_path": "/media/HTTP",
+   "build_name": "ubuntu-2404-efi",
+-  "cd_content_location": "./packer/ova/linux/{{user `distro_name`}}/http/{{user `distro_version`}}/*",
+-  "cd_label": "cidata",
+   "distro_arch": "amd64",
+   "distro_name": "ubuntu",
+   "distro_version": "24.04",
+   "firmware": "efi",
+-  "floppy_dirs": "",
++  "floppy_dirs": "./packer/ova/linux/{{user `distro_name`}}/http/",
+   "guest_os_type": "ubuntu-64",
+   "iso_checksum": "8762f7e74e4d64d72fceb5f70682e6b069932deedb4949c6975d0f0fe0a91be3",
+   "iso_checksum_type": "sha256",
+diff --git a/images/capi/packer/ova/ubuntu-2404.json b/images/capi/packer/ova/ubuntu-2404.json
+index 9656b4471..32eeb4a14 100644
+--- a/images/capi/packer/ova/ubuntu-2404.json
++++ b/images/capi/packer/ova/ubuntu-2404.json
+@@ -1,13 +1,12 @@
+ {
+-  "boot_command_prefix": "c<wait>linux /casper/vmlinuz ipv6.disable={{ user `boot_disable_ipv6` }} --- autoinstall ds='nocloud;'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
++  "boot_command_prefix": "c<wait>linux /casper/vmlinuz ipv6.disable={{ user `boot_disable_ipv6` }} --- autoinstall ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/24.04/'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
+   "boot_disable_ipv6": "0",
++  "boot_media_path": "/media/HTTP",
+   "build_name": "ubuntu-2404",
+-  "cd_content_location": "./packer/ova/linux/{{user `distro_name`}}/http/{{user `distro_version`}}/*",
+-  "cd_label": "cidata",
+   "distro_arch": "amd64",
+   "distro_name": "ubuntu",
+   "distro_version": "24.04",
+-  "floppy_dirs": "",
++  "floppy_dirs": "./packer/ova/linux/{{user `distro_name`}}/http/",
+   "guest_os_type": "ubuntu-64",
+   "iso_checksum": "8762f7e74e4d64d72fceb5f70682e6b069932deedb4949c6975d0f0fe0a91be3",
+   "iso_checksum_type": "sha256",
+diff --git a/images/capi/scripts/ci-ova.sh b/images/capi/scripts/ci-ova.sh
+index 683670a35..5794d876c 100755
+--- a/images/capi/scripts/ci-ova.sh
++++ b/images/capi/scripts/ci-ova.sh
+@@ -75,9 +75,6 @@ export GOVC_DATACENTER="SDDC-Datacenter"
+ export GOVC_CLUSTER="Cluster-1"
+ export GOVC_INSECURE=true
+ 
+-# Install xorriso which will be then used by packer to generate ISO for generating CD files
+-apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y xorriso
+-
+ # Run the vpn client in container
+ docker run --rm -d --name vpn -v "${HOME}/.openvpn/:${HOME}/.openvpn/" \
+   -w "${HOME}/.openvpn/" --cap-add=NET_ADMIN --net=host --device=/dev/net/tun \
+-- 
+2.46.0
+


### PR DESCRIPTION
*Description of changes:*
This PR adds a patch to the `kubernetes-sigs/image-builder` project which reverts [this](https://github.com/kubernetes-sigs/image-builder/commit/e49a35f6ecd4f3eb10c53df610f83606e1c36ab4) commit on the upstream repo. The upstream commit added a change to use CD for Ubuntu >=22 preseed/cloud-init boot files. Enabling that feature required adding a dependency on a tool called [xorriso](https://www.gnu.org/software/xorriso/) supposed to be used by Packer but that tool doesn't exist on our builder-base image. So our ova builds for ubuntu 22.04 started failing with the following error:
```
could not find a supported CD ISO creation command (the supported commands are: xorriso, mkisofs, hdiutil, oscdimg)
```
The above change was made in this [PR](https://github.com/kubernetes-sigs/image-builder/pull/1459) as a part of supporting Ubuntu 24.04 LTS for VMware vSphere. 

Since we don't support Ubuntu 24.04 yet, we don't need to have to build this `xorriso` package from source for Ubuntu 22.04. We can continue building it the way we currently do.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
