### PR TITLE
Update BottleRocket Host Container file path to match upstream

### DIFF
--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -38,7 +38,7 @@ const (
 	FailedPatchFilesRegex                   = "error: (.*): patch does not apply"
 	BottlerocketReleasesFile                = "BOTTLEROCKET_RELEASES"
 	BottlerocketContainerMetadataFileFormat = "BOTTLEROCKET_%s_CONTAINER_METADATA"
-	BottlerocketHostContainersTOMLFile      = "sources/models/shared-defaults/public-host-containers.toml"
+	BottlerocketHostContainersTOMLFile      = "sources/shared-defaults/public-host-containers.toml"
 	CiliumImageRepository                   = "public.ecr.aws/isovalent/cilium"
 	GithubPerPage                           = 100
 	datetimeFormat                          = "%Y-%m-%dT%H:%M:%SZ"


### PR DESCRIPTION
*Description of changes:*
BottleRocket refactored their folder [structure](https://github.com/bottlerocket-os/bottlerocket/tree/1.21.x/sources) on release 1.21. Consequently, our upgrade job failed for BottleRocket searching for the `BottlerocketHostContainersTOMLFile` in the wrong location. 

```
2024/08/13 08:07:57 Error upgrading project version: updating Bottlerocket version and metadata files: updating Bottlerocket host containers metadata files: getting contents of Bottlerocket host containers file: getting contents of file [sources/models/shared-defaults/public-host-containers.toml]: GET https://api.github.com/repos/bottlerocket-os/bottlerocket/contents/sources/models/shared-defaults/public-host-containers.toml?ref=v1.21.0: 404 Not Found []
```

This change updates the above location to sync with upstream.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
