### PR TITLE
Include branch name other than main in the PR title

### DIFF
--- a/build/update-attribution-files/create_pr.sh
+++ b/build/update-attribution-files/create_pr.sh
@@ -205,10 +205,14 @@ EOF
 }
 
 function pr::create::attribution() {
-    local -r pr_title="Update ATTRIBUTION.txt files"
+    local pr_title="Update ATTRIBUTION.txt files"
     local commit_message="[PR BOT] Update ATTRIBUTION.txt files"
     local pr_branch="attribution-files-update-$MAIN_BRANCH"
     local -r pr_body=$(pr::create::pr_body "attribution")
+
+    if [ "$MAIN_BRANCH" != "main" ]; then
+        pr_title="[$MAIN_BRANCH] $pr_title"
+    fi
     
     local force_push="true"
     if [ -n "${CODEBUILD_RESOLVED_SOURCE_VERSION:-}" ]; then
@@ -226,9 +230,13 @@ function pr::create::attribution() {
 }
 
 function pr::create::checksums() {
-    local -r pr_title="Update CHECKSUMS files"
+    local pr_title="Update CHECKSUMS files"
     local pr_branch="checksums-files-update-$MAIN_BRANCH"
     local -r pr_body=$(pr::create::pr_body "checksums")
+
+    if [ "$MAIN_BRANCH" != "main" ]; then
+        pr_title="[$MAIN_BRANCH] $pr_title"
+    fi
 
     local force_push="true"
     if [ -n "${CODEBUILD_RESOLVED_SOURCE_VERSION:-}" ]; then


### PR DESCRIPTION
*Description of changes:*
The most recent [PR](https://github.com/aws/eks-anywhere-build-tooling/pull/3639) created by `eks-distro-pr-bot` to update ATTRIBUTION.txt files on `release-0.20` branch did not include the branch name in the PR title. We follow the convention to prepend "[BRANCH_NAME] " to the PR title for most of the other automated PRs created by the bot when the PR is being created for any release branch in order to quickly identify the base branch. This PR updates the `create_attribution` function to follow this convention. The `-r` argument is removed for the `pr_title` local variable to allow updating it else it would be a read-only variable and throw an error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
