### PR TITLE
fixes combine for linuxkit by checking the repo

### DIFF
--- a/buildspecs/combine-images.yml
+++ b/buildspecs/combine-images.yml
@@ -2,7 +2,7 @@ version: 0.2
 
 env:
   variables:
-    RELEASE_TARGETS: "combine-images helm/push"
+    RELEASE_TARGETS: "checkout-repo combine-images helm/push"
     BINARY_TARGETS: ""
     LICENSES_TARGETS_FOR_PREREQ: ""
     HANDLE_DEPENDENCIES_TARGET: ""


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

A quirk about this build is it uses the dockerfiles from upstream.  The few places we use combine have never done this and therefore not needed the repo to be cloned.  Adding this checkout should be fine for those cases and fix the linuxkit build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
