### PR TITLE
[release-0.19] Downgrade bottlerocket version for 1.29 k8s

### DIFF
--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
@@ -1,7 +1,7 @@
 1-25:
-  ami-release-version: v1.20.5
-  ova-release-version: v1.20.5
-  raw-release-version: v1.20.5
+  ami-release-version: v1.19.5
+  ova-release-version: v1.19.5
+  raw-release-version: v1.19.5
 1-26:
   ami-release-version: v1.20.5
   ova-release-version: v1.20.5


### PR DESCRIPTION
*Description of changes:*
Bottlerocket dropped support for 1-25 kube version from v0.20.x Bottlerocket release. Downgrading version for 1-25 to use a supported Bottlerocket version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
