### PR TITLE
[release-0.19] Add patch to revert optionally sourcing /etc/default/kubelet in kubelet service

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
@@ -1,7 +1,7 @@
 From 8105653d982bab67680e5637c33a5982bcd253f0 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:05:13 -0800
-Subject: [PATCH 01/11] OVA improvements
+Subject: [PATCH 01/12] OVA improvements
 
 - Create /etc/pki/tls/certs dir as part of image-builds
 - Tweak Product info in OVF

--- a/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
@@ -1,7 +1,7 @@
 From e05873bc85c3e9c2440b406e5acb1a88631b09dd Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 18:36:56 -0800
-Subject: [PATCH 02/11] EKS-D support and changes
+Subject: [PATCH 02/12] EKS-D support and changes
 
 - Add goss validations for EKS-D artifacts
 - Add etcdadm and etcd.tar.gz to image for unstacked etcd support

--- a/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
@@ -1,7 +1,7 @@
 From 6ca24f8497cdf6375038da55c19d5d26497958f2 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Feb 2023 01:39:15 -0800
-Subject: [PATCH 03/11] Snow AMI support
+Subject: [PATCH 03/12] Snow AMI support
 
 ---
  images/capi/packer/ami/packer.json | 12 ++++++++++--

--- a/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22.04-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22.04-support-and-improvements.patch
@@ -1,7 +1,7 @@
 From 5f482fd8cae3edaa04f39a9aa48357d7adf47f91 Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Fri, 23 Jun 2023 10:50:08 -0500
-Subject: [PATCH 04/11] Ubuntu 22.04 support and improvements
+Subject: [PATCH 04/12] Ubuntu 22.04 support and improvements
 
 - adds support for raw ubuntu 22.04 builds
 - Ubuntu switch to offline-install when mirrors are unavailable

--- a/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
@@ -1,7 +1,7 @@
 From ae646fc9518af02d7e6a0a022547aa6225e6f255 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 6 Dec 2022 15:42:02 -0600
-Subject: [PATCH 05/11] RHEL support and improvements
+Subject: [PATCH 05/12] RHEL support and improvements
 
 - Fix redhat 9 cloud-init feature flags bug
 - Fix ensure iptables present for rhel

--- a/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-improvements.patch
@@ -1,7 +1,7 @@
 From c82fc503495b87087105f28da16fae15487074ad Mon Sep 17 00:00:00 2001
 From: Ilya Alekseyev <ilya.alekseyev@nutanix.com>
 Date: Wed, 11 Oct 2023 22:07:22 -0400
-Subject: [PATCH 06/11] Nutanix improvements
+Subject: [PATCH 06/12] Nutanix improvements
 
 - Fetch Nutanix RHEL source image URL from environment
 - Force-delete Nutanix builder VMs on failure

--- a/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
@@ -1,7 +1,7 @@
 From 3fd94b98f126b222930e62b3ff035bb4a7a8208b Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Mon, 21 Aug 2023 18:40:07 -0500
-Subject: [PATCH 07/11] adds retries and timeout to packer image-builder
+Subject: [PATCH 07/12] adds retries and timeout to packer image-builder
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---

--- a/projects/kubernetes-sigs/image-builder/patches/0008-Networking-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0008-Networking-improvements.patch
@@ -1,7 +1,7 @@
 From 576764f9fa5ab9e6ab1bd0a38c87cdd189498d30 Mon Sep 17 00:00:00 2001
 From: Taylor Neyland <tneyla@amazon.com>
 Date: Wed, 19 Jul 2023 12:51:30 -0500
-Subject: [PATCH 08/11] Networking improvements
+Subject: [PATCH 08/12] Networking improvements
 
 - Disable UDP offload service for Redhat and Ubuntu
 - Default Flatcar version to avoid pulling from internet on every make

--- a/projects/kubernetes-sigs/image-builder/patches/0009-Pin-Packer-Goss-plugin-version-to-3.1.4.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0009-Pin-Packer-Goss-plugin-version-to-3.1.4.patch
@@ -1,7 +1,7 @@
 From a4f84f376f0d9789ecc9b138324bf7d53b27e66d Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 19 Sep 2024 15:36:00 -0700
