### PR TITLE
adds moby_config to linuxkit images

### DIFF
--- a/projects/linuxkit/linuxkit/CHECKSUMS
+++ b/projects/linuxkit/linuxkit/CHECKSUMS
@@ -1,2 +1,2 @@
-a1aa199fab47d86ecab388b3e89f9bf54c6a198c14f8018aca16fdd2f60c654b  _output/bin/linuxkit/linux-amd64/linuxkit
-b864a52df0d6f48f2b761b4c55266c23d8009c79cceafebc67f8866aa1a9c48d  _output/bin/linuxkit/linux-arm64/linuxkit
+6aa7e326f119073908df604e9310f5d11f6a96a76218fe59fefee9d85ed7b944  _output/bin/linuxkit/linux-amd64/linuxkit
+8e9f51c7ed534567257cc00e791a0315a8371185605f445ea8936ce4cb1717f7  _output/bin/linuxkit/linux-arm64/linuxkit

--- a/projects/linuxkit/linuxkit/Makefile
+++ b/projects/linuxkit/linuxkit/Makefile
@@ -26,6 +26,11 @@ DHCPCD_IMAGE_COMPONENT=linuxkit/dhcpcd
 OPENNTPD_IMAGE_COMPONENT=linuxkit/openntpd
 GETTY_IMAGE_COMPONENT=linuxkit/getty
 
+# when using yq to conver to json 0666 is being parsed as a number and converted to 438
+# replace it back to 0600
+# https://github.com/mikefarah/yq/issues/1634
+MOBY_CONFIG='$(shell set -x && yq '.config' $(REPO)/pkg/$(IMAGE_NAME)/build.yml | yq -o=json -I=0 | sed 's/438/"0666"/g')'
+
 # we need to set IMAGE_BUILD_ARGS here even though its the same as the default. 
 # it is set in Common.mk on the images target (https://github.com/aws/eks-anywhere-build-tooling/blob/8b6d6d66974e881b22e3c9c8ea29adc26f7df5fd/Common.mk#L799)
 # and the combine-images target (https://github.com/aws/eks-anywhere-build-tooling/blob/8b6d6d66974e881b22e3c9c8ea29adc26f7df5fd/Common.mk#L846)
@@ -57,6 +62,7 @@ UPLOAD_DO_NOT_DELETE=true
 
 include $(BASE_DIRECTORY)/Common.mk
 
+dhcpcd/images/% getty/images/% modprobe/images/% openntpd/images/% rngd/images/% sysctl/images/% sysfs/images/%: IMAGE_BUILD_ARGS=MOBY_CONFIG
 
 $(GATHER_LICENSES_TARGETS): $(FIX_LICENSES_LINUXKIT_TARGET) $(FIX_LICENSES_HYPERKIT_TARGE)
 

