### PR TITLE
fixes dind overlayfs in codebuild

### DIFF
--- a/projects/tinkerbell/hook/CHECKSUMS
+++ b/projects/tinkerbell/hook/CHECKSUMS
@@ -1,4 +1,4 @@
-b813c8d917fd2c4419610c3b07c51a547cdacb55f2547ea2398342ad8bcc3190  _output/bin/hook/linux-amd64/hook-bootkit
-358976e428bbc25a53133f71774fa4efe33b9e0a70638964ea477bf469bfeba4  _output/bin/hook/linux-amd64/hook-docker
-ebbfc937d995fbf7a59a718bb16b271b75bc385836857e0d85c99076e69aa18d  _output/bin/hook/linux-arm64/hook-bootkit
-a6d960f7846021db78086591eadcbde64fea1283939c999b38bbf469213c6661  _output/bin/hook/linux-arm64/hook-docker
+3f3f5e303d8a9581ca31108cef3108704308a799148a6092ca95b5696ce6d344  _output/bin/hook/linux-amd64/hook-bootkit
+6f760ce27201f2aec68835265a8f88c4b23633ca16f0f58545a552f54da475fc  _output/bin/hook/linux-amd64/hook-docker
+9bf2453c3b9cca417943782d4055dcd7e9124297ed2244cb2a28b7d8f62bdf83  _output/bin/hook/linux-arm64/hook-bootkit
+0a8115762d740d60274473b745deedae8cb94d0b2f4a135c45dc3de425347e14  _output/bin/hook/linux-arm64/hook-docker

--- a/projects/tinkerbell/hook/Makefile
+++ b/projects/tinkerbell/hook/Makefile
@@ -19,6 +19,14 @@ HOOK_IP_IMAGE_COMPONENT=tinkerbell/hook-ip
 HOOK_MDEV_IMAGE_COMPONENT=tinkerbell/hook-mdev
 
 IMAGE_NAMES=hook-bootkit hook-docker hook-runc hook-containerd kernel hook-ip hook-mdev hook-dind hook-embedded
+# historically we have included these two images in our bundle even tho we really do not
+# need them at runtime since they are built into the final vmlinuz/initramfs files
+# when in codebuild we run the combine-images build, only bother merging these two
+# merging the others is actually a bit more complicated since we override the dockerfile location
+# the combine-images target does not easily support this case since we have not needed it before
+ifneq ($(findstring combine-images,$(RELEASE_TARGETS)),)
+IMAGE_NAMES=hook-bootkit hook-docker
+endif
 
 BINARY_TARGET_FILES=hook-bootkit hook-docker
 SOURCE_PATTERNS=./ ./
@@ -50,6 +58,14 @@ KERNEL_CONFIG_HOST_PATH=$(MAKE_ROOT)/$(OUTPUT_DIR)/kernel-config
 HOOK_EMBEDDED_FOLDER=$(REPO)/images/hook-embedded
 EMBEDDED_IMAGES=$(foreach platform,$(HOOK_PLATFORMS),$(OUTPUT_DIR)/hook-embedded/$(subst /,-,$(platform))/images)
 
+# we need to set IMAGE_BUILD_ARGS here even though its the same as the default. 
+# it is set in Common.mk on the images target (https://github.com/aws/eks-anywhere-build-tooling/blob/8b6d6d66974e881b22e3c9c8ea29adc26f7df5fd/Common.mk#L799)
+# and the combine-images target (https://github.com/aws/eks-anywhere-build-tooling/blob/8b6d6d66974e881b22e3c9c8ea29adc26f7df5fd/Common.mk#L846)
+# since combine-images has images as prereq target, the ?= does not really behavior as one might expect.
+# the images target being the actual action, its version of the set takes prioirty and resets to empty
+# setting it explicitly to empty here takes allows the combine-images override to take proirty
+IMAGE_BUILD_ARGS=
+
 BUILDSPECS=buildspec.yml buildspecs/combine-images.yml
 BUILDSPEC_1_COMPUTE_TYPE=BUILD_GENERAL1_LARGE
 BUILDSPEC_1_VARS_KEYS=IMAGE_PLATFORMS
