### PR TITLE
Retry image builds in case of Ansible SSH timeout

### DIFF
--- a/projects/kubernetes-sigs/image-builder/build/build_image.sh
+++ b/projects/kubernetes-sigs/image-builder/build/build_image.sh
@@ -57,6 +57,7 @@ function retry_image_builder() {
     ["Timeout waiting for SSH"]="Wrong VM IP might be fetched"
     ["Cancelling provisioner after a timeout"]="Provisioner timed out"
     ["image size mistmatch"]="Nutanix image size mismatch"
+    ["Connection timed out during banner exchange"]="Ansible SSH connection timed out"
   )
 
   until [ $n -eq $max ]; do


### PR DESCRIPTION
This PR configures image build retries in case of Ansible SSH timeout since we have observed these usually succeed on the next run when re-triggered.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
