### PR TITLE
adds source epoch to ipxe build for reproducibility

### DIFF
--- a/projects/isc-projects/dhcp/CHECKSUMS
+++ b/projects/isc-projects/dhcp/CHECKSUMS
@@ -1,0 +1,2 @@
+877361620bc4ddd940070c79bbc4a367bee5735fc128bdeab207a4dea27eb39a  _output/bin/dhcp/linux-amd64/dhcrelay
+c6e226d2a7ecd110bccb961e6d822c918f1c1d1fb9715dc5e614745238defa2a  _output/bin/dhcp/linux-arm64/dhcrelay

--- a/projects/isc-projects/dhcp/Makefile
+++ b/projects/isc-projects/dhcp/Makefile
@@ -17,11 +17,9 @@ HAS_LICENSES=false
 
 TAR_FILE_PREFIX=dhcp
 HAS_S3_ARTIFACTS=true
-SKIP_CHECKSUM_VALIDATION=true
 
 IMAGE_NAMES=
 
-EXCLUDE_FROM_CHECKSUMS_BUILDSPEC=true
 EXCLUDE_FROM_UPGRADE_BUILDSPEC=true
 
 BUILDSPEC_VARS_KEYS=BINARY_PLATFORMS
@@ -39,13 +37,15 @@ include $(BASE_DIRECTORY)/Common.mk
 
 tarballs: gather-non-golang-licenses $(OUTPUT_DIR)/ATTRIBUTION.txt
 
+# To be reproducible:
+# -debug-prefix-map to reset the build folder
 $(OUTPUT_BIN_DIR)/%: MAKEFLAGS=
 $(OUTPUT_BIN_DIR)/%: PLATFORM=$(subst -,/,$(*D:/dhcp=))
 $(OUTPUT_BIN_DIR)/%: $(GIT_CHECKOUT_TARGET) | $$(call ENABLE_DOCKER_PLATFORM,$$(PLATFORM))
 	@mkdir -p $(MAKE_ROOT)/$(@D); \
-	yum install perl -y; \
+	sudo yum install file perl -y; \
 	cd $(REPO) && \
-	./configure && \
+	./configure CFLAGS="-fdebug-prefix-map=$(MAKE_ROOT)=/buildroot" && \
 	$(MAKE) && \
 	cp relay/dhcrelay $(MAKE_ROOT)/$(@D)/
 

--- a/projects/tinkerbell/ipxedust/CHECKSUMS
+++ b/projects/tinkerbell/ipxedust/CHECKSUMS
@@ -1,0 +1,5 @@
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  _output/bin/ipxedust/linux-amd64/ipxe-efi.img
+631b597f9885cc212848a14dbe0024b78f029bf2be0e3a70bf944df5c8d35a66  _output/bin/ipxedust/linux-amd64/ipxe.efi
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  _output/bin/ipxedust/linux-amd64/ipxe.iso
+729ffc674c69867a7c353c6120fff1046dfde826afa9989f6e811657e64bac93  _output/bin/ipxedust/linux-amd64/undionly.kpxe
+5cf3ce722823293b9074e1790da5780ece45bfb456e66d39519ba5ccf885b47c  _output/bin/ipxedust/linux-arm64/snp.efi

--- a/projects/tinkerbell/ipxedust/Makefile
+++ b/projects/tinkerbell/ipxedust/Makefile
@@ -11,23 +11,24 @@ SIMPLE_CREATE_BINARIES=false # not a go project, can't use this script "simple_c
 # host platform to avoid ever creating a different arch'd
 # binary in the wrong folder
 BINARY_PLATFORMS?=linux/$(BUILDER_PLATFORM_ARCH)
-BINARY_TARGETS_AMD64=$(OUTPUT_BIN_DIR)/linux-amd64/ipxe.efi $(OUTPUT_BIN_DIR)/linux-amd64/undionly.kpxe
-BINARY_TARGETS_ARM64=$(OUTPUT_BIN_DIR)/linux-arm64/snp.efi
 
 # we are not building these because we do not need them
 # but the smee import is going to reguire them so we 
 # create empty files
 FAKE_BINARY_TARGETS=$(OUTPUT_BIN_DIR)/linux-amd64/ipxe.iso $(OUTPUT_BIN_DIR)/linux-amd64/ipxe-efi.img
