### PR TITLE
Update schema.json for MetalLB to align with upstream repository

### DIFF
--- a/projects/metallb/metallb/helm/patches/0001-packages-patches.patch
+++ b/projects/metallb/metallb/helm/patches/0001-packages-patches.patch
@@ -1,4 +1,4 @@
-From cf521735550ac50e7b78d7d3b8dc279642b77f9d Mon Sep 17 00:00:00 2001
+From d7d56fce16c1acc5810ffa7fa65e34a52003a7f8 Mon Sep 17 00:00:00 2001
 From: Jhaanvi Golani <jhaanvi4.golani@gmail.com>
 Date: Fri, 24 May 2024 16:25:03 -0700
 Subject: [PATCH] packages patches
@@ -22,11 +22,11 @@ Subject: [PATCH] packages patches
  charts/metallb/templates/secret.yaml          |  16 +
  .../metallb/templates/service-accounts.yaml   |   4 +-
  charts/metallb/templates/servicemonitor.yaml  |  34 +-
- charts/metallb/templates/speaker.yaml         | 355 +-----------------
+ charts/metallb/templates/speaker.yaml         | 358 +-----------------
  charts/metallb/templates/webhooks.yaml        |  16 +-
  charts/metallb/values.schema.json             |  46 +--
  charts/metallb/values.yaml                    |  54 +--
- 22 files changed, 135 insertions(+), 504 deletions(-)
+ 22 files changed, 135 insertions(+), 507 deletions(-)
  rename charts/{metallb/charts => }/crds/.helmignore (100%)
  rename charts/{metallb/charts => }/crds/Chart.yaml (100%)
  rename charts/{metallb/charts => }/crds/README.md (100%)
@@ -512,7 +512,7 @@ index 8be88dd3..cad6823d 100644
    apiGroup: rbac.authorization.k8s.io
    kind: Role
 diff --git a/charts/metallb/templates/speaker.yaml b/charts/metallb/templates/speaker.yaml
-index e70743ce..bfed6185 100644
+index e70743ce..b82b2a68 100644
 --- a/charts/metallb/templates/speaker.yaml
 +++ b/charts/metallb/templates/speaker.yaml
 @@ -1,125 +1,9 @@
@@ -704,7 +704,17 @@ index e70743ce..bfed6185 100644
          {{- if .Values.speaker.image.pullPolicy }}
          imagePullPolicy: {{ .Values.speaker.image.pullPolicy }}
          {{- end }}
-@@ -284,18 +124,6 @@ spec:
+@@ -255,9 +95,6 @@ spec:
+         {{- if .Values.prometheus.secureMetricsPort }}
+         - --host=localhost
+         {{- end }}
+-        {{- if .Values.frrk8s.external }}
+-        - --frrk8s-namespace={{ required "namespace is required when frrk8s is external" .Values.frrk8s.namespace }}
+-        {{- end }}
+         env:
+         - name: METALLB_NODE_NAME
+           valueFrom:
+@@ -284,18 +121,6 @@ spec:
          - name: METALLB_ML_SECRET_KEY_PATH
            value: "{{ .Values.speaker.memberlist.mlSecretKeyPath }}"
          {{- end }}
@@ -723,7 +733,7 @@ index e70743ce..bfed6185 100644
          - name: METALLB_POD_NAME
            valueFrom:
              fieldRef:
-@@ -351,194 +179,17 @@ spec:
+@@ -351,194 +176,17 @@ spec:
              - ALL
              add:
              - NET_RAW
@@ -1168,5 +1178,5 @@ index bc96d355..fbde67b9 100644
 -  external: false
 -  namespace: ""
 -- 
-2.46.0
+2.44.0
 

--- a/projects/metallb/metallb/helm/patches/0001-packages-patches.patch
+++ b/projects/metallb/metallb/helm/patches/0001-packages-patches.patch
@@ -1,4 +1,4 @@
-From d7d56fce16c1acc5810ffa7fa65e34a52003a7f8 Mon Sep 17 00:00:00 2001
+From b2d58b4f6fa2a2503456edab7953ed795cb825ec Mon Sep 17 00:00:00 2001
 From: Jhaanvi Golani <jhaanvi4.golani@gmail.com>
 Date: Fri, 24 May 2024 16:25:03 -0700
 Subject: [PATCH] packages patches
@@ -10,6 +10,7 @@ Subject: [PATCH] packages patches
  .../charts => }/crds/templates/crds.yaml      |   2 +-
  charts/crds/values.yaml                       |   1 +
  charts/metallb/Chart.yaml                     |   8 -
+ charts/metallb/charts/frr-k8s-0.0.14.tgz      | Bin 15624 -> 0 bytes
  charts/metallb/templates/_helpers.tpl         |   8 +
  .../metallb/templates/bgpadvertisements.yaml  |  15 +
  charts/metallb/templates/bgppeers.yaml        |  13 +
@@ -24,14 +25,15 @@ Subject: [PATCH] packages patches
  charts/metallb/templates/servicemonitor.yaml  |  34 +-
  charts/metallb/templates/speaker.yaml         | 358 +-----------------
  charts/metallb/templates/webhooks.yaml        |  16 +-
- charts/metallb/values.schema.json             |  46 +--
+ charts/metallb/values.schema.json             |  51 +--
  charts/metallb/values.yaml                    |  54 +--
- 22 files changed, 135 insertions(+), 507 deletions(-)
+ 23 files changed, 140 insertions(+), 507 deletions(-)
  rename charts/{metallb/charts => }/crds/.helmignore (100%)
  rename charts/{metallb/charts => }/crds/Chart.yaml (100%)
  rename charts/{metallb/charts => }/crds/README.md (100%)
  rename charts/{metallb/charts => }/crds/templates/crds.yaml (99%)
  create mode 100644 charts/crds/values.yaml
+ delete mode 100644 charts/metallb/charts/frr-k8s-0.0.14.tgz
  create mode 100644 charts/metallb/templates/bgpadvertisements.yaml
  create mode 100644 charts/metallb/templates/bgppeers.yaml
  create mode 100644 charts/metallb/templates/ipaddresspools.yaml
@@ -93,6 +95,316 @@ index ef8824fe..be8cdd96 100644
  
  
  # A chart can be either an 'application' or a 'library' chart.
