### PR TITLE
Use Dockerfile to retrieve Rufio Go version

### DIFF
--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -360,8 +360,8 @@ var (
 			GoVersionSearchString: `GO_VERSION: "(1\.\d\d)"`,
 		},
 		"tinkerbell/rufio": {
-			SourceOfTruthFile:     ".github/workflows/ci.yaml",
-			GoVersionSearchString: `GO_VERSION: '(1\.\d\d)'`,
+			SourceOfTruthFile:     "Dockerfile",
+			GoVersionSearchString: `golang:(1\.\d\d)`,
 		},
 		"tinkerbell/hook": {
 			SourceOfTruthFile:     "images/hook-bootkit/Dockerfile",


### PR DESCRIPTION
Use Dockerfile to retrieve Rufio Go version since the CI yaml isn't regularly updated upstream.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