-Subject: [PATCH 09/11] Pin Packer Goss plugin version to 3.1.4
+Subject: [PATCH 09/12] Pin Packer Goss plugin version to 3.1.4
 
 Upstream image-builder moved from installing packer-provisioner-goss through a script to installing it
 via Packer config (https://github.com/kubernetes-sigs/image-builder/commit/c0b70ae37c4aac14c156fc7b907a9b35147757df).

--- a/projects/kubernetes-sigs/image-builder/patches/0010-Remove-containerd-configuration-for-hosts.toml-paths.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0010-Remove-containerd-configuration-for-hosts.toml-paths.patch
@@ -1,7 +1,7 @@
 From 07208be41b7ff30a46e6fe06e0f82b5cbfc9062f Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 19 Sep 2024 16:04:19 -0700
-Subject: [PATCH 10/11] Remove containerd configuration for hosts.toml paths
+Subject: [PATCH 10/12] Remove containerd configuration for hosts.toml paths
 
 In EKS Anywhere, we're still using the older containerd config template (v2), so setting the
 config_path in the containerd config file causes errors like "invalid plugin config: `mirrors`

--- a/projects/kubernetes-sigs/image-builder/patches/0011-Revert-updating-preseed-and-cloud-init-to-use-CD-for.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0011-Revert-updating-preseed-and-cloud-init-to-use-CD-for.patch
@@ -1,7 +1,7 @@
 From 528abaa92f06b07af338b37e2c2f94c94505a8dc Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 19 Sep 2024 18:52:00 -0700
-Subject: [PATCH 11/11] Revert updating preseed and cloud-init to use CD for
+Subject: [PATCH 11/12] Revert updating preseed and cloud-init to use CD for
  boot files
 
 We are reverting the upstream change that updated preseed and cloud-init scripts

--- a/projects/kubernetes-sigs/image-builder/patches/0012-Revert-Optionally-source-etc-default-kubelet-in-kube.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0012-Revert-Optionally-source-etc-default-kubelet-in-kube.patch
@@ -1,0 +1,29 @@
+From 66b21e4e35f954ee15fea31ff2023d568cfdba80 Mon Sep 17 00:00:00 2001
+From: Saurabh Parekh <sjparekh@amazon.com>
+Date: Thu, 3 Oct 2024 21:24:40 -0700
+Subject: [PATCH 12/12] Revert "Optionally source /etc/default/kubelet in
+ kubelet.service"
+
+We are reverting the upstream change that optionally source /etc/default/kubelet in kubelet service.
+We will continue using /etc/sysconfig/kubelet environment file to update the kubelet extra args for
+ubuntu to configure the ecr credentials for curated packages.
+
+Signed-off-by: Saurabh Parekh <sjparekh@amazon.com>
+---
+ .../usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf     | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/images/capi/ansible/roles/kubernetes/templates/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf b/images/capi/ansible/roles/kubernetes/templates/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf
+index 4f1b8156b..165becb18 100644
+--- a/images/capi/ansible/roles/kubernetes/templates/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf
++++ b/images/capi/ansible/roles/kubernetes/templates/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf
+@@ -7,6 +7,5 @@ EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
+ # This is a file that the user can use for overrides of the kubelet args as a last resort. Preferably, the user should use
+ # the .NodeRegistration.KubeletExtraArgs object in the configuration files instead. KUBELET_EXTRA_ARGS should be sourced from this file.
+ EnvironmentFile=-/etc/sysconfig/kubelet
+-EnvironmentFile=-/etc/default/kubelet
+ ExecStart=
+ ExecStart={{ sysusr_prefix }}/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS
+-- 
+2.46.2
+


### PR DESCRIPTION
*Description of changes:*
This is a manual cherry-pick of https://github.com/aws/eks-anywhere-build-tooling/pull/3850.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
