### PR TITLE
Add Go version source of truth for tinkerbell hook project

### DIFF
--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -298,7 +298,7 @@ var (
 		},
 		"tinkerbell/hook": {
 			SourceOfTruthFile:     "images/hook-bootkit/Dockerfile",
-			GoVersionSearchString: `golang:'(1\.\d\d)'`,
+			GoVersionSearchString: `golang:(1\.\d\d)`,
 		},
 	}
 

--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -296,6 +296,10 @@ var (
 			SourceOfTruthFile:     ".github/workflows/ci.yaml",
 			GoVersionSearchString: `GO_VERSION: '(1\.\d\d)'`,
 		},
+		"tinkerbell/hook": {
+			SourceOfTruthFile:     "images/hook-bootkit/Dockerfile",
+			GoVersionSearchString: `golang:'(1\.\d\d)'`,
+		},
 	}
 
 	ProjectsWithUnconventionalUpgradeFlows = []string{


### PR DESCRIPTION
*Issue #, if available:*
`Tinkerbell/hook` project was recently added to upstream projects as part of Tinkerbell stack updates. The upgrader project tracks the go version for a project based on the source of truth it has to look which is supplied through `ProjectGoVersionSourceOfTruth`. This change adds the Go version source of truth and derives it from the hook-bootkit docker [file](https://github.com/tinkerbell/hook/blob/9dc7c7d39742b4d98699848cb57306edb42fd2fa/images/hook-bootkit/Dockerfile#L4).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
