### PR TITLE
Add patches to fix Ubuntu 22.04 OVA and RHEL 8/9 QEMU/raw builds

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
@@ -1,7 +1,7 @@
 From 890cbd7d1fdeb6280f8615886ebb468cee93e159 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:05:13 -0800
-Subject: [PATCH 01/11] OVA improvements
+Subject: [PATCH 01/12] OVA improvements
 
 - Create /etc/pki/tls/certs dir as part of image-builds
 - Tweak Product info in OVF

--- a/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
@@ -1,7 +1,7 @@
 From 9d44743a428515d1327df7e75d8a7fb34caf8bdc Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 18:36:56 -0800
-Subject: [PATCH 02/11] EKS-D support and changes
+Subject: [PATCH 02/12] EKS-D support and changes
 
 - Add goss validations for EKS-D artifacts
 - Add etcdadm and etcd.tar.gz to image for unstacked etcd support

--- a/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
@@ -1,7 +1,7 @@
 From 56d60f47033c07da293964341decf8ad57130b8e Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Feb 2023 01:39:15 -0800
-Subject: [PATCH 03/11] Snow AMI support
+Subject: [PATCH 03/12] Snow AMI support
 
 ---
  images/capi/packer/ami/packer.json | 12 ++++++++++--

--- a/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22.04-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22.04-support-and-improvements.patch
@@ -1,7 +1,7 @@
 From b0ecf4ff85ebd8130f716c1588cfa1e36f4f034f Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Fri, 23 Jun 2023 10:50:08 -0500
-Subject: [PATCH 04/11] Ubuntu 22.04 support and improvements
+Subject: [PATCH 04/12] Ubuntu 22.04 support and improvements
 
 - adds support for raw ubuntu 22.04 builds
 - Ubuntu switch to offline-install when mirrors are unavailable

--- a/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
@@ -1,7 +1,7 @@
-From c6e7e28d7b536565e41001471fec7e5355c536c4 Mon Sep 17 00:00:00 2001
+From cb5e388c16b803aa96f05af374a5cd884ca91c72 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 6 Dec 2022 15:42:02 -0600
-Subject: [PATCH 05/11] RHEL support and improvements
+Subject: [PATCH 05/12] RHEL support and improvements
 
 - Fix redhat 9 cloud-init feature flags bug
 - Fix ensure iptables present for rhel
@@ -9,14 +9,16 @@ Subject: [PATCH 05/11] RHEL support and improvements
 - Remove old kernels
 - Add dracut cmd to generate initramfs with all drivers for rhel raw
 - Add proxy, register with satellite, and pull packages from satellite support to redhat subscription manager
+- Fix Goss variables for RHEL-based images
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---
- images/capi/ansible/roles/node/tasks/main.yml |  3 +
- .../capi/ansible/roles/node/tasks/redhat.yml  | 32 +++++++
- .../capi/ansible/roles/setup/tasks/redhat.yml | 83 +++++++++++++++++++
- images/capi/packer/config/ansible-args.json   |  2 +-
- 4 files changed, 119 insertions(+), 1 deletion(-)
+ images/capi/ansible/roles/node/tasks/main.yml |   3 +
+ .../capi/ansible/roles/node/tasks/redhat.yml  |  32 +++++
+ .../capi/ansible/roles/setup/tasks/redhat.yml |  83 +++++++++++++
+ images/capi/packer/config/ansible-args.json   |   2 +-
+ images/capi/packer/goss/goss-vars.yaml        | 109 +++++++++++-------
+ 5 files changed, 187 insertions(+), 42 deletions(-)
  create mode 100644 images/capi/ansible/roles/node/tasks/redhat.yml
 
 diff --git a/images/capi/ansible/roles/node/tasks/main.yml b/images/capi/ansible/roles/node/tasks/main.yml
