### PR TITLE
Backport Go version detection improvements to release-0.20

### DIFF
--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -190,7 +190,7 @@ var (
 	ProjectGoVersionSourceOfTruth = map[string]types.GoVersionSourceOfTruth{
 		"apache/cloudstack-cloudmonkey": {
 			SourceOfTruthFile:     ".github/workflows/build.yml",
-			GoVersionSearchString: `go-version: (1\.\d\d)\.x`,
+			GoVersionSearchString: `go-version: (1\.\d\d)`,
 		},
 		"aquasecurity/harbor-scanner-trivy": {
 			SourceOfTruthFile:     "go.mod",
@@ -214,7 +214,7 @@ var (
 		},
 		"brancz/kube-rbac-proxy": {
 			SourceOfTruthFile:     ".github/workflows/build.yml",
-			GoVersionSearchString: `go-version: '(1\.\d\d)\.\d+'`,
+			GoVersionSearchString: `go-version: '(1\.\d\d)'`,
 		},
 		"cert-manager/cert-manager": {
 			SourceOfTruthFile:     "go.mod",
@@ -222,7 +222,7 @@ var (
 		},
 		"containerd/containerd": {
 			SourceOfTruthFile:     ".github/workflows/release.yml",
-			GoVersionSearchString: `GO_VERSION: "(1\.\d\d)\.\d+"`,
+			GoVersionSearchString: `GO_VERSION: "(1\.\d\d)"`,
 		},
 		"distribution/distribution": {
 			SourceOfTruthFile:     "Dockerfile",
@@ -234,7 +234,7 @@ var (
 		},
 		"fluxcd/flux2": {
 			SourceOfTruthFile:     ".github/workflows/release.yaml",
-			GoVersionSearchString: `go-version: (1\.\d\d)\.x`,
+			GoVersionSearchString: `go-version: (1\.\d\d)`,
 		},
 		"fluxcd/helm-controller": {
 			SourceOfTruthFile:     "Dockerfile",
@@ -278,7 +278,7 @@ var (
 		},
 		"kubernetes-sigs/cluster-api": {
 			SourceOfTruthFile:     "Makefile",
-			GoVersionSearchString: `GO_VERSION \?= (1\.\d\d)\.\d+`,
+			GoVersionSearchString: `GO_VERSION \?= (1\.\d\d)`,
 		},
 		"kubernetes-sigs/cluster-api-provider-cloudstack": {
 			SourceOfTruthFile:     "go.mod",
@@ -286,7 +286,7 @@ var (
 		},
 		"kubernetes-sigs/cluster-api-provider-vsphere": {
 			SourceOfTruthFile:     "Makefile",
-			GoVersionSearchString: `GO_VERSION \?= (1\.\d\d)\.\d+`,
+			GoVersionSearchString: `GO_VERSION \?= (1\.\d\d)`,
 		},
 		"kubernetes-sigs/cri-tools": {
 			SourceOfTruthFile:     ".github/workflows/release.yml",
@@ -298,7 +298,7 @@ var (
 		},
 		"kubernetes-sigs/kind": {
 			SourceOfTruthFile:     ".go-version",
-			GoVersionSearchString: `(1\.\d\d)\.\d+`,
+			GoVersionSearchString: `(1\.\d\d)`,
 		},
 		"metallb/metallb": {
 			SourceOfTruthFile:     "controller/Dockerfile",

--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -188,11 +188,27 @@ var (
 
 	// ProjectGoVersionSourceOfTruth is the mapping of project name to Go version source of truth files configuration.
 	ProjectGoVersionSourceOfTruth = map[string]types.GoVersionSourceOfTruth{
+		"apache/cloudstack-cloudmonkey": {
+			SourceOfTruthFile:     ".github/workflows/build.yml",
+			GoVersionSearchString: `go-version: (1\.\d\d)\.x`,
+		},
+		"aquasecurity/harbor-scanner-trivy": {
+			SourceOfTruthFile:     "go.mod",
+			GoVersionSearchString: `go (1\.\d\d)`,
+		},
+		"aquasecurity/trivy": {
+			SourceOfTruthFile:     "Dockerfile.protoc",
+			GoVersionSearchString: `golang:(1\.\d\d)`,
+		},
 		"aws/etcdadm-bootstrap-provider": {
 			SourceOfTruthFile:     "go.mod",
 			GoVersionSearchString: `go (1\.\d\d)`,
 		},
 		"aws/etcdadm-controller": {
+			SourceOfTruthFile:     "go.mod",
+			GoVersionSearchString: `go (1\.\d\d)`,
+		},
+		"aws/rolesanywhere-credential-helper": {
 			SourceOfTruthFile:     "go.mod",
 			GoVersionSearchString: `go (1\.\d\d)`,
 		},
@@ -204,13 +220,21 @@ var (
 			SourceOfTruthFile:     "go.mod",
 			GoVersionSearchString: `go (1\.\d\d)`,
 		},
+		"containerd/containerd": {
+			SourceOfTruthFile:     ".github/workflows/release.yml",
+			GoVersionSearchString: `GO_VERSION: "(1\.\d\d)\.\d+"`,
+		},
+		"distribution/distribution": {
+			SourceOfTruthFile:     "Dockerfile",
+			GoVersionSearchString: `ARG GO_VERSION=(1\.\d\d)`,
+		},
 		"emissary-ingress/emissary": {
 			SourceOfTruthFile:     "go.mod",
 			GoVersionSearchString: `go (1\.\d\d)`,
 		},
-		"goharbor/harbor": {
-			SourceOfTruthFile:     "Makefile",
-			GoVersionSearchString: `GOBUILDIMAGE=golang:(1\.\d\d)`,
+		"fluxcd/flux2": {
+			SourceOfTruthFile:     ".github/workflows/release.yaml",
+			GoVersionSearchString: `go-version: (1\.\d\d)\.x`,
 		},
 		"fluxcd/helm-controller": {
 			SourceOfTruthFile:     "Dockerfile",
@@ -228,6 +252,14 @@ var (
 			SourceOfTruthFile:     "Dockerfile",
 			GoVersionSearchString: `ARG GO_VERSION=(1\.\d\d)`,
 		},
+		"goharbor/harbor": {
+			SourceOfTruthFile:     "Makefile",
+			GoVersionSearchString: `GOBUILDIMAGE=golang:(1\.\d\d)`,
+		},
+		"helm/helm": {
+			SourceOfTruthFile:     ".github/workflows/release.yaml",
+			GoVersionSearchString: `go-version: '(1\.\d\d)'`,
+		},
 		"kube-vip/kube-vip": {
 			SourceOfTruthFile:     "Dockerfile",
 			GoVersionSearchString: `golang:(1\.\d\d)`,
@@ -244,6 +276,10 @@ var (
 			SourceOfTruthFile:     "go.mod",
 			GoVersionSearchString: `go (1\.\d\d)`,
 		},
+		"kubernetes-sigs/cluster-api": {
+			SourceOfTruthFile:     "Makefile",
+			GoVersionSearchString: `GO_VERSION \?= (1\.\d\d)\.\d+`,
+		},
 		"kubernetes-sigs/cluster-api-provider-cloudstack": {
 			SourceOfTruthFile:     "go.mod",
 			GoVersionSearchString: `go (1\.\d\d)`,
@@ -252,9 +288,21 @@ var (
 			SourceOfTruthFile:     "Makefile",
 			GoVersionSearchString: `GO_VERSION \?= (1\.\d\d)\.\d+`,
 		},
+		"kubernetes-sigs/cri-tools": {
+			SourceOfTruthFile:     ".github/workflows/release.yml",
+			GoVersionSearchString: `go-version: '(1\.\d\d)'`,
+		},
 		"kubernetes-sigs/etcdadm": {
 			SourceOfTruthFile:     "Makefile",
 			GoVersionSearchString: `GO_IMAGE \?= golang:(1\.\d\d)`,
+		},
+		"kubernetes-sigs/kind": {
+			SourceOfTruthFile:     ".go-version",
+			GoVersionSearchString: `(1\.\d\d)\.\d+`,
+		},
+		"metallb/metallb": {
+			SourceOfTruthFile:     "controller/Dockerfile",
+			GoVersionSearchString: `golang:(1\.\d\d)`,
 		},
 		"nutanix-cloud-native/cluster-api-provider-nutanix": {
 			SourceOfTruthFile:     "go.mod",
@@ -264,9 +312,13 @@ var (
 			SourceOfTruthFile:     "go.mod",
 			GoVersionSearchString: `go (1\.\d\d)`,
 		},
-		"metallb/metallb": {
-			SourceOfTruthFile:     "go.mod",
-			GoVersionSearchString: `go (1\.\d\d)`,
+		"opencontainers/runc": {
+			SourceOfTruthFile:     "Dockerfile",
+			GoVersionSearchString: `ARG GO_VERSION=(1\.\d\d)`,
+		},
+		"prometheus/node_exporter": {
+			SourceOfTruthFile:     ".promu.yml",
+			GoVersionSearchString: `version: (1\.\d\d)`,
 		},
 		"prometheus/prometheus": {
 			SourceOfTruthFile:     ".promu.yml",
@@ -275,6 +327,10 @@ var (
 		"rancher/local-path-provisioner": {
 			SourceOfTruthFile:     "Dockerfile.dapper",
 			GoVersionSearchString: `golang:(1\.\d\d)`,
+		},
+		"replicatedhq/troubleshoot": {
+			SourceOfTruthFile:     ".github/workflows/build-test-deploy.yaml",
+			GoVersionSearchString: `go-version: "(1\.\d\d)"`,
 		},
 		"tinkerbell/boots": {
 			SourceOfTruthFile:     "go.mod",
@@ -296,6 +352,14 @@ var (
 			SourceOfTruthFile:     ".github/workflows/ci.yaml",
 			GoVersionSearchString: `GO_VERSION: '(1\.\d\d)'`,
 		},
+		"tinkerbell/hook": {
+			SourceOfTruthFile:     "images/hook-bootkit/Dockerfile",
+			GoVersionSearchString: `golang:(1\.\d\d)`,
+		},
+		"vmware/govmomi": {
+			SourceOfTruthFile:     ".github/workflows/govmomi-release.yaml",
+			GoVersionSearchString: `go-version: '(1\.\d\d)'`,
+		},
 	}
 
 	ProjectsWithUnconventionalUpgradeFlows = []string{
@@ -315,6 +379,7 @@ var (
 	UpstreamPackagesProjects = []string{
 		"aquasecurity/harbor-scanner-trivy",
 		"aquasecurity/trivy",
+		"aws/rolesanywhere-credential-helper",
 		"aws-containers/hello-eks-anywhere",
 		"aws-observability/aws-otel-collector",
 		"distribution/distribution",


### PR DESCRIPTION
Backport #3625 and #3751 to release-0.20 branch


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
