### PR TITLE
fixes support for efi on rhel 9 raw builds

### DIFF
--- a/projects/aws/image-builder/Makefile
+++ b/projects/aws/image-builder/Makefile
@@ -34,6 +34,9 @@ EXTRA_GOBUILD_FLAGS=-buildvcs=false
 
 include $(BASE_DIRECTORY)/Common.mk
 
+
+build: unit-test
+
 $(REPO):
 	@mkdir $@
 	source $(BUILD_LIB)/common.sh && retry git clone --depth 1 --filter=blob:none --sparse -b $(BRANCH_NAME) $(EKS_ANYWHERE_CLONE_URL) $(EKS_ANYWHERE_REPO)
@@ -58,8 +61,9 @@ clean-extra:
 
 clean: clean-extra
 
-unit-test:
-	go test ./...
+unit-test: | $$(ENABLE_DOCKER)
+	@source $(BUILD_LIB)/common.sh && build::common::use_go_version $(GOLANG_VERSION); \
+	go test -v ./...
 
 
 ########### DO NOT EDIT #############################

--- a/projects/aws/image-builder/builder/builder.go
+++ b/projects/aws/image-builder/builder/builder.go
@@ -203,11 +203,7 @@ func (b *BuildOptions) BuildImage() {
 		case Ubuntu:
 			buildCommand = fmt.Sprintf("make -C %s local-build-raw-ubuntu-%s", imageBuilderProjectPath, b.OsVersion)
 		case RedHat:
-			if b.Firmware == EFI {
-				buildCommand = fmt.Sprintf("make -C %s local-build-raw-redhat-%s-efi", imageBuilderProjectPath, b.OsVersion)
-			} else {
-				buildCommand = fmt.Sprintf("make -C %s local-build-raw-redhat-%s", imageBuilderProjectPath, b.OsVersion)
-			}
+			buildCommand = fmt.Sprintf("make -C %s local-build-raw-redhat-%s", imageBuilderProjectPath, b.OsVersion)
 			commandEnvVars = append(commandEnvVars,
 				fmt.Sprintf("%s=%s", rhelUsernameEnvVar, b.BaremetalConfig.RhelUsername),
 				fmt.Sprintf("%s=%s", rhelPasswordEnvVar, b.BaremetalConfig.RhelPassword),

--- a/projects/aws/image-builder/builder/utils_test.go
+++ b/projects/aws/image-builder/builder/utils_test.go
@@ -2,13 +2,25 @@ package builder
 
 import (
 	"os"
+	"path"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
+func init() {
+	_, filename, _, _ := runtime.Caller(0)
+	// change to the parent folder of the eks-anywhere-build-tooling
+	dir := path.Join(path.Dir(filename), "..", "..", "..", "..", "..")
+	err := os.Chdir(dir)
+	if err != nil {
+		panic(err)
+	}
+}
+
 func TestGetSupportedReleaseBranchesSuccess(t *testing.T) {
 	b := BuildOptions{
-		ReleaseChannel: "1-24",
+		ReleaseChannel: "1-30",
 	}
 
 	supportedReleaseBranches := GetSupportedReleaseBranches()
@@ -109,11 +121,9 @@ func TestSetRhsmProxy(t *testing.T) {
 }
 
 func TestDownloadFile(t *testing.T) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Error getting current working dir: %v", err)
-	}
-	testDir := filepath.Join(cwd, "testdata")
+	_, filename, _, _ := runtime.Caller(0)
+	// change to the parent folder of the eks-anywhere-build-tooling
+	testDir := path.Join(path.Dir(filename), "testdata")
 	os.MkdirAll(testDir, 0o755)
 	testcases := []struct {
 		name    string


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We only support efi for rhel 9 and currently if firmware is set to efi when calling image-builder it will end up getting the efi appended again.  This changes the image builder to only support firmware efi for rhel 9 raw.

~We need a change to the codebuild job to set this when building rhel 9 raw.~

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