@@ -181,6 +183,211 @@ index 435797c65..e97099f63 100644
 +  "ansible_common_vars": "containerd_url={{user `containerd_url`}} containerd_sha256={{user `containerd_sha256`}} pause_image={{user `pause_image`}} containerd_additional_settings={{user `containerd_additional_settings`}} containerd_cri_socket={{user `containerd_cri_socket`}} containerd_version={{user `containerd_version`}} containerd_wasm_shims_url={{user `containerd_wasm_shims_url`}} containerd_wasm_shims_version={{user `containerd_wasm_shims_version`}} containerd_wasm_shims_sha256={{user `containerd_wasm_shims_sha256`}} containerd_wasm_shims_runtimes=\"{{user `containerd_wasm_shims_runtimes`}}\" containerd_wasm_shims_runtime_versions=\"{{user `containerd_wasm_shims_runtime_versions`}}\" crictl_url={{user `crictl_url`}} crictl_sha256={{user `crictl_sha256`}} crictl_source_type={{user `crictl_source_type`}} custom_role_names=\"{{user `custom_role_names`}}\" firstboot_custom_roles_pre=\"{{user `firstboot_custom_roles_pre`}}\" firstboot_custom_roles_post=\"{{user `firstboot_custom_roles_post`}}\" node_custom_roles_pre=\"{{user `node_custom_roles_pre`}}\" node_custom_roles_post=\"{{user `node_custom_roles_post`}}\" disable_public_repos={{user `disable_public_repos`}} extra_debs=\"{{user `extra_debs`}}\" extra_repos=\"{{user `extra_repos`}}\" extra_rpms=\"{{user `extra_rpms`}}\" http_proxy={{user `http_proxy`}} https_proxy={{user `https_proxy`}} kubeadm_template={{user `kubeadm_template`}} kubernetes_apiserver_port={{user `kubernetes_apiserver_port`}} kubernetes_cni_http_source={{user `kubernetes_cni_http_source`}} kubernetes_cni_http_checksum={{user `kubernetes_cni_http_checksum`}} kubernetes_goarch={{user `kubernetes_goarch`}} kubernetes_http_source={{user `kubernetes_http_source`}} kubernetes_container_registry={{user `kubernetes_container_registry`}} kubernetes_rpm_repo={{user `kubernetes_rpm_repo`}} kubernetes_rpm_gpg_key={{user `kubernetes_rpm_gpg_key`}} kubernetes_rpm_gpg_check={{user `kubernetes_rpm_gpg_check`}} kubernetes_deb_repo={{user `kubernetes_deb_repo`}} kubernetes_deb_gpg_key={{user `kubernetes_deb_gpg_key`}} kubernetes_cni_deb_version={{user `kubernetes_cni_deb_version`}} kubernetes_cni_rpm_version={{user `kubernetes_cni_rpm_version`}} kubernetes_cni_semver={{user `kubernetes_cni_semver`}} kubernetes_cni_source_type={{user `kubernetes_cni_source_type`}} kubernetes_semver={{user `kubernetes_semver`}} kubernetes_source_type={{user `kubernetes_source_type`}} kubernetes_load_additional_imgs={{user `kubernetes_load_additional_imgs`}} kubernetes_deb_version={{user `kubernetes_deb_version`}} kubernetes_rpm_version={{user `kubernetes_rpm_version`}} no_proxy={{user `no_proxy`}} pip_conf_file={{user `pip_conf_file`}} python_path={{user `python_path`}} redhat_epel_rpm={{user `redhat_epel_rpm`}} epel_rpm_gpg_key={{user `epel_rpm_gpg_key`}} reenable_public_repos={{user `reenable_public_repos`}} remove_extra_repos={{user `remove_extra_repos`}} systemd_prefix={{user `systemd_prefix`}} sysusr_prefix={{user `sysusr_prefix`}} sysusrlocal_prefix={{user `sysusrlocal_prefix`}} load_additional_components={{ user `load_additional_components`}} additional_registry_images={{ user `additional_registry_images`}} additional_registry_images_list={{ user `additional_registry_images_list`}} additional_url_images={{ user `additional_url_images`}} additional_url_images_list={{ user `additional_url_images_list`}} additional_executables={{ user `additional_executables`}} additional_executables_list={{ user `additional_executables_list`}} additional_executables_destination_path={{ user `additional_executables_destination_path`}} additional_s3={{ user `additional_s3`}} build_target={{ user `build_target`}} amazon_ssm_agent_rpm={{ user `amazon_ssm_agent_rpm` }} enable_containerd_audit={{ user `enable_containerd_audit` }} kubernetes_enable_automatic_resource_sizing={{ user `kubernetes_enable_automatic_resource_sizing` }} debug_tools={{user `debug_tools`}} ubuntu_repo={{user `ubuntu_repo`}} ubuntu_security_repo={{user `ubuntu_security_repo`}} etcd_http_source={{user `etcd_http_source`}} etcd_version={{user `etcd_version`}} etcdadm_http_source={{user `etcdadm_http_source`}} etcd_sha256={{user `etcd_sha256`}} etcdadm_version={{user `etcdadm_version`}} rhsm_server_hostname={{ user `rhsm_server_hostname` }} rhsm_server_release_version={{ user `rhsm_server_release_version` }} rhsm_server_proxy_hostname={{ user `rhsm_server_proxy_hostname` }} rhsm_server_proxy_port={{ user `rhsm_server_proxy_port` }}",
    "ansible_scp_extra_args": "{{env `ANSIBLE_SCP_EXTRA_ARGS`}}"
  }
