### PR TITLE
Add Go version configuration for Linuxkit project

### DIFF
--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -142,6 +142,11 @@ var (
 			BinaryName:       "linux-amd64/helm",
 			Extract:          true,
 		},
+		"linuxkit/linuxkit": {
+			AssetName:  "linuxkit-linux-amd64",
+			BinaryName: "linuxkit-linux-amd64",
+			Extract:    false,
+		},
 		"kubernetes-sigs/cluster-api": {
 			AssetName:  "clusterctl-linux-amd64",
 			BinaryName: "clusterctl-linux-amd64",
@@ -258,6 +263,10 @@ var (
 		},
 		"helm/helm": {
 			SourceOfTruthFile:     ".github/workflows/release.yaml",
+			GoVersionSearchString: `go-version: '(1\.\d\d)'`,
+		},
+		"linuxkit/linuxkit": {
+			SourceOfTruthFile:     ".github/workflows/release.yml",
 			GoVersionSearchString: `go-version: '(1\.\d\d)'`,
 		},
 		"kube-vip/kube-vip": {


### PR DESCRIPTION
Adding Go version configuration for Linuxkit project. This will be used to detect the correct Go version to use when upgrading to the latest upstream release.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