-BINARY_TARGETS=$(if $(findstring amd64,$(BINARY_PLATFORMS)),$(BINARY_TARGETS_AMD64),) $(if $(findstring arm64,$(BINARY_PLATFORMS)),$(BINARY_TARGETS_ARM64),) $(FAKE_BINARY_TARGETS)
+BINARY_TARGETS_AMD64=$(OUTPUT_BIN_DIR)/linux-amd64/ipxe.efi $(OUTPUT_BIN_DIR)/linux-amd64/undionly.kpxe $(FAKE_BINARY_TARGETS)
+BINARY_TARGETS_ARM64=$(OUTPUT_BIN_DIR)/linux-arm64/snp.efi
+
+BINARY_TARGETS=$(if $(findstring amd64,$(BINARY_PLATFORMS)),$(BINARY_TARGETS_AMD64),) $(if $(findstring arm64,$(BINARY_PLATFORMS)),$(BINARY_TARGETS_ARM64),)
+
+SOURCE_DATE_EPOCH=$(shell git -C $(REPO) log -1 --format=%at)
 
 HAS_LICENSES=false
 
 HAS_S3_ARTIFACTS=true
-SKIP_CHECKSUM_VALIDATION=true
 
 IMAGE_NAMES=
 
-EXCLUDE_FROM_CHECKSUMS_BUILDSPEC=true
 EXCLUDE_FROM_UPGRADE_BUILDSPEC=true
 
 BUILDSPECS=buildspec.yml
@@ -55,11 +56,18 @@ $(FAKE_BINARY_TARGETS):
 	touch $@
 
 # since we are yum installing, we need to run the docker container as root
+# To be reproducible:
+# - ipxe builds in a build timestamp, set that to the date from the ipxedust repo's last commit
+# - ipxe also builds in a build_id which is based on a checksum from a number of the makefiles
+#   as well as some of the built .a files, such as blib.a. When the final ipxe binary is built
+#   debugging symbols and other unncessary data is stripped out, making reproducibilty easier
+#   However the blib.a is not stripped so things like the build path will change the checksum and 
+#   therefore the build_id. We use -debug-prefix-map to reset the build folder
 $(OUTPUT_BIN_DIR)/%: MAKEFLAGS=
 $(OUTPUT_BIN_DIR)/%: $(GIT_PATCH_TARGET) | $$(call ENABLE_DOCKER_PLATFORM,$$(PLATFORM))
 	sudo yum install -y genisoimage perl syslinux xz-devel; \
 	mkdir -p $(@D); \
-	$(MAKE) -C $(REPO) binary/$(@F); \
+	$(MAKE) -C $(REPO) binary/$(@F) SOURCE_DATE_EPOCH=$(SOURCE_DATE_EPOCH) EXTRA_CFLAGS="-fdebug-prefix-map=$(MAKE_ROOT)=/buildroot"; \
 	cp $(REPO)/binary/$(@F) $@
 
 .PHONY: gather-non-golang-licenses

--- a/projects/torvalds/linux/.gitignore
+++ b/projects/torvalds/linux/.gitignore
@@ -1,2 +1,1 @@
 linux
-CHECKSUMS

--- a/projects/torvalds/linux/CHECKSUMS
+++ b/projects/torvalds/linux/CHECKSUMS
@@ -1,0 +1,2 @@
+c85efd563491105356329664275675b47872e0981451d0ab7e8c38dfbbe31d29  _output/bin/linux/linux-amd64/tools/bootconfig
+0b6df24ad5611557e7e572a44f883bb7d27295fc1fafed9270e292e285fa91e6  _output/bin/linux/linux-arm64/tools/bootconfig

--- a/projects/torvalds/linux/Makefile
+++ b/projects/torvalds/linux/Makefile
@@ -18,11 +18,9 @@ HAS_LICENSES=false
 
 TAR_FILE_PREFIX=bootconfig
 HAS_S3_ARTIFACTS=true
-SKIP_CHECKSUM_VALIDATION=true
 
 IMAGE_NAMES=
 
-EXCLUDE_FROM_CHECKSUMS_BUILDSPEC=true
 EXCLUDE_FROM_UPGRADE_BUILDSPEC=true
 
 BUILDSPEC_VARS_KEYS=BINARY_PLATFORMS
@@ -40,11 +38,17 @@ include $(BASE_DIRECTORY)/Common.mk
 
 tarballs: gather-non-golang-licenses $(OUTPUT_DIR)/ATTRIBUTION.txt
 
+# To be reproducible:
+# -debug-prefix-map to reset the build folder
+# - gcc 7, the verison in al2, does not support -macro-prefix-map which replaces
+#   __FILE__ automatically to avoid the build folder from creeping in to the final bin
+#   manually replace this since we are only building from one c/h files
 $(OUTPUT_BIN_DIR)/%: MAKEFLAGS=
 $(OUTPUT_BIN_DIR)/%: PLATFORM=$(subst -,/,$(*D:/tools=))
 $(OUTPUT_BIN_DIR)/%: $(GIT_CHECKOUT_TARGET) | $$(call ENABLE_DOCKER_PLATFORM,$$(PLATFORM))
 	@mkdir -p $(MAKE_ROOT)/$(@D); \