+diff --git a/images/capi/packer/goss/goss-vars.yaml b/images/capi/packer/goss/goss-vars.yaml
+index 28caefb31..3da31c025 100644
+--- a/images/capi/packer/goss/goss-vars.yaml
++++ b/images/capi/packer/goss/goss-vars.yaml
+@@ -150,7 +150,10 @@ centos:
+   amazon:
+     package:
+       amazon-ssm-agent:
+-      <<: *rh7_rpms
++    os_version:
++    - distro_version: "7"
++      package:
++        <<: *rh7_rpms
+     command:
+       /usr/local/sbin/aws --version:
+         exit-status: 0
+@@ -163,19 +166,23 @@ centos:
+     package:
+       python2-pip:
+       open-vm-tools:
+-      <<: *rh7_rpms
++    os_version:
++    - distro_version: "7"
++      package:
++        <<: *rh7_rpms
+   qemu:
+     package:
+       open-vm-tools:
+       cloud-init:
+       cloud-utils-growpart:
+-      python2-pip:
+-      <<: *rh7_rpms
+-  raw:
+-    package:
+-      cloud-init:
+-      cloud-utils-growpart:
+-      python2-pip:
++    os_version:
++    - distro_version: "7"
++      package:
++        python2-pip:
++        <<: *rh7_rpms
++    - distro_version: "9"
++      package:
++        <<: *rh9_rpms
+   hcloud:
+     package:
+       cloud-init:
+@@ -255,7 +262,10 @@ rockylinux:
+   amazon:
+     package:
+       amazon-ssm-agent:
+-      <<: *rh8_rpms
++    os_version:
++    - distro_version: "8"
++      package:
++        <<: *rh8_rpms
+     command:
+       /usr/local/sbin/aws --version:
+         exit-status: 0
+@@ -269,10 +279,6 @@ rockylinux:
+     package:
+       open-vm-tools:
+     os_version:
+-    - distro_version: "7"
+-      package:
+-        python2-pip:
+-        <<: *rh7_rpms
+     - distro_version: "8"
+       package:
+         python2-pip:
+@@ -285,23 +291,27 @@ rockylinux:
+       open-vm-tools:
+       cloud-init:
+       cloud-utils:
+-      python3-netifaces:
+-      <<: *rh8_rpms
+-  raw:
+-    package:
+-      cloud-init:
+-      cloud-utils:
+-      python3-netifaces:
+-      <<: *rh8_rpms
++    os_version:
++    - distro_version: "8"
++      package:
++        <<: *rh8_rpms
++    - distro_version: "9"
++      package:
++        <<: *rh9_rpms
+   nutanix:
+     package:
+       cloud-init:
+-      python3-netifaces:
+       iscsi-initiator-utils:
+       nfs-utils:
+       lvm2:
+       xfsprogs:
+-      <<: *rh8_rpms
++    os_version:
++    - distro_version: "8"
++      package:
++        <<: *rh8_rpms
++    - distro_version: "9"
++      package:
++        <<: *rh9_rpms
+     service:
+       iscsid:
+         enabled: true
+@@ -310,17 +320,19 @@ rockylinux:
+     package:
+       cloud-init:
+       cloud-utils-growpart:
+-      python3-netifaces:
+-      <<: *rh8_rpms
++    os_version:
++    - distro_version: "8"
++      package:
++        <<: *rh8_rpms
+ rhel:
+   common-package: *common_rpms
+   amazon:
+     package:
+       amazon-ssm-agent:
+     os_version:
+-      - distro_version: "8"
+-        package:
+-          <<: *rh8_rpms
++    - distro_version: "8"
++      package:
++        <<: *rh8_rpms
+     command:
+       /usr/local/sbin/aws --version:
+         exit-status: 0
+@@ -334,9 +346,9 @@ rhel:
+     package:
+       open-vm-tools:
+     os_version:
+-      - distro_version: "8"
+-        package:
+-          <<: *rh8_rpms
++    - distro_version: "8"
++      package:
++        <<: *rh8_rpms
+   gcp:
+     command:
+       find -L /bin -maxdepth 1 -type f -executable -printf "%f\n" | grep -Fx 'gcloud':
+@@ -345,9 +357,9 @@ rhel:
+         stderr: []
+         timeout: 0
+     os_version:
+-      - distro_version: "8"
+-        package:
+-          <<: *rh8_rpms
++    - distro_version: "8"
++      package:
++        <<: *rh8_rpms
+   ova:
+     package:
+       open-vm-tools:
+@@ -368,23 +380,38 @@ rhel:
+       open-vm-tools:
+       cloud-init:
+       cloud-utils-growpart:
+-      python2-pip:
+-      <<: *rh7_rpms
++    os_version:
++    - distro_version: "8"
++      package:
++        <<: *rh8_rpms
++    - distro_version: "9"
++      package:
++        <<: *rh9_rpms
+   raw:
+     package:
+       cloud-init:
+       cloud-utils-growpart:
+-      python2-pip:
+-      <<: *rh7_rpms
++    os_version:
++    - distro_version: "8"
++      package:
++        <<: *rh8_rpms
++    - distro_version: "9"
++      package:
++        <<: *rh9_rpms
+   nutanix:
+     package:
+       cloud-init:
+-      python3-netifaces:
+       iscsi-initiator-utils:
+       nfs-utils:
+       lvm2:
+       xfsprogs:
+-      <<: *rh8_rpms
++    os_version:
++    - distro_version: "8"
++      package:
++        <<: *rh8_rpms
++    - distro_version: "9"
++      package:
++        <<: *rh9_rpms
+     service:
+       iscsid:
+         enabled: true
 -- 
 2.46.1
 

