### PR TITLE
Update metallb to pull minimal base image

### DIFF
--- a/projects/metallb/metallb/Makefile
+++ b/projects/metallb/metallb/Makefile
@@ -3,6 +3,7 @@ GIT_TAG=$(shell cat GIT_TAG)
 GOLANG_VERSION=$(shell cat GOLANG_VERSION)
 REPO=metallb
 REPO_OWNER=metallb
+BASE_IMAGE_NAME?=eks-distro-minimal-base
 
 BINARY_TARGET_FILES=controller speaker
 SOURCE_PATTERNS=go.universe.tf/metallb/controller go.universe.tf/metallb/speaker


### PR DESCRIPTION
*Description of changes:*
This PR updates base image for metallb to `eks-distro-minimal-base`

*Testing*
Tested package installation by generating local bundle with override to personal registry.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
