### PR TITLE
Include branch name other than main in the PR title

### DIFF
--- a/build/update-attribution-files/create_pr.sh
+++ b/build/update-attribution-files/create_pr.sh
@@ -281,10 +281,14 @@ function pr::create::checksums() {
 }
 
 function pr::create::help() {
-    local -r pr_title="Update Makefile generated help"
+    local pr_title="Update Makefile generated help"
     local -r commit_message="[PR BOT] Update Help.mk files"
     local -r pr_branch="help-makefiles-update-$MAIN_BRANCH"
     local -r pr_body=$(pr::create::pr_body "makehelp")
+
+    if [ "$MAIN_BRANCH" != "main" ]; then
+        pr_title="[$MAIN_BRANCH] $pr_title"
+    fi
 
     if pr::commit::push "$commit_message" "$pr_branch"; then
         pr::create "$pr_title" "$pr_branch" "$pr_body"
@@ -292,10 +296,14 @@ function pr::create::help() {
 }
 
 function pr::create::go-mod() {
-    local -r pr_title="Update go.mod files"
+    local pr_title="Update go.mod files"
     local -r commit_message="[PR BOT] Update go.mod files"
     local -r pr_branch="go-mod-update-$MAIN_BRANCH"
     local -r pr_body=$(pr::create::pr_body "go-mod")
+
+    if [ "$MAIN_BRANCH" != "main" ]; then
+        pr_title="[$MAIN_BRANCH] $pr_title"
+    fi
 
     if pr::commit::push "$commit_message" "$pr_branch"; then
         pr::create "$pr_title" "$pr_branch" "$pr_body"


### PR DESCRIPTION
*Description of changes:*
This PR is a follow-up to [#3643](https://github.com/aws/eks-anywhere-build-tooling/pull/3643) for Makefile generated help PRs and go.mod update PRs. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
