### PR TITLE
fix yq usage to support fake yq

### DIFF
--- a/projects/kubernetes-sigs/image-builder/build/validate_required_deps.sh
+++ b/projects/kubernetes-sigs/image-builder/build/validate_required_deps.sh
@@ -47,7 +47,7 @@ if [ "${EKSA_SKIP_VALIDATE_DEPENDENCIES:-false}" = "true" ]; then
 fi
 
 # ansible
-ANSIBLE_VERSION=$(yq ".ansible" $DEPENDENCY_YAML)
+ANSIBLE_VERSION=$(yq -r ".ansible" $DEPENDENCY_YAML)
 if [[ "$(ansible --version | head -n 1)" != *"[core $ANSIBLE_VERSION]"* ]]; then
     echo "The version of ansible-core ($(ansible --version | head -n 1)) does not match the version ($ANSIBLE_VERSION) which has been tested by the EKS-A team."
     echo "    (Recommened) Remove this version and rerun your image build and the correct version of ansible-core will be installed."
@@ -56,7 +56,7 @@ if [[ "$(ansible --version | head -n 1)" != *"[core $ANSIBLE_VERSION]"* ]]; then
 fi
 
 # packer
-PACKER_VERSION=$(yq ".packer.version" $DEPENDENCY_YAML)
+PACKER_VERSION=$(yq -r ".packer.version" $DEPENDENCY_YAML)
 if [[ "$(packer --version)" != "$PACKER_VERSION" ]]; then
     echo "The version of packer ($(packer --version)) does not match the version ($PACKER_VERSION) which has been tested by the EKS-A team."
     echo "    (Recommened) Remove this version and rerun your image build and the correct version of packer will be installed."
@@ -65,7 +65,7 @@ if [[ "$(packer --version)" != "$PACKER_VERSION" ]]; then
 fi
 
 # ansible plugin
-PACKER_PLUGIN_ANSIBLE=$(yq ".packer.plugins.ansible" $DEPENDENCY_YAML)
+PACKER_PLUGIN_ANSIBLE=$(yq -r ".packer.plugins.ansible" $DEPENDENCY_YAML)
 if [[ "$(packer plugins installed | grep plugin-ansible)" != *"v$PACKER_PLUGIN_ANSIBLE"* ]]; then
     echo "The version of packer-plugin-ansible does not match the version ($PACKER_PLUGIN_ANSIBLE) which has been tested by the EKS-A team."
     echo "Current plugin: $(packer plugins installed | grep plugin-ansible)"
@@ -73,7 +73,7 @@ if [[ "$(packer plugins installed | grep plugin-ansible)" != *"v$PACKER_PLUGIN_A
 fi
 
 # nutanix plugn
-PACKER_PLUGIN_NUTANIX=$(yq ".packer.plugins.nutanix" $DEPENDENCY_YAML)
+PACKER_PLUGIN_NUTANIX=$(yq -r ".packer.plugins.nutanix" $DEPENDENCY_YAML)
 if [ "${IMAGE_FORMAT}" = "nutanix" ] && [[ "$(packer plugins installed | grep plugin-nutanix)" != *"v$PACKER_PLUGIN_NUTANIX"* ]]; then
     echo "The version of packer-plugin-nutanix does not match the version ($PACKER_PLUGIN_NUTANIX) which has been tested by the EKS-A team."
     echo "Current plugin: $(packer plugins installed | grep plugin-nutanix)"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We have run into an issue a couple times now where on Ubuntu 24.04 a version of yq is included but it is not the correct yq.  The noticable issue is that return values are double quoted.  The -r tells yq to remove the double quotes, which works with both the correct and incorrect version of yq.

We probably should add a more complete fix here where we validate the source of yq, but I *think* this will avoid the current pain during the image-builder flow since we dont use yq too much.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
