### PR TITLE
forces combine-images flow to build both platforms

### DIFF
--- a/buildspecs/combine-images.yml
+++ b/buildspecs/combine-images.yml
@@ -6,6 +6,7 @@ env:
     BINARY_TARGETS: ""
     LICENSES_TARGETS_FOR_PREREQ: ""
     HANDLE_DEPENDENCIES_TARGET: ""
+    IMAGE_PLATFORMS: "linux/amd64,linux/arm64"
 
 phases:
   pre_build:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In the linuxkit makefile we default image_platforms to the local host arch. We probably dont have to do this, but it makes it a bit easier when working locally.  Because of this we were combining the amd and arm images in codebuild but only including the arm image.  This sets the image platforms in the combine-images buildspec to override this.  There would not be a case, at least right now, where we wouldnt want both platforms during combine so this feels like a reasonable change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