--- a/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-improvements.patch
@@ -1,7 +1,7 @@
-From ef2b80283c5bbf13cffa13b063c7b818b735b518 Mon Sep 17 00:00:00 2001
+From 9d0fa760a2af66d867c939a866d0b7686d80eb38 Mon Sep 17 00:00:00 2001
 From: Ilya Alekseyev <ilya.alekseyev@nutanix.com>
 Date: Wed, 11 Oct 2023 22:07:22 -0400
-Subject: [PATCH 06/11] Nutanix improvements
+Subject: [PATCH 06/12] Nutanix improvements
 
 - Fetch Nutanix RHEL source image URL from environment
 - Force-delete Nutanix builder VMs on failure

--- a/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
@@ -1,7 +1,7 @@
-From 4f4496bf2e4a723551b0531798ed014e7d533520 Mon Sep 17 00:00:00 2001
-From: Prow Bot <prow@amazonaws.com>
+From 8f392c3948767bccb3930d99ab2dff91044651d4 Mon Sep 17 00:00:00 2001
+From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Mon, 21 Aug 2023 18:40:07 -0500
-Subject: [PATCH 07/11] adds retries and timeout to packer image-builder
+Subject: [PATCH 07/12] adds retries and timeout to packer image-builder
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0008-Networking-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0008-Networking-improvements.patch
@@ -1,7 +1,7 @@
-From 64ee8edfbf2992280f1d3eeb235618b2ef6d502e Mon Sep 17 00:00:00 2001
+From 19788b18a692cbabc10b31012ad8c4a51a1e0e1f Mon Sep 17 00:00:00 2001
 From: Taylor Neyland <tneyla@amazon.com>
 Date: Wed, 19 Jul 2023 12:51:30 -0500