+diff --git a/charts/metallb/charts/frr-k8s-0.0.14.tgz b/charts/metallb/charts/frr-k8s-0.0.14.tgz
+deleted file mode 100644
+index a62f251a8444a2017a5f659c9e58820945f8a733..0000000000000000000000000000000000000000
+GIT binary patch
+literal 0
+HcmV?d00001
+
+literal 15624
+zcmV+jJ@>*NiwG0|00000|0w_~VMtOiV@ORlOnEsqVl!4SWK%V1T2nbTPgYhoO;>Dc
+zVQyr3R8em|NM&qo0PMZ}ciT47FuK29{S~O(XPabAN^<;>>Rs=9UE67WH*tJqZ}&c@
+zr`Lf<NJ32#EC9;U#(Dqtd+<eq-<0e)X&>{4L?(g3U@$Wn3<iT4rOwSOHaK2D%H0(V
+zgTFlZGaL?w`@6gH|KV_0{C~JV9Q|dqyT7}?`*MGGfB!GT(azp*?=N8Z@TioZgmFm!
+zGQ4+N#m@af9vI`F5oMS}W3b%m!8p$T9J)hywA=Ghj3OUJ9!6~3bAU%8A9Gp6qds#{
+z1g8P=djLc*MCxS^0E%M5Feh|12K{~yfTaPP!et)Cv4V62ynrM=h#<#H1a2veV?+U&
+zf!C8sZ$Sj$1?Mpv4+bIPFbJk@5@7)oxqQ~co`BL&Vt_+9M{E#~IWgaz+Xd#xjiY(*
+zCYhqN=imL~5RBZ>_wLXce%DjI(t^@sB%z)nglTP#`68LR9tjQLfho;bF&YCH#{u@B
+z=xMJ=g)cn*dHD~Bck}RVw8{U@!9iL6cc0|{F`lAuuPMTKju;;Uwtzc(`{U`W=_?5L
+zM#I^weSf-lFnWm&_NK$Bw+DwW{n@Km2QLrc-faKX{woNl2M6BX=p~vCr&Hv=oW7bK
+z^yVl+6msN`L4Rksv+E2GoYD7Jqn+{aV7&Led+_pLe|PWIX#a1+o$+wk|I*U)$A66c
+zFJX`%_IV6|X89lO?CzH2|6p(bN&X+>*#akM29tmT#Q|VOsF~~B-WIr8U<NP)5d8Pi
+z+c(aP&=7Ktd@#cS5(Q3>7eI=@5>hPe00uY#Qv_nj81ey*H~}k?P{2_b2aqG?_T-fM
+zZiy(xK9Z_smIOiRWsgpwH|_zj1w4u%M}Wo1!!wK+xLqK=KvXn_BPJ$Y03#nH41viH
+zN5_CBfoKWnnq$Cef_lA}l2BAkn1ahZ3S$Id6cH}xXI9+?^nGxV)&(Kr6nhc^OgM2o
+z5(LN-^>d&&0WtBJ3oa3og)1zE3?uvJG$7LfMFD~gIXmuX;1e$iQKTRb&<7aC0kW$&
+z!h)d@5(Hj_fox8UB?KO!6tP%XZPDEBg-4<po+nhobiq-;5mokAu-X=bCV_--1#V%)
+zMQ;Ro`2yKM-o-*=6DrF-tLUIdC?YvbiLUZoA{Y{iKum5Coh1tGkVInA5!e<`Jevu$
+zs?abnw*g;Zrg#QMf)N8W;{b9ng8@T=Bh;85W#cqf-+Hpv6i2=o?o<lEEe-<Nq{LQ^
+zyl6oG`T<A&k?&K)*cgm<4qQ1kDp)b0JP#(ojH3vUs2bP>p?nMu_6~Lw06YT>@ok_?
+zYzBltfS8gGD+xkF<^-S*F=2|w1YtBdu*4AXK*|9_UP94ZyPfYxyTe{uM~I)Wx5aOU
+zJc_uM<d7s0m!d4cnO0-stGcH3T+6DtU?s;aA{@jNF%<D_00Be63@|*8kb>YL%JEDX
+z$VfMtFyy-#S+3q(UP_FVT9Bm8hTbPAV&8GFfJ=o#jA)3NFjNFMBjQ0IyU1ebAqE%$
+zw+PI|S_AXy8rqisjsX%0(hA~d9G7DnMKij@9s<zw1i@q<z;tC{DvMI|dx9zQg?5QR
+zAGklOnKvuu<{JWshf;ZgzSMAi3!tmpe5(Y;ti%pgaXIMn`;kH^qn;UWNeqFB5W%cP
+z%z%&LfUNWYJu1#AUU_uo^37roDL~?b)O%CtDY5WK#37Cl%?9klO6dB$H9PmHi^)LL
+zohCT&5tY9kQN@vvWEBqQaveO{afk9noCLuI39z>sE7U49A-K%-P)ncvO5wAm#Tu|A
+zR+@s)8qErHQQzV^AheWRhr{3voT7k@!N*S;GKtj(t4wZYGQ<<)qGIx*1r${SwvH^r
+z=0RZ&X$QM4w1@|#s*>}sR1>Mz5Qc>AsjCJcV8^lrMKT~Jds*f32FE`mif1b`wJU)C
+z51E2MP($LPC7DAyM_iWpjZ7u6#-I=5*tI52Oa_AW`UcXas*59z=n@90B9jWaF#Gu0
+zhGO|TLXeCq1L@nbY2p7;-3AmXj1?`VK8JA}tfVed6Fr!snV2VWBo<s^E|f47fQhP)
+zqd6OcUw+ll9RNM$Te(3f)-Qz=%+ZH2_)hfv`k4<=NFs*#of3FqV%){Vze}a?E+Rg<
+zV;picO9F=YbN6rGrO=c&#IWBl*Vm%n_4Ti57dP)4t?5;%Nuj5&vw^&hiGMASmbm<y
+zp^9QC<!KE5SCJb3-!u2c^Ka9)ieIh+#V7)n0A*E*1Lz?^t1<X?l)g9g*57-*En5(@
+zW-5w|Ha9&%5W!WiCzF4^Vphf87Dz|Q?ae5?d8Lh4#{tI~{D90sfR-q5!P|s!p(jZs
+zX7n+54};+SHhAx&X)+f-a5N+0|652S@js%J(D#5)@IE3Ddfx*A+#3OH3`F4`0GtGJ
+zZT=QAj;NM8p!9NC!Tz4Wl@O_-L(FK^k~RfkYYY6}Vu(Vk^KKIRkfTd3TAr_5zKSJ@
+zoIH&(3IV2z0#Q^!rD&G92J;f{6ORozWH)RO!U)chqaY1byZSGOAwH0>dI01x(yDw5
+zm={;7S^4f*S)fdrQWFvgZvL07FKGQPIza*ArnsVwbQtD}mgjM!p-L+iXyzVW60ikH
+z0$(7Z)<M3knp+boSXTuLumDHd{<aR36T4oPVWy!7fWpF)kT3(OKL;dCnDf$p)Jwf|
+zK`84gzms$_Rn0qFa-E7J#H9Twty2l4V#eVlZ5KcgqHv0+u)6_@Ji3aN)JYHu@DHm@
+zf6LeB5|@u3LEre14bFY=>64Q|G%T@YSCoD;<0Z~!%>aj(Gc%2C0WVI*U^E<t>6;LR
+zQglYc;ae;WA>yM;B-WKeXGuU>1{GnXPK+rg6!X<_02w>ahzMsh9AUo7=%+vlUcuf1
+z&?MqGM8FgE)Y`-tR@0TTqKTZhbipG0nD|GfQ3{k&R$~~)nbRDA1%d%zsCCDy;VYpu
+z1H42LV(fyFsn#H=m6LMj4B{Z6=xRX`TadsXgO_?T#T>)n1O;$)i98bdV)><wG(<7+
+zi*H%td5AF!lG5CwcO>CiaXEm{$6qOKj6=$kcwNjYo8MEcaRfXPhR{rr$d~I>p$a_g
+zQzlkQ(gOg4TewmVo`85aQuuJ>kx<AsB?(7js8y*SL<!9-TUEMBN-d%sP{Bonf?Gmw
+z7=R4KkaDAkZqal>$c^AcA2ZR<V?_BxGoCSr8=8oTFXT}Wjj8pEcx&3EXeLO6ScZ-g
+zWmmyG6{J;~3p25bSxQ|dOrccuXcWI=VrZr~z<i||!d&P;ip*LHgh{}093VNaOqjxY
+z;I+}C@q8Ce6nbjWJ5e}VeHC)GhCPujine<|)KzR_&D_;<_l$}$#nD{+(&gle=zDjh
+z*F(iQyv;3Ql}LRZFSYSd)S1;D3niWbfj*++%9=Aub)~BB9`)t>qR=d1fPG2A*GhPF
+zr-1nL&%4i1@c%P!fkNp1#z^#VZ8ZD;cSgIT{eu60cV}n#<o|z+=VK3m{<mt_`(w~I
+zX0qS_M{@(A^MOy{j61`FfqJ*q7pkPsF%OWarW`{0<tmo%$n-blarMqe(i{=CLVpZC
+zO1bQ3PNAa!QJ#LNhGDA2h;odWRT_Z4mgd|`3(S;|0KurAe*3hY)m2tYUDW~x@>}Lq
+zxv0h`2Z3>lqj}%@_^DU?mEzMkzPA1t{8H|pexp{kx{@Hu6n!b`6-|vgAUNV^j%YQI
+z3X5qYI63oXBM3!HY$G6fv#mRbj?7RZc?%_L3Dnf@`tDTnphv=(L@4@lQmp+Ib(OUg
+z=HwVfNth$8d<%mhS4^s}X)-Uq#L<it-`zqQ72iqcO7UexB4n$CU#sOpm}u*0rW(ou
+z#Z1P;D}8I!RymYZSvao(0i)HsS&5$FDHd&Qv7*&hI8hP=6;KLqer@boX3aie2Wt>p
+zvwIZ`oR+C%<n-&2T#!}P1fYL5J16`??atMeIY&!dQDx7s>(aY=7PJ*n&hhk6yssQp
+zO?+QcE}()vqz~wx!ecqNnn39uu1URgt<yrd%F4FGX_NYvcdD*Bq!h05!-hEu8?2`?
+z9jbd?a)h-^1l8m#IJ-81VLWe}P%!UR+XO<+sa6E=Ek#0o^|uC=Jw8z8V+}jmez48J
+zbu?<!R9CME@>WMr1FRBy1?nOR0_8uk>Dae|js@zvM7E<WCIB4Gm2)K1nKcYt!Myb<
+zs$M}=>y>T`h}>vZ5Y|9XU;JwGYV|_KIGVDijG1T0Xf=@46an4>Qst>HlhW>%fj>)v
+z;C#(CM4c7*J%It9VdMiC$7{4mr_gI?MFx}QJZxpKUCrCdNvPQ1sfq~@?dJ7ly%k(J
+zQrY6Vp?7vjTQTTr^L~~BtTr;}EjQt2E4iZka3d)BxR#AN(#@i2no`ou_>JZ?69v=4
+zc!l_v8m4bzh$f~0kFo-31ku&>)S)UZ<mwRk^DsoKUKE41ZC4Zda$nM$FqQ{gAeAJr
+zrtMZh53vL+#ndzrtZdJMdYcxs+4n_Mi>T4B0;y^_Dw%mIQYAk#z#u5`M}gg|jmpfu
+z)T<#+0Zc(!%ON90hfITbHVbIB@X?_$%_Odr)e27U=i^K|jayk-ni02QRDJ8<q$x{R
+zrPS8hrulYCABygUGL>3ZY@K>hhMI+QJPf=Ut>KCSn_lS++icWK)O9W6f`{URDqo}Z
+zxkWAqSp({%WhJXrI<M*ty^0>zP8D^~+swd+Xd~NUZU<hiV!?w6Qemekd)j4527yFX
+zmc|AwZ}#XvpW>?Xb=5c1jp$vZS@Y8$zjH12MlG)u=e*qKUn@<7UrQ!}M+>`SMSXZY
+zIjLQTY~*OEGp1`+;m4DcqTjq}BG1vUUlUQ%+O{qYVp-fAySl}Ekp`(ma}#w`i(ch+
+zLET0{|7;!+ipn;lz@^LBR{J1ICSZjD*ukS%Vf<N?Zd#<ho=k3DF)K>?VU}d9-Y9Dm
+z{x;EXGRN9?%sOc0hS{Ui2y0#})lV5~ttmA#za{?q+bfOySacVc`fqr&C(3^M($P4N
+z|Cso%^mOjv{N2^*rOQ9?2Wz7>|HG(w{(E<4wDT1I^%##>7z-7N8HmU&ph*<T?GL@`
+z2of>7yS?5yxs^w6Js71kvOGGu#1LT4!108+;6ff)1{BRy9KL;Cl+0$>!!Q6o@mP;U
+zU_ox}GsObHpEu6(YkkV{f4x9Kj3{$?{6MK7TIB!b-mobDd!x}){O6-QA3qLWfF%yc
+z@=VVR2S`k|hoK;gw?Jd?V({rxPn7DNeu!b@m(GgIEk3uW%Q-+=Zpcimt~xg3WFO^0
+z8&~BUIu~%vX<~bC5!?YzlgI=6FXc}hUM8~{{s8(;A81%8^2JYu+_5@|1k)Dkb_Lzu
+zzmbA1%X86!=mG;%<Uyf~7zq*hXL?LbpEJTJ@YMlTd6EbDO21(Sp6LTKC+C-<tWcjU
+zM&5I`cQyk$hl2u=h3u!>qC$n{PTxQVphR9{TSwRINRpu~o~5KLrqeJatNq@E+yP7B
+zd@E5OA9f$l49AoR3Wz&V6jF5!p1GH6A{SE}@fqm<7jyoL^$W06qusfy`e%;kticrW
+zp>rgOfwYfPsZ!E^Uq7g_P&T5)p4dcIzjewoaAyvkg8tw7pnu(8Uw}v$l1Lxnszp%8
+zN=pnEC<tA)7)Ye$c{v<;LE@LX<EjQrpP7y|dZU557MJM$9i{o`#JBQ^?KC0P$Bz|N
+z?!fN};i%BxG8A?6(|4vT1;}uW-p{L~mkE?=qgb(%P9+ABIdWK}krHvY8gH5TCh|}o
+zYg>@2__e6ORZFG(70NVg=$E~#eO{}Hs!F^1+-PA^cxLgt<?ja1ibTnDpZolIOH+|e
+z4NFUyM*I3le;qg_h47`P@r|Fd{bwD%exPh%&Gz5!aKE(v+uPrLvi~0C*^>KB=tC^e
+z26K{T(P2nhgA9<{NX=q1O2;!w0g22RRJXSUeu7JVvO5&3MhH~Cj<+xdFbK%4m<0vg
+zkob7E0#merOH3#m%WylL$V#2Y6L4fUD1Dkg*HSJ~>8N*uBY&K=)e8}aKICwmrXl_K
+zF+E{kr8vN+PmW-I-9SF^Oi`VxJUP~Ml0WM#bzVV71?i-A2O=E#DB@sORh5UM3#vTz
+zab}06O?Nak#^6rY)j8S3-~f(-fEgtYV(8t#InpP*4G}p}L{wQdwls`OMfaR@JxvS4
+zvLVn(v}PoUe1Icedyp_XU<*jmz$e~dMroFkEZ@%2)z#_w)!DoAaqjiM7bueXGM37l
+z4RwR*q1qXyjLUPf+cJfjKvVX48=xhM#1tcs*J^kujQMICEMS^`P6f1s7clZ)$XpnP
+zjRo|CAu5fvIVDM~_Gh={^q}F1LK-7!okv6_)R2T!U<QbL0~}%Q`lA1?%%G6vkzzXa
+zf`%uo`$KxWJwK$|<j}RLpfV%$mwd$*eZUfLk?*j~z85e8B7}V8yWq@D>tMR2A!hwq
+z@|8-yq_a;XbJ0FI1bjh~`N9Rq3*_CXZp1KDz1Rkvko*9OZrwueEd+-Nc>h6D3RC_N
+z3nG0iTocExKAp$@;R>lyA}pTyhY?Bt*iZkWIJSRB^YkywFiZc4ahU!N{H#i}pxGY?
+z&#k|vLJZTt1j}aM;wjC_&HN108Jtq=rQeoRSIQCQY^IifDjkv-B}wT8DzXMpTM{x;
+zU<f((pjep(1p3V4Ha+4?3^gwRXWGvWtP5)dQAO`Op(_Vc$j6E#GUrg_8#kL~vTv+@
+z$T!z&TP*Fr9O7%$F?QGoz&Xm!a07>d@AWL#Pe<7<oh#nY#=Z_>-{J_XjB^CWWBpMu
+zNJ|rnZ))mGHfnBPFjq?xg6CR_NLFlaNHJ(0(Lxc$wT(p-D>oJq{M~{s<ANcrQWdz&
+z{5B|BUYejt8LFp?X61Y;gP0Pb0Bxz8QF^UkANDzgCVahL@mb8D9*X4dbU~%5oTf5g
+zA^d>DBm_|sPIbQVlkdbQnE7Sk65>Dzh>^H|#hGQIlz`0h0JFuuvZ1vFB@>fMuaT~g
+z#k?8>LYe<7@<<qpnaZRug#r>IY6Dsx%a@bliX>E5XGpZGC0wRVljfV6M*~Rb$m&jv
+zgxW}FZU$H2haWF=Pu?E=zt^u%E)Pe;o!y?L@J;#;%Z8A1fSikRYAnm}qq{Ejp4ND}
+z5i@&aqo0nq=$JfPITy&s35^LuY&+d)P{}M-0D}H4g>fI~{l?U&k;z{XG}A1Zsn;gg
+zke<SQOp(Wf)iyxx+%?*834=MskuS_lsh><<C8MrHlZSn2>r8PpFy;HEF`D8jl`9N_
+zYlWrEyBY+BeEDW$L}!2^k5H>YQ`c(FDhC`#P}`YP7%za+x2BDV&=8uIQu2sl@_oxk
+z3DwMmA~|bFrSA%18-u&QDMg@H|1$PT4yYqbIZ7l|T8(^_Z!AM}jyMBEJNu%71*ayk
+z7{MDv0Y#B7Co(PUu7-6<0E||AVP}0sK9H#?#Vi{ID{0RY3h7E!67!t#w!P8`NyIz7
+zqG!NT5c1=KFfP~e6OwSG#3{fL5(H6y5N&hG*;JUdqSxXrj#TPn1<Y}r+=2wgF&m_-
+zk`p-?mxyn)D)|amA_g*r(HwzqZ_sKRe5+K`_^{|VQOz0nA3w_S;L|7B7hNldzk;nD
+zDMI2!SE}7e`IuN$y^xPh*5u^BVHmX3E>XimLkNV<yd^OVg${dT5xSbxWshdo$iC@q
+zXQCTMNfYa&yd-%wht2x<yvp!dgAMM%3Z2=Zz!FkDX|_l^T4If2AaDk(oWV>8RoB`D
+zMAQozjAcL+j~ix1i(m4CWtg;jOiJyR9j?{dq{=btW?;BjqDE4Y{YasQF7g?{Oj;+Q
+zD$fzWCG^J1D+a)l1WAajo|r2mq%VbdH;6MUB1f*vPcTiBI+d!V?icfT#-}sR#rbUL
+z)G4<p;CIE)1hIB4pC$BeC|=-SD>ZU4-L)+cg(e&i(Hx~!$a<b;g>;5%wOHamVb~p;
+zL}C^LY=L7EW1T@wrysHX7feZu%({l>3!Zb5=ok^{O7b;xxurgPu^d$i&FY{^U{)c`
+zV$zl$-R#7fP&rK{Ih=#L;(lg+`zc4*L>@LL5l0^iRHsRF#Qwz)m8l%dpMInyiN&{3
+zj_al6HU_`+rS-=a{cX^9Jn^p=1BbqufdLO=X_UOk?32D7pQq^eR>(ce<J2s2;*nY2
+zFCbrx({^eh6hx?4UE@~GAx5MshaOB3zeUF7p)E#X(3)D6yip;gwXD&NEjD0@wgH?0
+znFBZN2wS9tx;8J@9nFf4*Nnw=sc3FcO#W^3Atsbtr7S9!b=y}<WYe9r_xi=U^euO}
+zj=cGjlBX{y@sP46v@LH<qh3jorj*VSKYuAYR~uLgOqL+Wu8|r#CTU_F7S+{Db4@nV
+zJ$qCJMN1UYdCnB+J5EG=<Oot8e*5hF-O1_o`O(|c=lwz<Gbp0a(c9C@i=*RGAv4oX
+zapXHt<+42d__2N#wQ^qO2clf`f>1Hn_H!i2S(V0w)@iNsrhwxFWbVjp--n`|7GjDD
+zDgmz}vvWK^mo$1=THkgCvhu<fkyD=>nN{|%+)7Q&ik_lqSvE~yPbSyL@6KPJ{doQQ
+z?9HjI0z@+vT5@2V9hI;qr*GaJot#dtFV0RnLrfKajQtYSlu?V2UQ-h0b(0K4o1oda
+zpq1o%rIo~D$rW;NZnD<r+A{q9AZ?jdshf&aT2@RYEHA*R+EeLVyNF1|A|Oju(ZX@L
+zWH{!g5gTSj3TpK%IFElUn$xk;`HJWNlmArgPosPQy})XrfF*qS+LZ~W%Z=x|Ur{L!
+zwU8US4PLHz9#S!FbsMOB`GTokN{!tHtym)uubdjY4PLQEiwdf7PvkNwRq<j~&hbAH
+zGZqMNe{L)QycatbVBMD=3*he0kOhDnaAcKjk)AQlvtfF}ZH8lwyJ|FSX}MvYEQ5nC
+zC|=?K&Cx0IU{FZuZVSe{C|FGh;jeLk*otu!=FDmFcraGk*D)%X^FAeU(ZD}?^CtHO
+z`hKy<`RUd5<mlh&+q(5a<7%wKTFhEmcOhJTKWqAMbn^D>yrpmI?d5-8)|UR^?EK{V
+z@^td^nPoYADGyAwj?F-Ayh>>U(PnaHqj`09es+ENuOB9-M;E7)96_~>*cS}k@62A+
+z4%R$}Eg>DyBq}&>8eKQdj+-mFnVoJbzMf3J%Wk_u5vQw|;E032f?J5?wyO!?O1IL~
+zjZX+FM-GQr<=5k`)y&x}Uk9`3J8rJ50XPEtLm?7U8;gPhid39xbKPvYOVd*A#phyV
+zK(_6FOXv-xDw>VykSaUuQEngxWS+Z-;wG6Qj|b|#<H<6Aw^r)v$|)Ek@DI0T1*^Ok
+zxp$72`|~b0JOd_ba2#RaI4bTg!16k!fiIXryYs+b^O}Hj6vmt#=G~7;#Bl(A`9(TP
+ziaVTlci>x74>;&|LGxdK{a?T*1?!&$2*qGjc$+r)?XzbVpud3;c>X-Ej@5OF*&|1@
+z0;SdoOq9F-B(}4WLHBvq7NSx&V@~wFVWm{E=*rb<ExLzW2z()9+rA>FYG}$===?!O
+zrVBlDoo^y%hk?$)svYOjxYSxiPxeCIhh61&vbP8<fAv>r9^BvbZCaaXB7AQBZuh?E
+z@BdQlTE!w}3&X<G;*Pu{Tsc*Z|61s&3a4tLnzHK`oW<+wt+gD1-IQppBk-#hldAos
+z_T8jL`$s3DdNeVqx+S?<RLYk_e^}LvOJ!*xG9C4CW&LWMTqP?3nRCLpj|$`FI4Xaf
+zqb_bw#h?cDQnI<SR3$Ov6v6ON7#rik;9)nE28Gsmz#I?93$ac}Fh}h0>doc#>G8==
+zr`MCqqw9a4UHx=@bb5I`+Ie;T<MG?;%b$*R_V%~4Qm4l!E#*pZj(<4r1gElG1GKv7
+zyki7SMv<7}CFIDtK`R+lawsLwXjmRF_Xe%1D2XVqso+uGH0f`;7t+E|Ag@^D<z3Cv
+zPtorQV#N(_eHm$(*G&38(j9djsd}vNvA2jZA&}`kc|kCR-pv(xL+0#VbV@0q_Z+e|
+zZC)1)RaUE2s@FIc3$Dbjy3etd{AbgD9ZiO>R5x0)c?aG2=hRkpdcU(FRYTA^&HpFY
+zj@?=6NjpA<cFbK<ofhloqsa;Dk3oQ=<U^}bYs1TrXM50emvC(pQ=+fwv7++LmD#=S
+z4OTXXXMoURd-;5+HD6^+Y!<3*-S*w9WRz;y*2Hy#R%1Cr4kZC9r9EMGtRI@qkjKa1
+zoLqVf<R?Kk=tSReFb1a|FiV-K1-^EWJ8=LlkMH`;bRN@6D%K9;e#<a+YO-|gR92<p
+zYIYf`RXXkPCG&`s^M42v;h{2rsHY|W+wShpUNQgU%l*+){*T9a3JOIIzRu3$eEL*6
+z=qA6zgf9ri|B;gB%HU3toqju3IU^?|K-K5p8nXF-PoJDz0IWXbwBETkngn86cL0pB
+z47O)u@QbM>Pzr*ni-~lfS(k&$BKd?Evd9wAsr)=gyuS_l!rT@A%X6*$UpH$<=uF0i
+zz;$S2JH0z<8}xk?AoVLYAJxIO`=c@t|0UHJwKi6UEdg&rLcw4t;@Gn}tPG!%8x&Er
+z#OSurjHXs4;3DUi;j%>LZiX^yXFd47KG{Oi9Lp@xP3>gaymkKL`!io>1Y}scW&kk(
+zI2kgI#>UBKUcVpu8Q0uPqlkqOj^<xVv5)}ia9Bh2h7R-qC~L%x(A5knb(#WsnLFgy
+z1hwHf;5x^QHyE~unE^IB3;huDMTK6_*GYCz*!SZ12W9lfpx<U<@s-KL$B)tocmBxP
+z{MLWU_P-{Oqw_$r`>zGs^1tuzy)4-O`v*JwPxk*~JZq-wENZh<XB7mnTjGlcnwvgn
+z3XGgCt#bkt$YtH|t=h0&WH?rMB+7Xx>>RG2W&G>qUvI8IfGeO`{zt=umpeuI-#gfQ
+zlK;ne>OIf-+feN=I$Hr`AsDVlC?d@DNH{2}1r22LES+M7qMQ1PltVE;PA5WUcW%E)
+z)1wF~<WttHQU4AUk<NK9yCc@9w$?(?f>gw=BG(U!d>KWq$H>u<m3@2P#>B}lNMzF4
+z<TfTc_p)@oYvzY7eX_moojYG{pmFEGDQ+FKw?M0qr}spgc13u7e9eu)z{(|}-qeRZ
+zv;eTFCye|WG-|g8rwCF+ugDFGUgH3bK|hW9(yP2dUg|YQ+9)1K*OTE%<}HxWWqr-5
+zoe9GOrZN~?dp_pXdJ>mGO65%qor0OqS#JHR4vDQLTPm0{N}pu&Nj6(#^GVoplrZ<N
+zcciN+p0{OE%jdG3o=&-R)2-QR%Sb|L&26`-ZRY4sw5}6#mSAalWKl(MgGXU(pO@Rz
+zqWKIaOy0V@H`yKxL|5zBm|%I1ST~j6y4JG3R_^R#49?YIFe?JcM6Xnuf2A`w-KKjE
+z=^XKm0xhku?}|90rZYh6<I`T5A-TJAWI|O8{rE~q$g!cTl)rj0(NTc<&*GBqUatK%
+zw#~3ulT)>mUJOX)rcae!U*`ZX26YLO#m~Z3w2)*k(xr!dqn!Hb$2sEZ?*Oyx59#Fp
+zES~+(N4|&g(XWAD=A@T_Le*}13$(eK74+-1v#tojgvt9D)SX1WN|WE+hjDl)&C`BE
+z71NRy**vKmQB8|}PAnsPLch<IL}mY<xmfz)Vt`uwf1~}q{o?&UI|m0({=dg~8nRfU
+zI3TMKb@t{LRDp>iP&Ze6eO|jVf{&i$y44QftRKyJqf6Gdcyxw?LSy>mfs+PfHxjR$
+zl6uo&c*^!%nIN*1QKB^?;%Ck(*mu&=3yF^oNffN~i+){fyT-uBOw4k}i1LYM#}aH^
+zMjb4my3}DlYswl4xa48>cadz4P&G&sG^2<uN=@t14vAF5a)Bi(I8@bWN26n+$)?PV
+z<5$C1S)Pr`+=h>q&F_C=64LCzZ>`FEpd450B(Ex`uj-T`>+497nB(ZLKa=5~EL)(c
+zwR*T=`GPt9{>)kPs?T+$38Im8n68|+y{xH}J3X40&Vf~)@OnBg^>kk9k8@ti7MONf
+zsk$RW8zXOtkH%nkC!a9QzCfee3~;O_9_NOZ(XeTEMc`YpUT;SJK7rtkJ3IA_Z@yKL
+zZWWmA=-u6yl5)0F{d@H?zrfyPIa<2utKon}<~#X0JsR<E1@72B8qq+awo@2A<DHY?
+z>IRpIJfos<)U;WS<VFid5jT6B7LVpP`sxP=lzg9cdx{{lGIS@9qxjv?=Z_proaJbW
+zI2<{}lUBWSMz1j5J?b;pP=-XW?Sk31sO(1m2ufB*_slv9)dQe@OThu9qf?rLuuWw}
+zXW64(rjPBf$CJ~et5f~Qzb;P99|e2CDdR4<7yIZ`YJa9TdLG{YXZ*kJ0tF$SM}(pW
+zZ=)^#d+%lO{O8WW&eQ$xkMeAR3&=U5>Mkb50BWORn&7~f*K(?B#hKgFIaFB^OC=20
+z0tEq>2V|<8mpGbl%U~Cdmq=;@>phJ8-WG_^TseE5#T3o(2jnX=;hX0!5Vj~Fk*q0D
+z66*zdKcm}oPcE-7IiaYx1&&D=k_h~Kd<lF^S<jtgK9K(^^n32~KXf4fH7^$Pf%wP#
+z$(GR|12l!+O%kiSs(LS6b{qFzxKnu3d*Sj>{3aC7doTV^ZwvekDJBU6XD6qu=f;%$
+zhCJSLv5(+D6{qC4p1Wio@zLOqaE`>t|K#-O<n5^&`k$eV*7)z;QBnSfyHD}okMeA#
+zVHv$|eo3tyc`Nhoug_$t!+0>j;oM~li~?WUIaBD*(Lk4WRADD~L+bx#d=;R>Spd1i
+zeor7p&%rmpT*)W}7{`G=+S}5CDDPOsyR?yc6USiLsUKMlXW6kYz1|V<0+RS3Qo8Pz
+z!Z_CVM^7fb-isGMkr2gjj>a!ufWMpejX9A-c!?-OE}#9Q*W20xm(m&l$HYgyo>gIv
+z`68Lhn0j5;c>GnpiQ0({QN&rV_s`V09fSA(I0Pei^u0TDhVOg5J21&Sw0A(RyzYSU
+zyWaKg9P7Eu{U?6)?f|$0!Vm*@nmfRq#6a0-qJe)R0a=V0xC1BJ$18rR+o0`s$_+TV
+z_Is+W)bVu(ri29G4!q|yLGOXU#+0cu4DSHrRLoy@;C)|w>ZkRJE{!`tWUPWH`teh#
+zn05P54rmEr)uu*<y7c)Lt5hbCwOfgBP+y1IV`^dcdjeO2!Dp0`M64#nuM)b&+@uzO
+z@7<9*tgKLxp(<B1yVSj*whU;x12~c-KiE5XSyedmv^5V<b-Yvx{`=AHsG>?ab7pfZ
+z*6k@N=vTv6CD7}RX19?nNPmgA)#F&voZ6#xVI1chssmiTK~N)*-8|wc`AVbS?&nYI
+zj)u*Z^S<NG)k=4@WHp;B7VeB`sAl$FbL1B@j->r@df-rAhah)jUGP?i5((>=%*Nn7
+z41)LD;Jv&&U;GgD#s9aEM&f@&DWUHHq2PT)A~8Z42DuDd%}gH?|0ov;+gP~d+iO;r
+zHM<<myw&E^uV=0fyA=&=(zrFzz1|x9)qE*YQ@v8^?B;P>qg=xlddoytin(a!jfNw&
+z%}7=sU2f*7LY=4sdQ~?Jv^3I~mp^0M5(hOT;ZJMr6)P3CIGRzj_W|x?sH-UX%df?9
+z`3v-2u1r0PP7@LYIGX=UCBMk3>&UQoOGGL5Yl+*XO!LiTZKg;~;$+(t*=Z=8rD1Hx
+zF0!21ZDk7q*>$4SmdLek>TgR$n?rE!QDJc0BvT|^K!^?siEo>_kY=s5ATEdQXva1u
+z?bug&xFbKuw06GP*c(<?$%XZ{4@vu}+e$6e^+d^<mCGuofjHIYvpO(G{ShRKTIF37
+z8T8o!Ue)Ql3T4yv9Nbz}(=%HxjuiV`-e9rr$Fo(PcC?e>RTk+vYdyWAgp)anq+<5L
+zjFJ#|3rKkycLfqA$o$I!1)<{;kAdaL9Sz-K=EAT%0uiCNg!sP=(&7WEHfPvC*L&XP
+zgEam>i3b~q74<-cWj$O9$Tt7~%Y$P6huwphPx&7o<;iX3?(|^Ud)D(a2ade|82s}U
+z1ILpS)?1JejX{HRtA{;NsiDL`E?n6lAoFyQ>)b9dM{XR=dwLt6`mC33m^q-`JJ#bx
+zS7UFPcW(X>ob!+HRLOsK7NoQbdR^M5?4T!_<$r&)yF1Lw|IY5gQ~uY-c}npOF-9La
+zisT-5ITK^TI0+|uy?BD8|Fjs<P&#0c<xq0wC~_^!QUbU1&1lyh)^F##<xP1L6f#!_
+z+NyT#qwH9;>cs2G<hT%f0HiVT&&tnl%*nqvNGJ>{@KS*lIGQH`q~-5D0GLOFI!Z$(
+ze3e1a3fE9wwu1@eLHG3328mI0baD3c%gfwr0E*f<hdaOwKoDc(A-y#La;RmuRmPOW
+zh!(?-EzT$eO<9fJIfd|Kfv4VBP)Fa?rJcIN$k$yH81aR?tuv;Gp-6ko$qc|q8^~?}
+z^rei-VSp`268NGsOGG)K$RqOz|0jhlceCY{qC$^xmDC`Dfr^b+o6&j5AzT59q*0zk
+z7QCg3K`E4eODF<3nvt<R85w!;NEjv&<|`G_ho=cAlns2eM8SaJxdW*urZ|r$6b)dE
+z9odmcae3%(r5>4FvuaLLrnvP%a`hU+BiLLqhPLX}aiw$=#4AC%$?4@)8mOX1O0Qbd
+zq9wYR@e$O-(F{>lPnx;{ra5n`u56XjNq{BO5ObDZz5qBWf<2Zx1xyi8E(pI^;4A{i
+zFhs#IWayE{N{k9~#2|DUt>SSkyRag!9k6H}gsK?YqPSni$jgbGkC;5CD$_e_4RBno
+z06?u05YKd8I)qTb<%b_H1XJm&cr6tq<3ZFVyW*oL7gNHCM}p!=HDMsJnE4l!$Uu#%
+z&qa)0pP14HGr43WGXY36rM__@8H=H!N-&QMhcTTp(h(s%UrY%tiGX@AM_~<;ZSt8t
+zSr59A_Vr0hS^ya%9u}W#!E*wj91opUpt>h*gJQZQMC5G}a2y91(fX3zyDuKYttmr`
+zW<=k^v?<XK@t%gbaItWyBhb4+90Y_hS6*#RQAjufoWh9dSjsg24Y<WYAUGp!sh*PJ
+znXZ(sQ`*$V$&6g2Q5Wr7J>fV+w2t=TQLzYPf!WKQhH@eNfWsslgPpy-reZkK#Tp7J
+zg(PS(FI?+sKge5<Gm|gq^NhH}76!5@G0!8s%nw*2uyio_0&+Dz>Tr}0D0%2Aka}?e
+zBVXN19)S=C0oJ#THw_CgK@L)d><vTqkYl(nRuNrBanw|*`!LD?_y-!oQ|YZ_fKZ@A
+zBGg#QG0X{DNc_@#oquG+p(rLsOhfa9u<5{kY0Cj&9q6z`<O8D~8UZgz%m70?i5o{*
+zQE*B~fM7kZ>Cw324<-h$300jCh#C#e0Fmc)%rt;95lO;EaOgvfJVBeQt2gqFeke4Z
+zM?%5$V&c$?G_4~aSRL(lV&r@Cv0Oww5dFpUAU6W#Dn(7MW-?Y514T1LQRE?CXbr*_
+zh=Ldvui7d;8eGjXtgh!JGcy0gkTJYO4=KZMA-yqd2Ou*|jKz9V{Y<~gi83O*5gz0m
+zg)tYjlN*}FNl{3#1au2AmmHes$Y!d_1xAbz1yeMW_P$sx%yA@Fm%$20^ZN_Ao_!vA
+z!n?{uxa)k?2v4CY<hnq?%_p~)!(rH1{Hvbc^o+wl=fG8)kk10d82Alyj_C77Sf%m4
+zg^{9t!lc4sDDo>5wHVY!z_|f059%LtOico&x{*}=w3?4KYwcnINGV)Ze5WMgR$7ky
+zlVhKWDp_27Y5?FC$w8K0IZm=Uy$0=P@?->};OEKf=l5N7D%3JZ4uI)`R^w-**R+Dv
+zD!jsJW1cR{N64biQh9WFZb*7`38EyNsx_bx6fti|S`$yK8A@Kh{G;dMmgO(lL>6{;
+zzTf?R|6u3)PAjqd>o{C13!q59vlBx;vG&)aeRgtR8w7`?Yh0VrQ00r#p}-(tuz4yY
+z&2vA|UPj%O0a(&m(_l7=NiC+9*Ha=K6UMNZj&m3{Le(ypIbNbjW7|9jcM%=+ENLmP
+zOG~eQrZYqPC7q?>&WY}jw5eJ_c47_CMeEwd>U6JqQrBB&UOP86irkih>cnZB0K_<)
+z2AC~u#~G7n*dCJQ&QoQaF`e?&rC+)r46MneMN6xvJHzQ5MQbvhiPO`=aCTwf<Y?Op
+z6WDsYmH4_wS59r6jjH<9bx!KgHDTy=pPAItb$(LMdb5<S(`BwwPq!IMJ(){?O^UbJ
+z=ISXs(3_X^2}6E5UgC4M0B-fBTm8>=I?MoqvzhWyA--J#eoLb7<mMJb93=6Bva%NZ
+zE8OfEQBU4PRNHaLmmNtJ2oBM<S%b9Ac0jt>Zb3kzxr8Ft_6$rBzeQ?GC0+e1?|@JP
+z9bjh0>Vwh>fDcX<+2~{k%Q|Q|2ZZXv_i>I?W}|wF(q4~%UX69=sN|*ny}g(1@~P4p
+zjDfFxO3xSyX3yO@GA9O}JqQ0d1S9a*zc!WWgw)>;J0jIW6`kY|KybSt0n&Q26AEOu
+z1{v!p^VV7$KYI@T3yg-tAviqjgh87g)V}Js7hU8|uFA`4;p&Q8VtPfS+Q2yrPPYx-
+zUP!Uy3)p5Sh)25L7>Xf<T+GeOUFnrOyIAfkYZagm-U3E*#DsS5BB?%R97i6{Sxa4o
+zw#^@>9yFcDa^LZ%a-zHnglyWK{_x|4sS0r9V-IrCx0%u37pN0EVy0a6j@(m#w{Z2q
+zU6lJNG8xb;2`1_o&gYmfPpcYIX$+a#xkt*b5t54|wa+;t^cGSd$N*;Jm4ZU&cWCh@
+zBDZ=i#K7%BPQ?oZ^s&`!JKH*uEyz7Z;wwdr6N-E>y{>69Vu7MehnJb1$ltEmWS3I0
+zfJ>w^adnxWX3Du@Cb(#BY=XE8L#@La3ljJnOzxey;U^8-*iJNO5y)dp${dIh1(Vmu
+zyE_M?cE-<pmPfCKo%KPdN&E((7zTKWJ{MK~X*W<!niPlo(`WyI$rD4yZV7Gl7O7`_
+z%3NsJMPoV@FcUk|A?BnKu9%I?ANm{?qzHrwPhb$N#Pk#-3@=-@l)+{syR66_SM_X8
+zINc}Aa?6zbZTLDTUAju?ZV4L&D65;h2}B#K7=eENNY4~9>^Y+4zS>|{$6(}6CttLi
+zC;%|ggX|0(RC1!j&4CY5D3(Q6LMNKx#SAEYzD6sW3l#Jlv;uttuK%T2tGf>cbl9`b
+zo*Z9E2Ehy@5&k_v(gh+7>2l)c=7*DP9~(eJPZRaog@kJ^vFv<un{`_;lpW@%-Y6P$
+z?Dy>gdkb42BteZ-D5`#j-goqZswcM^4PoqP=O`y3_S%#d`8*b)JZ*`M2b}8F1`Je?
+zWJ%Mnq2+T{!NK?KRZ=h3X#eG_rU(;V{PQ@ll%Q<p4edm6l^UqzI9=`nLe<(#M`&A~
+zRNL+N!;cr86sfX{rJX7!AT_NdbX&%9Pmzp8#xsn3p=}YC;Vv+;T)3T<gA{o@SP9f2
+zQ!z*!(U}n6h8^4NSwq-3Ir5i653|o=23}?0i#tPRb3tdglOqDt!g?j3Hi69S-DOb`
+z`N|wfU6IyI^U$-BT=LcLujilji6@>T)r8<^TthdFg|;U}58zw}Ja?VmEMBJ4+*m0k
+zFY^*AEoNFX*EA{PqtpJJdDbH?kZHS{L$&fx<{-iWN3@d{+SJ@+Y=AsA;it<R8Gotu
+zid6JzysS;ZZnRR*zXcSA<owY$z3Okv_{RLO=;2WEB3Z-)W^4A?xLFtk!nzHDe1mBq
+zh72UlSYh*aQIv$;2ip-1tWkPxo><df1CqfNak}@S!;a^@vFf&6TrS_y{sPjZJT?b}
+zKBqFg(DePc-Jm+8Rh~^2P%TcZnLx}i9h;iYV~`$t(y3mhH!Yo_e7!D9)o{KYBZ@M_
+zMilC*^0aZS1-eGdTUd00yB4421}CNSMXG8ndUs~QS~8_X?y4x(pG82{$U34{O@{1@
+zk$$lTL{RAcrqjYkN??8ER3L%P09A&_JqfWkBLHhh-@|^l9WnK+t#&u0xm-`3$;KK3
+z_p2N0uCUiu+3PkTRQwyE$^;WUmWodsTvNq&jv)bBEVN_if3TKMN&T6$d`2Ke>(8m|
+zgZ21SJ=N4mRb2u7FQD_+i(Sf|b-Xm$^R-VFoAMKQnlp+uKGU4B25?R$>derZ9;ho*
+zug$g8Wz#1+Hk+nl$UC3@*v_L4o+I6VzgtMNdh(v5Coj;G7wE|g^ax&{im5hDRV@uS
+z)z7sitAZ<DYlC$dW)ovgJo7cATRodgs(Lb$9t0?w^M#OFJi|zOzcEX%L<7+CP|O*C
+z(JH;A$5fS9@~HZ2V=$MI0u&Gm(C-NhEV-4bG1j3wxQBTNa$AHuuhy;F<yd;vvzb{c
+zo-Q%)`R9+%E%Jcu6RWJtDvI*!vdf0+1F*TlzqTO`KDSf9bK$l##_Dl8?S4A|vgXK?
+z2Rt6vWtLuRMQcTtH})ah<JJp}>`W$(7>6yZ*$%csM=tC_rIrJe`J<AP*M>F=!niyy
+zDWe;62Leradt(oZl(}c>kM@J`^^A9~bMOt7?dwHalEzg|S?BikBmtJW0cE5k@r`R#
+z+Td135g5mTPQRt>_A0U}tKUSi)P{Ob<y(e*q-=kAC!uP*0_g36Fa*@4I#y6Y7A#|C
+z(8_g@L<y^iPr~gG8<|l>^ml`<He0I_$<q%p)$H0KkwLLa-fJy8pIHjjx{|DpyRUS}
+zv?(Wj-ACsqb<3#-$)<PIfT_-hX}(A%)2EYkMmM$%Ah<y*6%Grd^z!ZI(={qZUlyJ!
+zDp#izHBXnd#tmxR@5@m{v}zQ)?7w)S(~Tg@z>DJmw>XrVPY-ue&gqrqUD0o`YSU53
+z9hAO7tM8b;iIhZafn(*Y7i)epYZ(Cb$Sa&v@QOpvqHS<axcE<9xGsnDgdlcKxO{VO
+z`Y6;MiaH9KWbQ~Qa(QshO8d&>(Nw_+DJ3xjXOXbURacuiVu4H}3cT6=iAdxKm9?sb
+zuc=39j(8h3rJIrK74=2s6b_(=eBi5;oif=i<Y?X!IU6E6mlx1__dU=5fVN5@6j&(U
+zF0sJv#=#A$Yt%`{>vLES8+A#}LhAOF>K<ixv|P06(ALrECT12+Y6=NqEJW<1m?<Q;
+zegZMXl)2zYrU(yE?wfXNT3~7$ibVrrM3*o?>X;{t01DLnMP{X0dRrSOLf_9Y3Z%EZ
+ze}h*2?S|78wwU(MB7OX$Bz)=QC=H~({ML8Zp4c0?sPW@E!SNK{ZeoZ|;H|a`A{@tR
+z>Y(rz%qT4wj&eGk%X5!$j3PhX&Z~e*B0-`^nU^wcSOC+U+wv?9gEIt<F3#4q?9Bap
+z9W1(9hQ81+jLAT#FMZy8VcVQ`dimB4i)TtWC!smfly*O#1rZ#91)eVu)j4!S1S8e}
+zRE&j!kV7PZYQ<S$;LmVSvjlB(#ZY*w64Ty?xW^f?68Ta-eiI#$rzt32Cs0WYL(?UO
+z%G!J-Xo8!%TciGJ<*qJEIfp!9>*Ohy6>>*-$dn<v?4GK;5|z?R1#=8IO%xL`PN+;r
+zkiAK!X|{dS1>GU=@zbCFmY5Chf064_F-l$Te)&uL{ZD(to!#R7FT;b~r~6+X<N3Pp
+zf3aBY!R~&M?j-?JzRunIl76bX^CiPY=?(k7m-Jh9*UNE`Ftt(nnJ#)skp<{OOqe+e
+zsZ^_;XvG9$T(5v8Q6%h)+!TVKw~(Hur>kJn=jke#r>kK8fLFn!3Zc_AFlp%yc2zeM
+zFKfS}c~^r%{URrTj2}xm7usWjSQ1nma?S_5R#Y)-o4l?Rz_ayOrJZe3c!}cgi}vYz
+z2C|E^#hUr`Wb$2M!BpkpN>|c-eK&X?sPz2u3iq=4-e9_mE==U@-<@e=7cT}IR?w$y
+zC8A_fI}wBipRNQQwjZ*WdLFA=j^&fs*=39U^AbvtPQYv?N7ccqaZ(urD(~SbO|@d7
+ztbhkA1G)-iW#Y=(u0O4Lo}Pz(s@8w*0tF$SM}(pWX`}7_-@TW6h5LW^MlTPZ)_;%j
+zY=H~Ng+VOMWHspexR6+)$tW-A-N3mpe7AH^n7U|3nBFJ|z&s$+G$w3Y@47AJCd$Hk
+zFYN3s5TUu!na^}|iLacC-#mB0JGIv?YYLQP-mCye$nCi&m)Dn^P}JL!2Np>Lem=eg
+zKBlba&M_aze--*YclsYXkpG$&i}^tOWBz2zXpjM#LhmMtrEie+UbyTw?!9oQ@TT{|
+z<)QdZD4zFT{GZ+y_!&}65(dsrPFc^5DUn*&#Xf=qRh*LFdhU{W#7Bcaf+DSw|H<jm
+z$=g#m^dG2=7Wp5Ih6ly_zjyYBPxAj5&z8DeyZ6m6Kil_XTNlpbaPG1NMuD$0gZXnb
+z(1jgY*0GW^!r*^1z6#LcEP&i$zbBBQ=ir-Pu8Q|@w=^KiJ67>7Z5$OZFK_EbR>4_z
+z>q)QodNOg+3($KnUi?Ht6btj}#S8HFhKtVs(d%t(>100OnE0sIvntfzWd4s{&spo~
+z9VML1Q6wyIedGm5=}y<1AYnqU|01S&$0r^G%aJ?Ek;}p-BJ`FJ|F=O}d_YlvAVX}R
+i>plM?Xu7B8>3Mpdo~Ort{{H{~0RR7?jpIoGZ~*|6RY8gX
+
 diff --git a/charts/metallb/templates/_helpers.tpl b/charts/metallb/templates/_helpers.tpl
 index cd89381d..a1f635e8 100644
 --- a/charts/metallb/templates/_helpers.tpl
@@ -1005,7 +1317,7 @@ index e708beea..2fee46dd 100644
    labels:
      {{- include "metallb.labels" . | nindent 4 }}
 diff --git a/charts/metallb/values.schema.json b/charts/metallb/values.schema.json
-index bc0dd840..73d59218 100644
+index bc0dd840..0f333dfd 100644
 --- a/charts/metallb/values.schema.json
 +++ b/charts/metallb/values.schema.json
 @@ -62,11 +62,8 @@
@@ -1064,7 +1376,7 @@ index bc0dd840..73d59218 100644
              }
            },
            "required": [ "tolerateMaster" ]
-@@ -429,10 +391,6 @@
+@@ -429,16 +391,17 @@
        "description": "CRD configuration",
        "type": "object",
        "properties": {
@@ -1075,6 +1387,17 @@ index bc0dd840..73d59218 100644
          "validationFailurePolicy": {
            "description": "Failure policy to use with validating webhooks",
            "type": "string",
+           "enum": [ "Ignore", "Fail" ]
+         }
+       }
++    },
++    "sourceRegistry": {
++      "description": "Override source registry of the helm chart.",
++      "default": "public.ecr.aws/eks-anywhere",
++      "type": "string"
+     }
+   },
+   "required": [
 diff --git a/charts/metallb/values.yaml b/charts/metallb/values.yaml
 index bc96d355..fbde67b9 100644
 --- a/charts/metallb/values.yaml

--- a/projects/metallb/metallb/helm/schema.json
+++ b/projects/metallb/metallb/helm/schema.json
@@ -36,7 +36,7 @@
         "name",
         "addresses"
       ],
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "name": {
           "type": "string"
@@ -60,10 +60,17 @@
       "required": [
         "ipAddressPools"
       ],
-      "additionalProperties": false,
+      "additionalProperties": true,
       "properties": {
         "ipAddressPools": {
           "description": "The list of IPAddressPools to advertise via this advertisement, selected by name.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "interfaces": {
+          "description": "A list of interfaces to announce from. The LB IP will be announced only from these interfaces. If the field is not set, we advertise from all the interfaces on the host.",
           "items": {
             "type": "string"
           },
@@ -81,7 +88,7 @@
       "required": [
         "ipAddressPools"
       ],
-      "additionalProperties": false,
+      "additionalProperties": true,
       "type": "object",
       "properties": {
         "name": {
@@ -127,7 +134,7 @@
       }
     },
     "BGPPeer": {
-      "additionalProperties": false,
+      "additionalProperties": true,
       "description": "Peers for the BGP protocol.",
       "required": [
         "myASN",

--- a/projects/metallb/metallb/helm/schema.json
+++ b/projects/metallb/metallb/helm/schema.json
@@ -2,195 +2,493 @@
   "$id": "https://packages.eks.amazonaws.com/metallb.schema.json",
   "title": "Metallb",
   "type": "object",
-  "properties": {
-    "IPAddressPools": {
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/IPAddressPool"
-      }
-    },
-    "L2Advertisements": {
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/L2Advertisement"
-      }
-    },
-    "BGPAdvertisements": {
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/BGPAdvertisement"
-      }
-    },
-    "BGPPeers": {
-      "type": "array",
-      "items": {
-        "$ref": "#/$defs/BGPPeer"
-      }
-    }
-  },
-  "$defs": {
-    "IPAddressPool": {
-      "description": "A list of IP address ranges over which MetalLB has authority. You can list multiple ranges in a single pool, they will all share the same settings. Each range can be either a CIDR prefix, or an explicit start-end range of IPs.",
+  "definitions": {
+    "prometheusAlert": {
       "type": "object",
-      "required": [
-        "name",
-        "addresses"
-      ],
-      "additionalProperties": true,
       "properties": {
-        "name": {
-          "type": "string"
+        "enabled": {
+          "type": "boolean"
         },
-        "addresses": {
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "enabled"
+      ]
+    },
+    "probe": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "failureThreshold": {
+          "type": "integer"
+        },
+        "initialDelaySeconds": {
+          "type": "integer"
+        },
+        "periodSeconds": {
+          "type": "integer"
+        },
+        "successThreshold": {
+          "type": "integer"
+        },
+        "timeoutSeconds": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "failureThreshold",
+        "initialDelaySeconds",
+        "periodSeconds",
+        "successThreshold",
+        "timeoutSeconds"
+      ]
+    },
+    "component": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "logLevel": {
+          "type": "string",
+          "enum": [
+            "all",
+            "debug",
+            "info",
+            "warn",
+            "error",
+            "none"
+          ]
+        },
+        "image": {
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "digest": {
+              "type": "string"
+            },
+            "pullPolicy": {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "string",
+                  "enum": [
+                    "Always",
+                    "IfNotPresent",
+                    "Never"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "serviceAccount": {
+          "type": "object",
+          "properties": {
+            "create": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            },
+            "annotations": {
+              "type": "object"
+            }
+          }
+        },
+        "resources": {
+          "type": "object"
+        },
+        "nodeSelector": {
+          "type": "object"
+        },
+        "tolerations": {
           "type": "array",
           "items": {
+            "type": "object"
+          }
+        },
+        "priorityClassName": {
+          "type": "string"
+        },
+        "runtimeClassName": {
+          "type": "string"
+        },
+        "affinity": {
+          "type": "object"
+        },
+        "podAnnotations": {
+          "type": "object"
+        },
+        "livenessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "readinessProbe": {
+          "$ref": "#/definitions/probe"
+        }
+      },
+      "required": [
+        "image",
+        "serviceAccount"
+      ]
+    }
+  },
+  "properties": {
+    "imagePullSecrets": {
+      "description": "Secrets used for pulling images",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
             "type": "string"
           }
         },
-        "autoAssign": {
-          "default": true,
-          "description": "AutoAssign flag used to prevent MetallB from automatic allocation for a pool.",
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "nameOverride": {
+      "description": "Override chart name",
+      "type": "string"
+    },
+    "fullNameOverride": {
+      "description": "Override fully qualified app name",
+      "type": "string"
+    },
+    "configInLine": {
+      "description": "MetalLB configuration",
+      "type": "object"
+    },
+    "loadBalancerClass": {
+      "type": "string"
+    },
+    "rbac": {
+      "description": "RBAC configuration",
+      "type": "object",
+      "properties": {
+        "create": {
+          "description": "Enable RBAC",
           "type": "boolean"
         }
       }
     },
-    "L2Advertisement": {
-      "description": "L2Advertisement allows to advertise the LoadBalancer IPs provided by the selected pools via L2.",
+    "prometheus": {
+      "description": "Prometheus monitoring config",
       "type": "object",
-      "required": [
-        "ipAddressPools"
-      ],
-      "additionalProperties": true,
       "properties": {
-        "ipAddressPools": {
-          "description": "The list of IPAddressPools to advertise via this advertisement, selected by name.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
+        "scrapeAnnotations": {
+          "type": "boolean"
         },
-        "interfaces": {
-          "description": "A list of interfaces to announce from. The LB IP will be announced only from these interfaces. If the field is not set, we advertise from all the interfaces on the host.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
+        "metricsPort": {
+          "type": "integer"
         },
-        "name": {
-            "description": "The name of this L2Advertisement resource.",
-            "type": "string"
+        "secureMetricsPort": {
+          "type": "integer"
+        },
+        "rbacPrometheus": {
+          "type": "boolean"
+        },
+        "serviceAccount": {
+          "type": "string"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "rbacProxy": {
+          "description": "kube-rbac-proxy configuration",
+          "type": "object",
+          "properties": {
+            "repository": {
+              "type": "string"
+            },
+            "tag": {
+              "type": "string"
+            }
+          }
+        },
+        "podMonitor": {
+          "description": "Prometheus Operator PodMonitors",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "additionalMonitors": {
+              "type": "object"
+            },
+            "jobLabel": {
+              "type": "string"
+            },
+            "interval": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "metricRelabelings": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "relabelings": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "serviceMonitor": {
+          "description": "Prometheus Operator ServiceMonitors",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "jobLabel": {
+              "type": "string"
+            },
+            "interval": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "metricRelabelings": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            },
+            "relabelings": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "prometheusRule": {
+          "description": "Prometheus Operator alertmanager alerts",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "additionalMonitors": {
+              "type": "object"
+            },
+            "staleConfig": {
+              "$ref": "#/definitions/prometheusAlert"
+            },
+            "configNotLoaded": {
+              "$ref": "#/definitions/prometheusAlert"
+            },
+            "addressPoolExhausted": {
+              "$ref": "#/definitions/prometheusAlert"
+            },
+            "addressPoolUsage": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "thresholds": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "percent": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 100
+                      },
+                      "labels": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "required": [
+                      "percent"
+                    ]
+                  }
+                }
+              },
+              "required": [
+                "enabled"
+              ]
+            },
+            "bgpSessionDown": {
+              "$ref": "#/definitions/prometheusAlert"
+            },
+            "extraAlerts": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
+          },
+          "required": [
+            "enabled",
+            "staleConfig",
+            "configNotLoaded",
+            "addressPoolExhausted",
+            "addressPoolUsage",
+            "bgpSessionDown"
+          ]
         }
-      }
-    },
-    "BGPAdvertisement": {
-      "description": "BGPAdvertisement allows to advertise the IPs coming from the selected IPAddressPools via BGP, setting the parameters of the BGP Advertisement.",
-      "type": "object",
+      },
       "required": [
-        "ipAddressPools"
-      ],
-      "additionalProperties": true,
-      "type": "object",
-      "properties": {
-        "name": {
-            "description": "The name of this BGPAdvertisement resource.",
-            "type": "string"
+        "podMonitor",
+        "prometheusRule"
+      ]
+    },
+    "controller": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/component"
         },
-        "aggregationLength": {
-          "default": 32,
-          "description": "The aggregation-length advertisement option lets you “roll up” the /32s into a larger prefix. Defaults to 32. Works for IPv4 addresses.",
-          "minimum": 1,
-          "type": "integer"
-        },
-        "aggregationLengthV6": {
-          "default": 128,
-          "description": "The aggregation-length advertisement option lets you “roll up” the /128s into a larger prefix. Defaults to 128. Works for IPv6 addresses.",
-          "type": "integer"
-        },
-        "communities": {
-          "description": "The BGP communities to be associated with the announcement. Each item can be a community of the form 1234:1234 or the name of an alias defined in the Community CRD.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "ipAddressPools": {
-          "description": "The list of IPAddressPools to advertise via this advertisement, selected by name.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "localPref": {
-          "description": "The BGP LOCAL_PREF attribute which is used by BGP best path algorithm, Path with higher localpref is preferred over one with lower localpref.",
-          "type": "integer"
-        },
-        "peers": {
-          "description": "Limits the bgppeer to advertise the ips of the selected pools to. When empty, the loadbalancer IP is announced to all the BGPPeers configured.",
-          "type": "array",
-          "items": {
-            "type": "string"
+        {
+          "description": "MetalLB Controller",
+          "type": "object",
+          "properties": {
+            "strategy": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            "command": {
+              "type": "string"
+            },
+            "webhookMode": {
+              "type": "string"
+            },
+            "extraContainers": {
+              "type": "array",
+              "items": {
+                "type": "object"
+              }
+            }
           }
         }
-      }
+      ]
     },
-    "BGPPeer": {
-      "additionalProperties": true,
-      "description": "Peers for the BGP protocol.",
-      "required": [
-        "myASN",
-        "peerASN",
-        "peerAddress"
-      ],
+    "speaker": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/component"
+        },
+        {
+          "description": "MetalLB Speaker",
+          "type": "object",
+          "properties": {
+            "tolerateMaster": {
+              "type": "boolean"
+            },
+            "memberlist": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "mlBindPort": {
+                  "type": "integer"
+                },
+                "mlBindAddrOverride": {
+                  "type": "string"
+                },
+                "mlSecretKeyPath": {
+                  "type": "string"
+                }
+              }
+            },
+            "excludeInterfaces": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "ignoreExcludeLB": {
+              "type": "boolean"
+            },
+            "updateStrategy": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type"
+              ]
+            },
+            "runtimeClassName": {
+              "type": "string"
+            },
+            "securityContext": {
+              "type": "object"
+            },
+            "secretName": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "tolerateMaster"
+          ]
+        }
+      ]
+    },
+    "crds": {
+      "description": "CRD configuration",
       "type": "object",
       "properties": {
-        "holdTime": {
-          "description": "Requested BGP hold time, per RFC4271.",
-          "type": "string"
-        },
-        "keepaliveTime": {
-          "description": "Requested BGP keepalive time, per RFC4271.",
-          "type": "string"
-        },
-        "myASN": {
-          "description": "AS number to use for the local end of the session.",
-          "maximum": 4294967295,
-          "minimum": 0,
-          "type": "integer"
-        },
-        "password": {
-          "description": "Authentication password for routers enforcing TCP MD5 authenticated sessions",
-          "type": "string"
-        },
-        "passwordSecret": {
-          "description": "passwordSecret is name of the authentication secret for BGP Peer. The secret must be of type 'kubernetes.io/basic-auth', and created in the same namespace and cluster as the MetalLB deployment. The password is stored in the secret as the key 'password'.",
-          "type": "object"
-        },
-        "peerASN": {
-          "description": "AS number to expect from the remote end of the session.",
-          "maximum": 4294967295,
-          "minimum": 0,
-          "type": "integer"
-        },
-        "peerAddress": {
-          "description": "Address to dial when establishing the session.",
-          "type": "string"
-        },
-        "peerPort": {
-          "default": 179,
-          "description": "Port to dial when establishing the session.",
-          "maximum": 16384,
-          "minimum": 0,
-          "type": "integer"
-        },
-        "routerID": {
-          "description": "BGP router ID to advertise to the peer",
-          "type": "string"
-        },
-        "sourceAddress": {
-          "description": "Source address to use when establishing the session.",
-          "type": "string"
+        "validationFailurePolicy": {
+          "description": "Failure policy to use with validating webhooks",
+          "type": "string",
+          "enum": [
+            "Ignore",
+            "Fail"
+          ]
         }
       }
+    },
+    "sourceRegistry": {
+      "description": "Override source registry of the helm chart.",
+      "default": "public.ecr.aws/eks-anywhere",
+      "type": "string"
     }
   }
 }


### PR DESCRIPTION
**Description of changes:**
* Update schema.json for MetalLB to align with upstream repository.
* Removed chart corresponding to [frr-k8s-0.0.14.tgz](https://github.com/metallb/metallb/blob/main/charts/metallb/charts/frr-k8s-0.0.14.tgz) in the patch

**Why we are doing this?**
Customer wants to be able to configure interfaces and other attributes which are supported in upstream repository.

Testing

- `helm install -f  values.yaml metallb oci://public.ecr.aws/g0y6o3v0/metallb/metallb --version  0.14.8-3047eee74b2d54f6406a0f469cb3c72fde300822 --set sourceRegistry=public.ecr.aws/g0y6o3v0`

- Tested package installation by generating local bundle with override to registry `public.ecr.aws/g0y6o3v0`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
