### PR TITLE
boots uses eksa ipxedust

### DIFF
--- a/projects/tinkerbell/boots/CHECKSUMS
+++ b/projects/tinkerbell/boots/CHECKSUMS
@@ -1,2 +1,2 @@
-84ce3a91828040164ed2c9e7f5050a613f337838605e6e5baa2ba226eb28dae6  _output/bin/boots/linux-amd64/smee
-56eefe4d4a8686428d2417aeb54b48809753a5617f4739437402ef135c3d8598  _output/bin/boots/linux-arm64/smee
+24e93381f9030db984849cfa856600fafd17a6811779943a60342e500d1d5fb1  _output/bin/boots/linux-amd64/smee
+f96b2525354e518b126a70d061be0af6fa3610f05c5c49d70ff4b857b709faa4  _output/bin/boots/linux-arm64/smee

--- a/projects/tinkerbell/boots/Help.mk
+++ b/projects/tinkerbell/boots/Help.mk
@@ -21,6 +21,10 @@ images: ## Pushes `boots/images/push` to IMAGE_REPO
 boots/images/amd64: ## Builds/pushes `boots/images/amd64`
 boots/images/push: ## Builds/pushes `boots/images/push`
 
+##@ Fetch Binary Targets
+_output/dependencies/linux-amd64/eksa/tinkerbell/ipxedust: ## Fetch `_output/dependencies/linux-amd64/eksa/tinkerbell/ipxedust`
+_output/dependencies/linux-arm64/eksa/tinkerbell/ipxedust: ## Fetch `_output/dependencies/linux-arm64/eksa/tinkerbell/ipxedust`
+
 ##@ Checksum Targets
 checksums: ## Update checksums file based on currently built binaries.
 validate-checksums: # Validate checksums of currently built binaries against checksums file.

--- a/projects/tinkerbell/boots/Makefile
+++ b/projects/tinkerbell/boots/Makefile
@@ -15,7 +15,22 @@ EXTRA_GO_LDFLAGS=-X main.GitRev=${GITREV}
 
 EXCLUDE_FROM_UPGRADE_BUILDSPEC=true
 
+PROJECT_DEPENDENCIES=eksa/tinkerbell/ipxedust
+BUILDSPEC_DEPENDS_ON_OVERRIDE=tinkerbell_ipxedust_linux_amd64 tinkerbell_ipxedust_linux_arm64
+
+OVERRIDE_VENDOR_BINARIES_TARGET=$(REPO)/vendor/github.com/tinkerbell/ipxedust/binary/eks-a-overridden
+
 include $(BASE_DIRECTORY)/Common.mk
+
+
+# smee embeds the ipxe binarys into the final go bin
+# overriding them with the ones built via eks-a build tooling
+$(OVERRIDE_VENDOR_BINARIES_TARGET): $(PROJECT_DEPENDENCIES_TARGETS) | $(GO_MOD_DOWNLOAD_TARGETS)
+	for bin in "ipxe-efi.img" "ipxe.efi" "ipxe.iso" "undionly.kpxe"; do cp $(OUTPUT_DIR)/dependencies/linux-amd64/eksa/tinkerbell/ipxedust/$$bin $(@D); done
+	for bin in "snp.efi"; do cp $(OUTPUT_DIR)/dependencies/linux-arm64/eksa/tinkerbell/ipxedust/$$bin $(@D); done
+	touch $(@)
+
+$(BINARY_TARGETS): $(OVERRIDE_VENDOR_BINARIES_TARGET)
 
 
 ########### DO NOT EDIT #############################

--- a/projects/tinkerbell/boots/docker/linux/Dockerfile
+++ b/projects/tinkerbell/boots/docker/linux/Dockerfile
@@ -7,6 +7,8 @@ ARG TARGETOS
 COPY _output/bin/boots/$TARGETOS-$TARGETARCH/smee /usr/bin/boots
 COPY _output/LICENSES /LICENSES
 COPY ATTRIBUTION.txt /ATTRIBUTION.txt
+COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksa/tinkerbell/ipxedust/LICENSES /IPXE_LICENSES
+COPY _output/dependencies/$TARGETOS-$TARGETARCH/eksa/tinkerbell/ipxedust/ATTRIBUTION.txt /IPXE_ATTRIBUTION.txt
 
 EXPOSE 67 69 80
 

--- a/release/staging-build.yml
+++ b/release/staging-build.yml
@@ -719,6 +719,9 @@ batch:
           PROJECT_PATH: projects/replicatedhq/troubleshoot
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/replicatedhq.troubleshoot
     - identifier: tinkerbell_boots
+      depend-on:
+        - tinkerbell_ipxedust_linux_amd64
+        - tinkerbell_ipxedust_linux_arm64
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Once we are building ipxedust, this will download it as an artifact from our s3 bucket and use the built ipxe bins instead of the embedded from ipxedust.

This does not currently do anything with the golang src files from ipxedust, those will continue to be pulled via go mods.

Follow up to: #3530 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