-Subject: [PATCH 08/11] Networking improvements
+Subject: [PATCH 08/12] Networking improvements
 
 - Disable UDP offload service for Redhat and Ubuntu
 - Default Flatcar version to avoid pulling from internet on every make

--- a/projects/kubernetes-sigs/image-builder/patches/0009-Support-and-improvements-for-RHEL-9-EFI.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0009-Support-and-improvements-for-RHEL-9-EFI.patch
@@ -1,7 +1,7 @@
-From 9eef45b1e4afd1fcff9f060ba63c3ce4f832f337 Mon Sep 17 00:00:00 2001
+From 0e92fecfa44298d620e1d019454faeabc8b3dd3a Mon Sep 17 00:00:00 2001
 From: Shizhao Liu <lshizhao@amazon.com>
 Date: Mon, 19 Aug 2024 10:14:26 -0700
-Subject: [PATCH 09/11] Support and improvements for RHEL 9 EFI
+Subject: [PATCH 09/12] Support and improvements for RHEL 9 EFI
 
 1. Remove 2 unwanted partitions (the swap partition and /boot
 partition).

--- a/projects/kubernetes-sigs/image-builder/patches/0010-Pin-Packer-Goss-plugin-version-to-3.1.4.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0010-Pin-Packer-Goss-plugin-version-to-3.1.4.patch
@@ -1,7 +1,7 @@
-From 490c1887a0a37c55d383d1ca2f4ba28ca5424901 Mon Sep 17 00:00:00 2001
+From 9891cfd0e3c9dab94100f6e2b133b49fd3132e24 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 19 Sep 2024 15:36:00 -0700
-Subject: [PATCH 10/11] Pin Packer Goss plugin version to 3.1.4
+Subject: [PATCH 10/12] Pin Packer Goss plugin version to 3.1.4
 
 Upstream image-builder moved from installing packer-provisioner-goss through a script to installing it
 via Packer config (https://github.com/kubernetes-sigs/image-builder/commit/c0b70ae37c4aac14c156fc7b907a9b35147757df).

--- a/projects/kubernetes-sigs/image-builder/patches/0011-Remove-containerd-configuration-for-hosts.toml-paths.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0011-Remove-containerd-configuration-for-hosts.toml-paths.patch
@@ -1,7 +1,7 @@
-From bad3e90d17f0b9bd6d516f8ad18fde0c9592a582 Mon Sep 17 00:00:00 2001
+From 2e31fec812d7eca2e90ee6d5f747f5e98c042bb5 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 19 Sep 2024 16:04:19 -0700
-Subject: [PATCH 11/11] Remove containerd configuration for hosts.toml paths
+Subject: [PATCH 11/12] Remove containerd configuration for hosts.toml paths
 
 In EKS Anywhere, we're still using the older containerd config template (v2), so setting the
 config_path in the containerd config file causes errors like "invalid plugin config: `mirrors`

--- a/projects/kubernetes-sigs/image-builder/patches/0012-Revert-updating-preseed-and-cloud-init-to-use-CD-for.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0012-Revert-updating-preseed-and-cloud-init-to-use-CD-for.patch
@@ -1,0 +1,177 @@
+From 44750ef8da75a7d55b901896e2bc10226598de80 Mon Sep 17 00:00:00 2001
+From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
+Date: Thu, 19 Sep 2024 18:52:00 -0700
+Subject: [PATCH 12/12] Revert updating preseed and cloud-init to use CD for
+ boot files
+
+We are reverting the upstream change that updated preseed and cloud-init scripts
+to be obtained from CD, with the help of xorriso for image builds. We will continue
+to use floppy drives to mount the boot files until we add xorriso to the builder image.
+ 
+Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
+---
+ images/capi/Dockerfile                      | 2 --
+ images/capi/packer/ova/packer-node.json     | 4 ----
+ images/capi/packer/ova/photon-5.json        | 6 ++----
+ images/capi/packer/ova/ubuntu-2204-efi.json | 6 ++----
+ images/capi/packer/ova/ubuntu-2204.json     | 7 +++----
+ images/capi/packer/ova/ubuntu-2404-efi.json | 7 +++----
+ images/capi/packer/ova/ubuntu-2404.json     | 7 +++----
+ images/capi/scripts/ci-ova.sh               | 3 ---
+ 8 files changed, 13 insertions(+), 29 deletions(-)
+
+diff --git a/images/capi/Dockerfile b/images/capi/Dockerfile
+index 18a4dd00e..62e767c7d 100644
+--- a/images/capi/Dockerfile
++++ b/images/capi/Dockerfile
+@@ -31,8 +31,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+ 	wget \
+ 	qemu-system-x86 \
+ 	qemu-kvm \
+-	# Adding xorriso to create iso for mounting cd_drives which then can be used for bootstrapping node image
+-	xorriso \
+ 	&& useradd -ms /bin/bash imagebuilder \
+ 	&& apt-get purge --auto-remove -y \
+ 	&& rm -rf /var/lib/apt/lists/*
+diff --git a/images/capi/packer/ova/packer-node.json b/images/capi/packer/ova/packer-node.json
+index 3d0c3ed11..54e518181 100644
+--- a/images/capi/packer/ova/packer-node.json
++++ b/images/capi/packer/ova/packer-node.json
+@@ -203,8 +203,6 @@
+         "{{user `boot_command_suffix`}}"
+       ],
+       "boot_wait": "{{user `boot_wait`}}",
+-      "cd_files": "{{user `cd_content_location`}}",
+-      "cd_label": "{{user `cd_label`}}",
+       "cdrom_type": "{{user `cdrom_type`}}",
+       "cluster": "{{user `cluster`}}",
+       "communicator": "ssh",
+@@ -486,8 +484,6 @@
+     "block_nouveau_loading": "true",
+     "build_timestamp": "{{timestamp}}",
+     "build_version": "{{user `build_name`}}-kube-{{user `kubernetes_semver`}}",
+-    "cd_files": "{{user `cd_content_location`}}",
+-    "cd_label": "{{user `cd_label`}}",
+     "cdrom_adapter_type": "ide",
+     "cdrom_type": "ide",
+     "cluster": "",
+diff --git a/images/capi/packer/ova/photon-5.json b/images/capi/packer/ova/photon-5.json
+index 612c552c0..82b5fa949 100644
+--- a/images/capi/packer/ova/photon-5.json
++++ b/images/capi/packer/ova/photon-5.json
+@@ -1,10 +1,8 @@
+ {
+   "boot_command_prefix": "<esc><wait> vmlinuz initrd=initrd.img root/dev/ram0 loglevel=3 photon.media=cdrom ks=",
+-  "boot_command_suffix": " insecure_installation=1<enter><wait>",
+-  "boot_media_path": "/dev/sr1:/5/ks.json",
++  "boot_command_suffix": "/5/ks.json insecure_installation=1<enter><wait>",
++  "boot_media_path": "http://{{ .HTTPIP }}:{{ .HTTPPort }}",
+   "build_name": "photon-5",
+-  "cd_content_location": "./packer/ova/linux/{{user `distro_name`}}/http/*",
+-  "cd_label": "cidata",
+   "cdrom_type": "sata",
+   "distro_arch": "amd64",
+   "distro_name": "photon",
+diff --git a/images/capi/packer/ova/ubuntu-2204-efi.json b/images/capi/packer/ova/ubuntu-2204-efi.json
+index 85b548009..67ec60e7f 100644
+--- a/images/capi/packer/ova/ubuntu-2204-efi.json
++++ b/images/capi/packer/ova/ubuntu-2204-efi.json
+@@ -1,15 +1,13 @@
+ {
+-  "boot_command_prefix": "c<wait>linux /casper/vmlinuz ipv6.disable={{ user `boot_disable_ipv6` }} --- autoinstall ds='nocloud;'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
++  "boot_command_prefix": "c<wait>linux /casper/vmlinuz ipv6.disable={{ user `boot_disable_ipv6` }} --- autoinstall ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/22.04.efi/'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
+   "boot_disable_ipv6": "0",
+   "boot_media_path": "/media/HTTP",
+   "build_name": "ubuntu-2204-efi",
+-  "cd_content_location": "./packer/ova/linux/{{user `distro_name`}}/http/22.04.efi/*",
+-  "cd_label": "cidata",
+   "distro_arch": "amd64",
+   "distro_name": "ubuntu",
+   "distro_version": "22.04",
+   "firmware": "efi",
+-  "floppy_dirs": "",
++  "floppy_dirs": "./packer/ova/linux/{{user `distro_name`}}/http/",
+   "guest_os_type": "ubuntu-64",
+   "iso_checksum": "9bc6028870aef3f74f4e16b900008179e78b130e6b0b9a140635434a46aa98b0",
+   "iso_checksum_type": "sha256",
+diff --git a/images/capi/packer/ova/ubuntu-2204.json b/images/capi/packer/ova/ubuntu-2204.json
+index 85991d07c..7cadf0227 100644
+--- a/images/capi/packer/ova/ubuntu-2204.json
++++ b/images/capi/packer/ova/ubuntu-2204.json
+@@ -1,13 +1,12 @@
+ {
+-  "boot_command_prefix": "c<wait>linux /casper/vmlinuz ipv6.disable={{ user `boot_disable_ipv6` }} --- autoinstall ds='nocloud;'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
++  "boot_command_prefix": "c<wait>linux /casper/vmlinuz ipv6.disable={{ user `boot_disable_ipv6` }} --- autoinstall ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/22.04/'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
+   "boot_disable_ipv6": "0",
++  "boot_media_path": "/media/HTTP",
+   "build_name": "ubuntu-2204",
+-  "cd_content_location": "./packer/ova/linux/{{user `distro_name`}}/http/{{user `distro_version`}}/*",
+-  "cd_label": "cidata",
+   "distro_arch": "amd64",
+   "distro_name": "ubuntu",
+   "distro_version": "22.04",
+-  "floppy_dirs": "",
++  "floppy_dirs": "./packer/ova/linux/{{user `distro_name`}}/http/",
+   "guest_os_type": "ubuntu-64",
+   "iso_checksum": "9bc6028870aef3f74f4e16b900008179e78b130e6b0b9a140635434a46aa98b0",
+   "iso_checksum_type": "sha256",
+diff --git a/images/capi/packer/ova/ubuntu-2404-efi.json b/images/capi/packer/ova/ubuntu-2404-efi.json
+index bd97ca36e..6ec6e6176 100644
+--- a/images/capi/packer/ova/ubuntu-2404-efi.json
++++ b/images/capi/packer/ova/ubuntu-2404-efi.json
+@@ -1,14 +1,13 @@
+ {
+-  "boot_command_prefix": "c<wait>linux /casper/vmlinuz ipv6.disable={{ user `boot_disable_ipv6` }} --- autoinstall ds='nocloud;'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
++  "boot_command_prefix": "c<wait>linux /casper/vmlinuz ipv6.disable={{ user `boot_disable_ipv6` }} --- autoinstall ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/24.04.efi/'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
+   "boot_disable_ipv6": "0",
++  "boot_media_path": "/media/HTTP",
+   "build_name": "ubuntu-2404-efi",
+-  "cd_content_location": "./packer/ova/linux/{{user `distro_name`}}/http/24.04.efi/*",
+-  "cd_label": "cidata",
+   "distro_arch": "amd64",
+   "distro_name": "ubuntu",
+   "distro_version": "24.04",
+   "firmware": "efi",
+-  "floppy_dirs": "",
++  "floppy_dirs": "./packer/ova/linux/{{user `distro_name`}}/http/",
+   "guest_os_type": "ubuntu-64",
+   "iso_checksum": "e240e4b801f7bb68c20d1356b60968ad0c33a41d00d828e74ceb3364a0317be9",
+   "iso_checksum_type": "sha256",
+diff --git a/images/capi/packer/ova/ubuntu-2404.json b/images/capi/packer/ova/ubuntu-2404.json
+index 200d18ea7..1289c31b0 100644
+--- a/images/capi/packer/ova/ubuntu-2404.json
++++ b/images/capi/packer/ova/ubuntu-2404.json
+@@ -1,13 +1,12 @@
+ {
+-  "boot_command_prefix": "c<wait>linux /casper/vmlinuz ipv6.disable={{ user `boot_disable_ipv6` }} --- autoinstall ds='nocloud;'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
++  "boot_command_prefix": "c<wait>linux /casper/vmlinuz ipv6.disable={{ user `boot_disable_ipv6` }} --- autoinstall ds='nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/24.04/'<enter><wait>initrd /casper/initrd<enter><wait>boot<enter>",
+   "boot_disable_ipv6": "0",
++  "boot_media_path": "/media/HTTP",
+   "build_name": "ubuntu-2404",
+-  "cd_content_location": "./packer/ova/linux/{{user `distro_name`}}/http/{{user `distro_version`}}/*",
+-  "cd_label": "cidata",
+   "distro_arch": "amd64",
+   "distro_name": "ubuntu",
+   "distro_version": "24.04",
+-  "floppy_dirs": "",
++  "floppy_dirs": "./packer/ova/linux/{{user `distro_name`}}/http/",
+   "guest_os_type": "ubuntu-64",
+   "iso_checksum": "e240e4b801f7bb68c20d1356b60968ad0c33a41d00d828e74ceb3364a0317be9",
+   "iso_checksum_type": "sha256",
+diff --git a/images/capi/scripts/ci-ova.sh b/images/capi/scripts/ci-ova.sh
+index 683670a35..5794d876c 100755
+--- a/images/capi/scripts/ci-ova.sh
++++ b/images/capi/scripts/ci-ova.sh
+@@ -75,9 +75,6 @@ export GOVC_DATACENTER="SDDC-Datacenter"
+ export GOVC_CLUSTER="Cluster-1"
+ export GOVC_INSECURE=true
+ 
+-# Install xorriso which will be then used by packer to generate ISO for generating CD files
+-apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y xorriso
+-
+ # Run the vpn client in container
+ docker run --rm -d --name vpn -v "${HOME}/.openvpn/:${HOME}/.openvpn/" \
+   -w "${HOME}/.openvpn/" --cap-add=NET_ADMIN --net=host --device=/dev/net/tun \
+-- 
+2.46.1
+


### PR DESCRIPTION
This PR
* Brings back [this](https://github.com/aws/eks-anywhere-build-tooling/commit/3047eee74b2d54f6406a0f469cb3c72fde300822#diff-a1179b5f7cbfbe758c70dfad87aeeecdc87853c41b381b18defd56180b02f7c2) image-builder patch that was necessary for image-builder >= 0.1.31, but was removed when we moved back to v0.1.30. This change fixes Ubuntu 22.04 OVA builds
* Adds [this](https://github.com/kubernetes-sigs/image-builder/pull/1569) upstream image-builder fix as a patch to fix RHEL 8/0 QEMU/raw builds.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
