### PR TITLE
[Patch] Remove unwanted partitions from RHEL 9

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0009-Image-builder-patch-remove-unwanted-partitions-from-RHEL-9.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0009-Image-builder-patch-remove-unwanted-partitions-from-RHEL-9.patch
@@ -1,25 +1,28 @@
-From fc6d5206a917f6fdd493dc4bc9cd2d48733f7ead Mon Sep 17 00:00:00 2001
+From c55cd669ba6770f5ca3d615351260efa355f08cd Mon Sep 17 00:00:00 2001
 From: Shizhao Liu <lshizhao@amazon.com>
-Date: Fri, 9 Aug 2024 09:50:31 -0700
-Subject: [PATCH 9/9] Image-builder patch: remove swap partition from RHEL 9
- EFI
+Date: Mon, 19 Aug 2024 10:14:26 -0700
+Subject: [PATCH 9/9] Remove unwanted partitions from RHEL 9 efi
 
+- Remove both swap and /boot partitions from RHEL 9 efi
+
+Signed-off-by: Shizhao Liu <lshizhao@amazon.com>
 ---
- images/capi/packer/raw/linux/rhel/http/9/ks-efi.cfg | 1 -
- 1 file changed, 1 deletion(-)
+ images/capi/packer/raw/linux/rhel/http/9/ks-efi.cfg | 2 --
+ 1 file changed, 2 deletions(-)
 
 diff --git a/images/capi/packer/raw/linux/rhel/http/9/ks-efi.cfg b/images/capi/packer/raw/linux/rhel/http/9/ks-efi.cfg
-index c2f7daa1f..a4b03b6eb 100644
+index c2f7daa1f..50d4af8b1 100644
 --- a/images/capi/packer/raw/linux/rhel/http/9/ks-efi.cfg
 +++ b/images/capi/packer/raw/linux/rhel/http/9/ks-efi.cfg
-@@ -34,7 +34,6 @@ zerombr
+@@ -34,8 +34,6 @@ zerombr
  clearpart --all --initlabel --drives=sda
  part / --fstype="ext4" --grow --asprimary --label=slash --ondisk=sda
  part /boot/efi --fstype="efi" --ondisk=sda --size=200 --fsoptions="umask=0077,shortname=winnt"
 -part swap --fstype="swap" --ondisk=sda --size=100
- part /boot --fstype="ext4" --ondisk=sda --size=1024
+-part /boot --fstype="ext4" --ondisk=sda --size=1024
  
  # Reboot after successful installation
+ reboot
 -- 
 2.46.0
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The swap partition and the /boot partition are both not needed for RHEL 9 efi image. This patch removes them.

*Testing:
Built RHEL 9 image with these 2 partitions removed and successfully created eks-a cluster on Tinkerbell using the RHEL 9 image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
