### PR TITLE
Update patch and CHECKSUMS for CAPC v0.5.0

### DIFF
--- a/projects/kubernetes-sigs/cluster-api-provider-cloudstack/CHECKSUMS
+++ b/projects/kubernetes-sigs/cluster-api-provider-cloudstack/CHECKSUMS
@@ -1,2 +1,2 @@
-8c83c64aa2c2a2cfc5205ea1834f71ed2befd2e184d9a9a1ad27b71d8311038b  _output/bin/cluster-api-provider-cloudstack/linux-amd64/manager
-4508f64a1b01b4b9397791b2dfe8db20cf0fc601ff0f191d23fc5d87cb75cd75  _output/bin/cluster-api-provider-cloudstack/linux-arm64/manager
+b845065c9fde77c5a1c0330bbd0d64524e6f5621c2579314709b4baf63bd70f4  _output/bin/cluster-api-provider-cloudstack/linux-amd64/manager
+c5f2c85da4b5083d30b0468cfea289f30b9dbe6a6a55af8e5725b8860838bfdb  _output/bin/cluster-api-provider-cloudstack/linux-arm64/manager

--- a/projects/kubernetes-sigs/cluster-api-provider-cloudstack/patches/0001-Support-re-assignment-of-another-failure-domain-when.patch
+++ b/projects/kubernetes-sigs/cluster-api-provider-cloudstack/patches/0001-Support-re-assignment-of-another-failure-domain-when.patch
@@ -1,4 +1,4 @@
-From 56adab19686da6cb98b61d3286531d4e0b49bb7d Mon Sep 17 00:00:00 2001
+From b955446b9e03c0958c6e1e8a54e5021437689e66 Mon Sep 17 00:00:00 2001
 From: Jhaanvi Golani <jhaanvi@amazon.com>
 Date: Mon, 11 Mar 2024 17:32:24 -0700
 Subject: [PATCH] Support re-assignment of another failure domain when the
@@ -18,6 +18,7 @@ Signed-off-by: Jhaanvi Golani <jhaanvi@amazon.com>
  ...loudstackmachinestatechecker_controller.go |   2 +-
  controllers/controllers_suite_test.go         |  18 +-
  controllers/utils/failuredomains.go           |  44 +--
+ metadata.yaml                                 |   2 +-
  pkg/cloud/instance.go                         |  76 +++--
  pkg/cloud/network.go                          |  24 ++
  pkg/errors/cloudstack.go                      |  85 +++++
@@ -29,7 +30,7 @@ Signed-off-by: Jhaanvi Golani <jhaanvi@amazon.com>
  pkg/failuredomains/client_test.go             | 159 +++++++++
  .../failuredomains_suite_test.go              |  33 ++
  pkg/metrics/metrics.go                        |  22 +-
- 23 files changed, 1244 insertions(+), 109 deletions(-)
+ 24 files changed, 1245 insertions(+), 110 deletions(-)
  create mode 100644 pkg/errors/cloudstack.go
  create mode 100644 pkg/errors/cloudstack_test.go
  create mode 100644 pkg/errors/errors_suite_test.go
@@ -108,7 +109,7 @@ index 83ecdc6..187e51c 100644
  - apiGroups:
    - cluster.x-k8s.io
 diff --git a/controllers/cks_cluster_controller.go b/controllers/cks_cluster_controller.go
-index 2511651..b69a748 100644
+index 2511651..05d22ab 100644
 --- a/controllers/cks_cluster_controller.go
 +++ b/controllers/cks_cluster_controller.go
 @@ -75,7 +75,7 @@ func (r *CksClusterReconciliationRunner) Reconcile() (res ctrl.Result, reterr er
@@ -116,7 +117,7 @@ index 2511651..b69a748 100644
  	controllerutil.AddFinalizer(r.ReconciliationSubject, CksClusterFinalizer)
  
 -	res, err := r.AsFailureDomainUser(&r.FailureDomains.Items[0].Spec)()
-+	res, err := r.AsFailureDomainUser(context.Background(), &r.FailureDomains.Items[0].Spec)()
++	res, err := r.AsFailureDomainUser(r.RequestCtx, &r.FailureDomains.Items[0].Spec)()
  	if r.ShouldReturn(res, err) {
  		return res, err
  	}
@@ -125,12 +126,12 @@ index 2511651..b69a748 100644
  			return ctrl.Result{}, fmt.Errorf("no failure domains found")
  		}
 -		res, err := r.AsFailureDomainUser(&r.FailureDomains.Items[0].Spec)()
