### PR TITLE
Skip checksums validation for Boots project

### DIFF
--- a/projects/tinkerbell/boots/Makefile
+++ b/projects/tinkerbell/boots/Makefile
@@ -14,6 +14,7 @@ GITREV?=$(shell git -C $(REPO) rev-parse --short HEAD)
 EXTRA_GO_LDFLAGS=-X main.GitRev=${GITREV}
 
 EXCLUDE_FROM_UPGRADE_BUILDSPEC=true
+SKIP_CHECKSUM_VALIDATION=true
 
 PROJECT_DEPENDENCIES=eksa/tinkerbell/ipxedust
 BUILDSPEC_DEPENDS_ON_OVERRIDE=tinkerbell_ipxedust_linux_amd64 tinkerbell_ipxedust_linux_arm64


### PR DESCRIPTION
Skipping checksums validation for Boots project since we override the ipxedust Go mod with the ipxe binaries we build, and these binaries cannot be built reproducibly, thus changing the checksum each time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
