### PR TITLE
[release-0.20] Add patch to revert optionally sourcing /etc/default/kubelet in kubelet service

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
@@ -1,7 +1,7 @@
 From 8105653d982bab67680e5637c33a5982bcd253f0 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:05:13 -0800
-Subject: [PATCH 01/12] OVA improvements
+Subject: [PATCH 01/13] OVA improvements
 
 - Create /etc/pki/tls/certs dir as part of image-builds
 - Tweak Product info in OVF

--- a/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
@@ -1,7 +1,7 @@
-From e05873bc85c3e9c2440b406e5acb1a88631b09dd Mon Sep 17 00:00:00 2001
+From f494f6e61d78ddd9c5f23cef9455905aaa0ce951 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 18:36:56 -0800
-Subject: [PATCH 02/12] EKS-D support and changes
+Subject: [PATCH 02/13] EKS-D support and changes
 
 - Add goss validations for EKS-D artifacts
 - Add etcdadm and etcd.tar.gz to image for unstacked etcd support
@@ -129,7 +129,7 @@ index 537c4adec..0bfbf32cd 100644
        "version": "{{user `goss_version`}}"
      }
 diff --git a/images/capi/packer/config/ansible-args.json b/images/capi/packer/config/ansible-args.json
-index b100f8e74..d7a90cc5a 100644
+index b100f8e74..92481888b 100644
 --- a/images/capi/packer/config/ansible-args.json
 +++ b/images/capi/packer/config/ansible-args.json
 @@ -1,5 +1,5 @@

--- a/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
@@ -1,7 +1,7 @@
-From 6ca24f8497cdf6375038da55c19d5d26497958f2 Mon Sep 17 00:00:00 2001
+From 44b21ceaa6060f0386bf14138af7845287dec0c6 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Feb 2023 01:39:15 -0800
-Subject: [PATCH 03/12] Snow AMI support
+Subject: [PATCH 03/13] Snow AMI support
 
 ---
  images/capi/packer/ami/packer.json | 12 ++++++++++--

--- a/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22.04-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22.04-support-and-improvements.patch
@@ -1,7 +1,7 @@
-From 5f482fd8cae3edaa04f39a9aa48357d7adf47f91 Mon Sep 17 00:00:00 2001
+From 4063690dd24383d1cc6df145199216a716f4506a Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Fri, 23 Jun 2023 10:50:08 -0500
-Subject: [PATCH 04/12] Ubuntu 22.04 support and improvements
+Subject: [PATCH 04/13] Ubuntu 22.04 support and improvements
 
 - adds support for raw ubuntu 22.04 builds
 - Ubuntu switch to offline-install when mirrors are unavailable

--- a/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
@@ -1,7 +1,7 @@
-From 07eb184d1836b193052e6b1fc9312e20a836f43d Mon Sep 17 00:00:00 2001
+From f9f48a5be880f522bf6ff6c49469b5a502dd1711 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 6 Dec 2022 15:42:02 -0600
-Subject: [PATCH 05/12] RHEL support and improvements
+Subject: [PATCH 05/13] RHEL support and improvements
 
 - Fix redhat 9 cloud-init feature flags bug
 - Fix ensure iptables present for rhel
@@ -171,7 +171,7 @@ index 5716fff78..c1fc46769 100644
 +    lock_timeout: 60
 +  when: ansible_os_family == "RedHat" and ansible_distribution == "RedHat" and ansible_distribution_major_version == "9"
 diff --git a/images/capi/packer/config/ansible-args.json b/images/capi/packer/config/ansible-args.json
-index d7a90cc5a..d7040dc58 100644
+index 92481888b..d7040dc58 100644
 --- a/images/capi/packer/config/ansible-args.json
 +++ b/images/capi/packer/config/ansible-args.json
 @@ -1,5 +1,5 @@

--- a/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-improvements.patch
@@ -1,7 +1,7 @@
-From c3936fba05f8152f296a8b0f6d056dbd1ca4c42e Mon Sep 17 00:00:00 2001
+From 1a1d73dcd7b3c9b44480a4f03242b15bd579132f Mon Sep 17 00:00:00 2001
 From: Ilya Alekseyev <ilya.alekseyev@nutanix.com>
 Date: Wed, 11 Oct 2023 22:07:22 -0400
-Subject: [PATCH 06/12] Nutanix improvements
+Subject: [PATCH 06/13] Nutanix improvements
 
 - Fetch Nutanix RHEL source image URL from environment
 - Force-delete Nutanix builder VMs on failure

--- a/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
@@ -1,7 +1,7 @@
-From 5a767b3b2a5a269469e3f6c1d67bce76021944ef Mon Sep 17 00:00:00 2001
+From b70bf9546017d21479a90d40e509dfa0aff0c612 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Mon, 21 Aug 2023 18:40:07 -0500
-Subject: [PATCH 07/12] adds retries and timeout to packer image-builder
+Subject: [PATCH 07/13] adds retries and timeout to packer image-builder
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0008-Networking-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0008-Networking-improvements.patch
@@ -1,7 +1,7 @@
-From d175cb9772570a4bdefbdc0e22aef86d3086882e Mon Sep 17 00:00:00 2001
+From 47b53d8f5938d0673a086bacca94e58616924926 Mon Sep 17 00:00:00 2001
 From: Taylor Neyland <tneyla@amazon.com>
 Date: Wed, 19 Jul 2023 12:51:30 -0500
