### PR TITLE
Upgrade only the patch versions for cilium on release branch

### DIFF
--- a/tools/version-tracker/pkg/commands/upgrade/upgrade.go
+++ b/tools/version-tracker/pkg/commands/upgrade/upgrade.go
@@ -218,7 +218,7 @@ func Run(upgradeOptions *types.UpgradeOptions) error {
 		var latestRevision string
 		var needsUpgrade bool
 		if projectName == "cilium/cilium" {
-			latestRevision, needsUpgrade, err = ecrpublic.GetLatestRevision(constants.CiliumImageRepository, currentRevision)
+			latestRevision, needsUpgrade, err = ecrpublic.GetLatestRevision(constants.CiliumImageRepository, currentRevision, branchName)
 			if err != nil {
 				return fmt.Errorf("getting latest revision from ECR Public: %v", err)
 			}


### PR DESCRIPTION
*Description of changes:*
Project upgrades on release branch was supported in [#3275](https://github.com/aws/eks-anywhere-build-tooling/pull/3275) but it didn't handle getting the latest patch version on release branches for Cilium. Cilium is a special case as the Isovalent team cuts EKS-A specific builds of Cilium which are accessible in our ECR:  https://gallery.ecr.aws/isovalent/cilium

Currently, the eks distro PR bot opens PR for Cilium on release branches for the absolute latest version which could also be a minor version upgrade. We only want to update the patch versions for release branches. This PR updates the logic in the upgrade tool to handle this scenario.

*Testing:*
```
➜  bin/version-tracker display --project cilium/cilium 
ORGANIZATION  REPOSITORY  CURRENT VERSION  LATEST VERSION   
cilium        cilium      v1.13.18-eksa.1  v1.14.12-eksa.2                                                                /2.7s
➜  BRANCH_NAME=release-0.19 bin/version-tracker display --project cilium/cilium
ORGANIZATION  REPOSITORY  CURRENT VERSION  LATEST VERSION   
cilium        cilium      v1.13.18-eksa.1  v1.13.19-eksa.1
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