-	$(MAKE) -C $(REPO)/tools/bootconfig OUTPUT=$(MAKE_ROOT)/$(@D)/
+	sed -i 's/__FILE__/"lib\/bootconfig.c"/' linux/tools/bootconfig/include/linux/bootconfig.h; \
+	$(MAKE) -C $(REPO)/tools/bootconfig OUTPUT=$(MAKE_ROOT)/$(@D)/ CFLAGS="-Wall -g -I$(MAKE_ROOT)/$(REPO)/tools/bootconfig/include -fdebug-prefix-map=$(MAKE_ROOT)=/buildroot"
 
 .PHONY: gather-non-golang-licenses
 gather-non-golang-licenses: $(GIT_CHECKOUT_TARGET)

--- a/release/checksums-build.yml
+++ b/release/checksums-build.yml
@@ -197,6 +197,22 @@ batch:
         variables:
           PROJECT_PATH: projects/helm/helm
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/helm.helm
+    - identifier: isc_projects_dhcp_linux_amd64
+      env:
+        type: LINUX_CONTAINER
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          PROJECT_PATH: projects/isc-projects/dhcp
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/isc-projects.dhcp
+          BINARY_PLATFORMS: linux/amd64
+    - identifier: isc_projects_dhcp_linux_arm64
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          PROJECT_PATH: projects/isc-projects/dhcp
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/isc-projects.dhcp
+          BINARY_PLATFORMS: linux/arm64
     - identifier: kube_vip_kube_vip
       env:
         type: ARM_CONTAINER
@@ -473,6 +489,22 @@ batch:
         variables:
           PROJECT_PATH: projects/tinkerbell/hub
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/tinkerbell.hub
+    - identifier: tinkerbell_ipxedust_linux_amd64
+      env:
+        type: LINUX_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          PROJECT_PATH: projects/tinkerbell/ipxedust
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/tinkerbell.ipxedust
+          BINARY_PLATFORMS: linux/amd64
+    - identifier: tinkerbell_ipxedust_linux_arm64
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          PROJECT_PATH: projects/tinkerbell/ipxedust
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/tinkerbell.ipxedust
+          BINARY_PLATFORMS: linux/arm64
     - identifier: tinkerbell_rufio
       env:
         type: ARM_CONTAINER
@@ -493,6 +525,22 @@ batch:
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           PROJECT_PATH: projects/tinkerbell/tinkerbell-chart
+    - identifier: torvalds_linux_linux_amd64
+      env:
+        type: LINUX_CONTAINER
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          PROJECT_PATH: projects/torvalds/linux
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/torvalds.linux
+          BINARY_PLATFORMS: linux/amd64
+    - identifier: torvalds_linux_linux_arm64
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_SMALL
+        variables:
+          PROJECT_PATH: projects/torvalds/linux
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/torvalds.linux
+          BINARY_PLATFORMS: linux/arm64
     - identifier: vmware_govmomi
       env:
         type: ARM_CONTAINER
@@ -532,6 +580,8 @@ batch:
         - fluxcd_source_controller
         - goharbor_harbor
         - helm_helm
+        - isc_projects_dhcp_linux_amd64
+        - isc_projects_dhcp_linux_arm64
         - kube_vip_kube_vip
         - kubernetes_autoscaler_1_27
         - kubernetes_autoscaler_1_28
@@ -569,9 +619,13 @@ batch:
         - tinkerbell_hegel
         - tinkerbell_hook
         - tinkerbell_hub
+        - tinkerbell_ipxedust_linux_amd64
+        - tinkerbell_ipxedust_linux_arm64
         - tinkerbell_rufio
         - tinkerbell_tink
         - tinkerbell_tinkerbell_chart
+        - torvalds_linux_linux_amd64
+        - torvalds_linux_linux_arm64
         - vmware_govmomi
 version: 0.2
 env:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Set build time based on the ipxedust repo commit timestamp to make builds reproducible.

Going to keep boots set to ignore checksums because updating boots due to a update in ipxe will get a bit problematic.  I started to code out a way for the boots presubmit to build ipxe and then use it so that we can use presubmits to validate checksums like we do for other projects.  That would have made it so whenever ipxe changes the boots pre would fail, cluing us into the need to update the checksum.  The issue is that the boots bin, both the amd and the arm, needs to include the amd and arm versions of ipxe.  We do not have a good way to build both arm and amd in the same prow job so we could build just the amd or just arm, depending on the job, but that means we would have an out of date version of the other which would affect the checksum anyway.

I think this is a fine trade off. We can validate the checksums in ipxe and ignore them in boots.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
