### PR TITLE
fixes combine-image phase for linuxkit

### DIFF
--- a/projects/linuxkit/linuxkit/Makefile
+++ b/projects/linuxkit/linuxkit/Makefile
@@ -62,7 +62,7 @@ UPLOAD_DO_NOT_DELETE=true
 
 include $(BASE_DIRECTORY)/Common.mk
 
-dhcpcd/images/% getty/images/% modprobe/images/% openntpd/images/% rngd/images/% sysctl/images/% sysfs/images/%: IMAGE_BUILD_ARGS=MOBY_CONFIG
+dhcpcd/images/% getty/images/% modprobe/images/% openntpd/images/% rngd/images/% sysctl/images/% sysfs/images/%: IMAGE_BUILD_ARGS+=MOBY_CONFIG
 
 $(GATHER_LICENSES_TARGETS): $(FIX_LICENSES_LINUXKIT_TARGET) $(FIX_LICENSES_HYPERKIT_TARGE)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I broke the combine-images in codebuild...  I'll take a pass as a follow up to see if we can test this target in presubmit so it doesn't break it in codebuild.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