-Subject: [PATCH 08/12] Networking improvements
+Subject: [PATCH 08/13] Networking improvements
 
 - Disable UDP offload service for Redhat and Ubuntu
 - Default Flatcar version to avoid pulling from internet on every make

--- a/projects/kubernetes-sigs/image-builder/patches/0009-Support-and-improvements-for-RHEL-9-EFI.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0009-Support-and-improvements-for-RHEL-9-EFI.patch
@@ -1,7 +1,7 @@
-From 69ea09ee053a71242152c00592e58b3ee0f384b8 Mon Sep 17 00:00:00 2001
+From 60f4cd1c6fa8634fe3fb82adbfe23e74dd763d51 Mon Sep 17 00:00:00 2001
 From: Shizhao Liu <lshizhao@amazon.com>
 Date: Mon, 19 Aug 2024 10:14:26 -0700
-Subject: [PATCH 09/12] Support and improvements for RHEL 9 EFI
+Subject: [PATCH 09/13] Support and improvements for RHEL 9 EFI
 
 1. Remove 2 unwanted partitions (the swap partition and /boot
 partition).

--- a/projects/kubernetes-sigs/image-builder/patches/0010-Pin-Packer-Goss-plugin-version-to-3.1.4.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0010-Pin-Packer-Goss-plugin-version-to-3.1.4.patch
@@ -1,7 +1,7 @@
-From a154023470415118e5f8098f5ed0c3719b54cf9d Mon Sep 17 00:00:00 2001
+From 39d00a398efa29f92ec1360c5c5fb3082617d32d Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 19 Sep 2024 15:36:00 -0700
-Subject: [PATCH 10/12] Pin Packer Goss plugin version to 3.1.4
+Subject: [PATCH 10/13] Pin Packer Goss plugin version to 3.1.4
 
 Upstream image-builder moved from installing packer-provisioner-goss through a script to installing it
 via Packer config (https://github.com/kubernetes-sigs/image-builder/commit/c0b70ae37c4aac14c156fc7b907a9b35147757df).

--- a/projects/kubernetes-sigs/image-builder/patches/0011-Remove-containerd-configuration-for-hosts.toml-paths.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0011-Remove-containerd-configuration-for-hosts.toml-paths.patch
@@ -1,7 +1,7 @@
-From 707d1fadaf61873d656721e2429be6f9820aebe6 Mon Sep 17 00:00:00 2001
+From 5e8a59d98edbee77e439b2eb5924eb2e62bf9e65 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 19 Sep 2024 16:04:19 -0700
-Subject: [PATCH 11/12] Remove containerd configuration for hosts.toml paths
+Subject: [PATCH 11/13] Remove containerd configuration for hosts.toml paths
 
 In EKS Anywhere, we're still using the older containerd config template (v2), so setting the
 config_path in the containerd config file causes errors like "invalid plugin config: `mirrors`

--- a/projects/kubernetes-sigs/image-builder/patches/0012-Revert-updating-preseed-and-cloud-init-to-use-CD-for.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0012-Revert-updating-preseed-and-cloud-init-to-use-CD-for.patch
@@ -1,7 +1,7 @@
-From c321d4574c5fa981705e3d7c362c4d553a0ac46f Mon Sep 17 00:00:00 2001
+From 0bdd89aa2812890a62ea17557edbf6c2fdf5a72d Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 19 Sep 2024 18:52:00 -0700
-Subject: [PATCH 12/12] Revert updating preseed and cloud-init to use CD for
+Subject: [PATCH 12/13] Revert updating preseed and cloud-init to use CD for
  boot files
 
 We are reverting the upstream change that updated preseed and cloud-init scripts

--- a/projects/kubernetes-sigs/image-builder/patches/0013-Revert-Optionally-source-etc-default-kubelet-in-kube.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0013-Revert-Optionally-source-etc-default-kubelet-in-kube.patch
@@ -1,0 +1,28 @@
+From c1df3e862ba2717623a6193fd9bd78ce3fea540b Mon Sep 17 00:00:00 2001
+From: Saurabh Parekh <sjparekh@amazon.com>
+Date: Thu, 3 Oct 2024 21:24:40 -0700
+Subject: [PATCH 13/13] Revert "Optionally source /etc/default/kubelet in kubelet.service"
+
+We are reverting the upstream change that optionally source /etc/default/kubelet in kubelet service.
+We will continue using /etc/sysconfig/kubelet environment file to update the kubelet extra args for 
+ubuntu to configure the ecr credentials for curated packages.
+
+Signed-off-by: Saurabh Parekh <sjparekh@amazon.com>
+---
+ .../usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf     | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/images/capi/ansible/roles/kubernetes/templates/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf b/images/capi/ansible/roles/kubernetes/templates/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf
+index 4f1b8156b..165becb18 100644
+--- a/images/capi/ansible/roles/kubernetes/templates/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf
++++ b/images/capi/ansible/roles/kubernetes/templates/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf
+@@ -7,6 +7,5 @@ EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
+ # This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
+ # the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
+ EnvironmentFile=-/etc/sysconfig/kubelet
+-EnvironmentFile=-/etc/default/kubelet
+ ExecStart=
+ ExecStart={{ sysusr_prefix }}/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS
+-- 
+2.46.2
+


### PR DESCRIPTION
*Description of changes:*
This is a manual cherry-pick of [#3850](https://github.com/aws/eks-anywhere-build-tooling/pull/3850).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