--- a/projects/linuxkit/linuxkit/patches/0001-add-moby-config-to-dockerfiles-for-packages-used-by-.patch
+++ b/projects/linuxkit/linuxkit/patches/0001-add-moby-config-to-dockerfiles-for-packages-used-by-.patch
@@ -1,0 +1,109 @@
+From 79fa5de9df184d11c6cdfeb6b3b8448c49e94409 Mon Sep 17 00:00:00 2001
+From: Jackson West <jaxesn@gmail.com>
+Date: Wed, 2 Oct 2024 17:57:37 +0000
+Subject: [PATCH] add moby config to dockerfiles for packages used by hook
+
+---
+ pkg/dhcpcd/Dockerfile   | 2 ++
+ pkg/getty/Dockerfile    | 2 ++
+ pkg/modprobe/Dockerfile | 2 ++
+ pkg/openntpd/Dockerfile | 2 ++
+ pkg/rngd/Dockerfile     | 2 ++
+ pkg/sysctl/Dockerfile   | 2 ++
+ pkg/sysfs/Dockerfile    | 2 ++
+ 7 files changed, 14 insertions(+)
+
+diff --git a/pkg/dhcpcd/Dockerfile b/pkg/dhcpcd/Dockerfile
+index ed760cfed..0ff5500e9 100644
+--- a/pkg/dhcpcd/Dockerfile
++++ b/pkg/dhcpcd/Dockerfile
+@@ -10,6 +10,8 @@ RUN apk add --no-cache --initdb -p /out \
+ RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
+ 
+ FROM scratch
++ARG MOBY_CONFIG
++LABEL "org.mobyproject.config"="${MOBY_CONFIG}"
+ ENTRYPOINT []
+ CMD []
+ WORKDIR /
+diff --git a/pkg/getty/Dockerfile b/pkg/getty/Dockerfile
+index ae10de07d..60d687065 100644
+--- a/pkg/getty/Dockerfile
++++ b/pkg/getty/Dockerfile
+@@ -27,6 +27,8 @@ RUN cp /out/usr/bin/setsid /out/usr/bin/setsid.getty
+ RUN rm -rf /out/etc/inittab
+ 
+ FROM scratch
++ARG MOBY_CONFIG
++LABEL "org.mobyproject.config"="${MOBY_CONFIG}"
+ ENTRYPOINT ["/sbin/tini","-s","-v","--"]
+ WORKDIR /
+ COPY --from=mirror /out/ /
+diff --git a/pkg/modprobe/Dockerfile b/pkg/modprobe/Dockerfile
+index 0cb683fa6..3c1cab58c 100644
+--- a/pkg/modprobe/Dockerfile
++++ b/pkg/modprobe/Dockerfile
+@@ -7,6 +7,8 @@ RUN apk add --no-cache --initdb -p /out \
+ RUN rm -rf /out/var/cache
+ 
+ FROM scratch
++ARG MOBY_CONFIG
++LABEL "org.mobyproject.config"="${MOBY_CONFIG}"
+ ENTRYPOINT []
+ CMD []
+ WORKDIR /
+diff --git a/pkg/openntpd/Dockerfile b/pkg/openntpd/Dockerfile
+index b8c073005..4fd4928c3 100644
+--- a/pkg/openntpd/Dockerfile
++++ b/pkg/openntpd/Dockerfile
+@@ -10,6 +10,8 @@ RUN apk add --no-cache --initdb -p /out \
+ RUN rm -rf /out/etc/apk /out/lib/apk /out/var/cache
+ 
+ FROM scratch
++ARG MOBY_CONFIG
++LABEL "org.mobyproject.config"="${MOBY_CONFIG}"
+ ENTRYPOINT []
+ CMD []
+ WORKDIR /
+diff --git a/pkg/rngd/Dockerfile b/pkg/rngd/Dockerfile
+index 58695caef..9bca2ac43 100644
+--- a/pkg/rngd/Dockerfile
++++ b/pkg/rngd/Dockerfile
+@@ -14,6 +14,8 @@ COPY . /go/src/rngd/
+ RUN REQUIRE_CGO=1 go-compile.sh /go/src/rngd/cmd/rngd
+ 
+ FROM scratch
++ARG MOBY_CONFIG
++LABEL "org.mobyproject.config"="${MOBY_CONFIG}"
+ ENTRYPOINT []
+ CMD []
+ WORKDIR /
+diff --git a/pkg/sysctl/Dockerfile b/pkg/sysctl/Dockerfile
+index c989b81be..4abac9b15 100644
+--- a/pkg/sysctl/Dockerfile
++++ b/pkg/sysctl/Dockerfile
+@@ -12,6 +12,8 @@ COPY . /go/src/sysctl/
+ RUN go-compile.sh /go/src/sysctl
+ 
+ FROM scratch
++ARG MOBY_CONFIG
++LABEL "org.mobyproject.config"="${MOBY_CONFIG}"
+ ENTRYPOINT []
+ CMD []
+ WORKDIR /
+diff --git a/pkg/sysfs/Dockerfile b/pkg/sysfs/Dockerfile
+index b38ef5cbe..e4c048f9f 100644
+--- a/pkg/sysfs/Dockerfile
++++ b/pkg/sysfs/Dockerfile
+@@ -11,6 +11,8 @@ COPY . /go/src/sysfs/
+ RUN go-compile.sh /go/src/sysfs
+ 
+ FROM scratch
++ARG MOBY_CONFIG
++LABEL "org.mobyproject.config"="${MOBY_CONFIG}"
+ ENTRYPOINT []
+ CMD []
+ WORKDIR /
+-- 
+2.34.1
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When linuxkit builds their images upstream, most images have a [build.yml](https://github.com/linuxkit/linuxkit/blob/master/pkg/ip/build.yml) file. The config section of these files are added to the docker image as the value of the `org.mobyproject.config` label.  When a linuxkit built image, in our case hook, runs these containers if the template, ex [hook-template](https://github.com/tinkerbell/hook/blob/main/linuxkit-templates/hook.template.yaml), does not include these config values such as capbilities in the template for that image, the linuxkit containerd runtime pulls this label from the final image and uses the config as the default.

Without these our hook will not actually work since it relies on these defaults.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
