### PR TITLE
Update bottlerocket release version and host containers

### DIFF
--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_ADMIN_CONTAINER_METADATA
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_ADMIN_CONTAINER_METADATA
@@ -1,2 +1,2 @@
 imageDigest: sha256:0af31983e8c0f6696e0c85c43d9b775e401b1cecd2e0fe5bd46137a16e619ad9
-tag: v0.11.9
+tag: v0.11.11

--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_CONTROL_CONTAINER_METADATA
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_CONTROL_CONTAINER_METADATA
@@ -1,2 +1,2 @@
 imageDigest: sha256:cf4c175e4865b89a05dffea63ee2fb2bfb99df8d8ca9590a2898f10fc2e4dfb7
-tag: v0.7.13
+tag: v0.7.15

--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
@@ -3,12 +3,15 @@
   ova-release-version: v1.20.5
   raw-release-version: v1.20.5
 1-28:
-  ami-release-version: v1.20.5
-  ova-release-version: v1.20.5
-  raw-release-version: v1.20.5
+  ami-release-version: v1.22.0
+  ova-release-version: v1.22.0
+  raw-release-version: v1.22.0
 1-29:
-  ami-release-version: v1.20.5
-  ova-release-version: v1.20.5
+  ami-release-version: v1.22.0
+  ova-release-version: v1.22.0
 1-30:
-  ami-release-version: v1.20.5
-  ova-release-version: v1.20.5
+  ami-release-version: v1.22.0
+  ova-release-version: v1.22.0
+1-31:
+  ami-release-version: v1.22.0
+  ova-release-version: v1.22.0


### PR DESCRIPTION
*Issue #, if available:*
[#2399](https://github.com/aws/eks-anywhere-internal/issues/2399)

*Description of changes:*
- Updated bottlerocket version to latest `v1.22.0`
- Updated bottlerocket admin container to latest `v0.11.11`
- Updated bottlerocket control container to latest `v0.7.15`

*NOTE:*
Bottlerocket 1.27 VMWare variant is no longer supported from v1.21.0 onwards.
PR: https://github.com/bottlerocket-os/bottlerocket/pull/4079

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
