### PR TITLE
Remove distribution from staging buildspec

### DIFF
--- a/projects/distribution/distribution/Makefile
+++ b/projects/distribution/distribution/Makefile
@@ -15,6 +15,8 @@ EXTRA_GO_LDFLAGS=-X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision
 EXTRA_GOBUILD_FLAGS=-tags include_oss,include_gcs
 
 HAS_S3_ARTIFACTS=true
+EXCLUDE_FROM_STAGING_BUILDSPEC=true
+SKIP_ON_RELEASE_BRANCH=true
 IMAGE_NAMES=
 
 FIX_LICENSES_REDIS_TARGET=$(REPO)/vendor/github.com/garyburd/redigo/LICENSE.txt

--- a/release/staging-build.yml
+++ b/release/staging-build.yml
@@ -212,13 +212,6 @@ batch:
           PROJECT_PATH: projects/containerd/containerd
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/containerd.containerd
           BINARY_PLATFORMS: linux/arm64
-    - identifier: distribution_distribution
-      env:
-        type: ARM_CONTAINER
-        compute-type: BUILD_GENERAL1_SMALL
-        variables:
-          PROJECT_PATH: projects/distribution/distribution
-          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/distribution.distribution
     - identifier: envoyproxy_envoy
       env:
         type: ARM_CONTAINER


### PR DESCRIPTION
Remove distribution project from staging buildspec since we only need it for the Harbor build which we don't run in staging build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