-+		res, err := r.AsFailureDomainUser(context.Background(), &r.FailureDomains.Items[0].Spec)()
++		res, err := r.AsFailureDomainUser(r.RequestCtx, &r.FailureDomains.Items[0].Spec)()
  		if r.ShouldReturn(res, err) {
  			return res, err
  		}
 diff --git a/controllers/cks_machine_controller.go b/controllers/cks_machine_controller.go
-index 574f932..f7f40d4 100644
+index 574f932..f8a8119 100644
 --- a/controllers/cks_machine_controller.go
 +++ b/controllers/cks_machine_controller.go
 @@ -63,7 +63,7 @@ func (reconciler *CksMachineReconciler) Reconcile(ctx context.Context, req ctrl.
@@ -138,7 +139,7 @@ index 574f932..f7f40d4 100644
  	r.WithAdditionalCommonStages(
  		r.GetFailureDomainByName(func() string { return r.ReconciliationSubject.Spec.FailureDomainName }, r.FailureDomain),
 -		r.AsFailureDomainUser(&r.FailureDomain.Spec))
-+		r.AsFailureDomainUser(ctx, &r.FailureDomain.Spec))
++		r.AsFailureDomainUser(r.RequestCtx, &r.FailureDomain.Spec))
  	return r.RunBaseReconciliationStages()
  }
  
@@ -147,7 +148,7 @@ index 574f932..f7f40d4 100644
  	controllerutil.AddFinalizer(r.ReconciliationSubject, CksMachineFinalizer)
  
 -	res, err := r.AsFailureDomainUser(&r.FailureDomain.Spec)()
-+	res, err := r.AsFailureDomainUser(context.Background(), &r.FailureDomain.Spec)()
++	res, err := r.AsFailureDomainUser(r.RequestCtx, &r.FailureDomain.Spec)()
  	if r.ShouldReturn(res, err) {
  		return res, err
  	}
@@ -556,6 +557,17 @@ index bf66c25..5ca3e97 100644
 +func (c *CloudClientImplementation) GetCloudClientAndUser(ctx context.Context, fdSpec *infrav1.CloudStackFailureDomainSpec) (csClient cloud.Client, csUser cloud.Client, err error) {
 +	return c.fdClientFactory.GetCloudClientAndUser(ctx, fdSpec)
 +}
+diff --git a/metadata.yaml b/metadata.yaml
+index bd61395..a030a70 100644
+--- a/metadata.yaml
++++ b/metadata.yaml
+@@ -7,5 +7,5 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
+ kind: Metadata
+ releaseSeries:
+   - major: 0
+-    minor: 4
++    minor: 5
+     contract: v1beta1
 diff --git a/pkg/cloud/instance.go b/pkg/cloud/instance.go
 index 6fb5857..e622920 100644
 --- a/pkg/cloud/instance.go


### PR DESCRIPTION
*Description of changes:*
CloudStack tests are failing with the following error after [#3409](https://github.com/aws/eks-anywhere-build-tooling/pull/3409) bumped CAPC version to v0.5.0:
```
Error: initializing capi resources in cluster: executing init: Fetching providers
Using Override="core-components.yaml" Provider="cluster-api" Version="v1.7.2+9e7aabb"
Using Override="bootstrap-components.yaml" Provider="bootstrap-kubeadm" Version="v1.7.2+9cf3afa"
Using Override="bootstrap-components.yaml" Provider="bootstrap-etcdadm-bootstrap" Version="v1.0.13+6519b1e"
Using Override="bootstrap-components.yaml" Provider="bootstrap-etcdadm-controller" Version="v1.0.22+782ca1f"
Using Override="control-plane-components.yaml" Provider="control-plane-kubeadm" Version="v1.7.2+5724915"
Using Override="infrastructure-components.yaml" Provider="infrastructure-cloudstack" Version="v0.5.0+5866184"
Error: invalid provider metadata: version v0.5.0+5866184 for the provider capc-system/infrastructure-cloudstack does not match any release series
    cluster.go:940: Command failed, scanning output for error
    cluster.go:960: Command eksctl anywhere [create cluster -f main-i-06cb9-8abe159/main-i-06cb9-8abe159-eks-a.yaml -v 6] failed with error: exit status 255: Error: invalid provider metadata: version v0.5.0+5866184 for the provider capc-system/infrastructure-cloudstack does not match any release series
```
This is because the minor version in [metadata.yaml](https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack/blob/v0.5.0/metadata.yaml) wasn't updated to the latest version.It was updated in [main](https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack/commit/fa624e9f145a93bb5c9d0b841ced3ecb21eb03cc) but wasn't backported to the v0.5.0 tag. This PR updates the patch to update the minor version in `metadata.yaml`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