@@ -77,8 +93,6 @@ $(GATHER_LICENSES_TARGETS): | $(FIX_LICENSES_HOOK_BOOTKIT_TARGET) $(FIX_LICENSES
 # hook-docker image required docker runtime.
 # We are using eks-distro-minimal-base-glibc as the base and builder to install docker.
 hook-docker/images/% hook-dind/images/%: BASE_IMAGE_NAME=eks-distro-minimal-base-iptables
-
-hook-docker/images/%: IMAGE_TARGET=hook-docker
 
 hook-dind/images/%: DOCKERFILE_FOLDER=./docker/linux/hook-docker
 hook-dind/images/%: IMAGE_TARGET=hook-dind
@@ -123,8 +137,8 @@ $(CREATE_HOOK_FILES_PATTERN)-%: | $$(ENABLE_DOCKER)
 	DEBUG=yes HOOK_KERNEL_OCI_BASE=$(IMAGE_REPO)/$(KERNEL_IMAGE_COMPONENT) \
 		HOOK_LK_CONTAINERS_OCI_BASE=$(IMAGE_REPO)/tinkerbell/ \
 		HOOK_KERNEL_POINT_RELEASE=$(lastword $(subst ., ,$(KERNEL_VERSION))) \
-		HOOK_KERNEL_OCI_VERSION=$(LATEST_TAG) \
-		HOOK_LK_CONTAINERS_OCI_VERSION=$(LATEST_TAG) \
+		HOOK_KERNEL_OCI_VERSION=$(LATEST_TAG)$(IMAGE_TAG_SUFFIX) \
+		HOOK_LK_CONTAINERS_OCI_VERSION=$(LATEST_TAG)$(IMAGE_TAG_SUFFIX) \
 		./build.sh build hook-default-$(BUILD_ARCH); \
 	cd ..; \
 	mkdir -p $(OUTPUT_DIR)/hook/$(GIT_TAG); \

--- a/projects/tinkerbell/hook/docker/linux/hook-docker/Dockerfile
+++ b/projects/tinkerbell/hook/docker/linux/hook-docker/Dockerfile
@@ -44,4 +44,5 @@ FROM hook-docker as hook-dind
 
 COPY --from=dind-builder /newroot /
 
-VOLUME /var/lib/docker
+# last stage not named to avoid needing to pass a target which messes up the combine phase
+FROM hook-docker

--- a/projects/tinkerbell/hook/patches/0001-patches-build.sh-flow-for-linuxkit.patch
+++ b/projects/tinkerbell/hook/patches/0001-patches-build.sh-flow-for-linuxkit.patch
@@ -1,7 +1,7 @@
-From 075903d2f8c06480458d62cfed380a2ca7502a50 Mon Sep 17 00:00:00 2001
+From 0923c9018b51fa4d78545a6d07b2d63d4128f41d Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
 Date: Tue, 13 Aug 2024 19:42:41 +0000
-Subject: [PATCH 1/2] patches build.sh flow for linuxkit
+Subject: [PATCH 1/3] patches build.sh flow for linuxkit
 
 - do not require docker
 - allow tag overriddes for kernel and other images
@@ -195,7 +195,7 @@ index 5f05325..3da85a0 100644
  	if [[ "${OUTPUT_TARBALL_FILELIST:-"no"}" == "yes" ]]; then
  		log info "OUTPUT_TARBALL_FILELIST=yes; including tar and filelist in output."
 diff --git a/build.sh b/build.sh
-index 985bea8..b7cc83b 100755
+index e07f788..bebfa11 100755
 --- a/build.sh
 +++ b/build.sh
 @@ -63,7 +63,8 @@ mkdir -p "${CACHE_DIR}" # ensure the directory exists

--- a/projects/tinkerbell/hook/patches/0002-builds-kernel-from-al2.patch
+++ b/projects/tinkerbell/hook/patches/0002-builds-kernel-from-al2.patch
@@ -1,7 +1,7 @@
-From b7503f69af84b5a14f5b1a30266217de88b59769 Mon Sep 17 00:00:00 2001
+From bcbc69bfef4d8434fb3c08b55ec13b0db01cacbf Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Mon, 15 Jul 2024 20:41:42 +0000
-Subject: [PATCH 2/2] builds kernel from al2
+Subject: [PATCH 2/3] builds kernel from al2
 
 ---
  kernel/Dockerfile | 34 +++++++++++++++++++++++++++-------

--- a/projects/tinkerbell/hook/patches/0003-use-tmpfs-for-var-lib-docker.patch
+++ b/projects/tinkerbell/hook/patches/0003-use-tmpfs-for-var-lib-docker.patch
@@ -1,0 +1,25 @@
+From 067eff9d94403b33816a5cb6155387fc6b88569d Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Thu, 29 Aug 2024 01:08:55 +0000
+Subject: [PATCH 3/3] use tmpfs for var/lib/docker
+
+---
+ images/hook-embedded/pull-images.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/images/hook-embedded/pull-images.sh b/images/hook-embedded/pull-images.sh
+index 45bf18d..6689946 100755
+--- a/images/hook-embedded/pull-images.sh
++++ b/images/hook-embedded/pull-images.sh
+@@ -69,7 +69,7 @@ function main() {
+     # will change the permissions of the bind mount directory (images/) to root.
+     echo -e "Starting DinD container"
+     echo -e "-----------------------"
+-    docker run -d --privileged --name "${dind_container}" -v "${PWD}/images_tar":/images_tar -v "${PWD}"/images/:/var/lib/docker-embedded/ -d "${dind_container_image}"
++    docker run -d --privileged --mount type=tmpfs,destination=/var/lib/docker --name "${dind_container}" -v "${PWD}/images_tar":/images_tar -v "${PWD}"/images/:/var/lib/docker-embedded/ -d "${dind_container_image}"
+ 
+     # wait until the docker daemon is ready
+     until docker exec "${dind_container}" docker info &> /dev/null; do
+-- 
+2.34.1
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Codebuild was failing to build because the dind container we launch to pull images to create the embed cache was running with the `vfs` storage driver instead of overlay2.  

We have a similar problem in prow presubmits which run on fargate where because the buildkit process that is running can not create a overlay2 fs for the build layers/stages, it ends up using vfs as well which results in each layer basically be a full copy/duplicate of all previous layers.  In presubmits this is kind of whatever as long as we have the space available.

The codebuild job much like the fargate job are themselves a running container whose rootfs is overlay2.  When we launch the dind container, that docker process on boot attempts to create a overlay2 fs at `/var/lib/docker`.  Since the rootfs for the running job/container is already overlay2, this attempt by the dind process to create a new one fails, since you cant make a overlay2 fs on top of an existing overlay2 fs.

This avoid this issue by use a tmpfs for /var/lib/docker when running the dind container.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
