### PR TITLE
Fix typo in password env var in autoinstall script

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0014-Set-SSH-password-dynamically-during-auto-install.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0014-Set-SSH-password-dynamically-during-auto-install.patch
@@ -650,7 +650,7 @@ index 095d9cef3..3ddbf78be 100644
 -        # openssl passwd -6 -stdin <<< builder
 -        passwd: $6$xyz$UtXVazU08Q5b8AW.TJ3MPYZglyXa3Ttf2RCel8MCUPlEYO1evWxeWBhZ2QqivU/Ij4tqYAxMCqc2ujEM4dMSe1
 +        # openssl passwd -6 -salt <random salt> -stdin <<< <SSH password>
-+        passwd: $ENCYRPTED_SSH_PASSWORD
++        passwd: $ENCRYPTED_SSH_PASSWORD
          groups: [adm, cdrom, dip, plugdev, lxd, sudo]
          lock-passwd: false
          sudo: ALL=(ALL) NOPASSWD:ALL
@@ -668,7 +668,7 @@ index fdcb56c26..552fab33e 100644
 -        # openssl passwd -6 -stdin <<< builder
 -        passwd: $6$xyz$UtXVazU08Q5b8AW.TJ3MPYZglyXa3Ttf2RCel8MCUPlEYO1evWxeWBhZ2QqivU/Ij4tqYAxMCqc2ujEM4dMSe1
 +        # openssl passwd -6 -salt <random salt> -stdin <<< <SSH password>
-+        passwd: $ENCYRPTED_SSH_PASSWORD
++        passwd: $ENCRYPTED_SSH_PASSWORD
          groups: [adm, cdrom, dip, plugdev, lxd, sudo]
          lock-passwd: false
          sudo: ALL=(ALL) NOPASSWD:ALL
@@ -686,7 +686,7 @@ index 4fc719c5e..d2dfa8cdc 100644
 -        # openssl passwd -6 -stdin <<< builder
 -        passwd: $6$xyz$UtXVazU08Q5b8AW.TJ3MPYZglyXa3Ttf2RCel8MCUPlEYO1evWxeWBhZ2QqivU/Ij4tqYAxMCqc2ujEM4dMSe1
 +        # openssl passwd -6 -salt <random salt> -stdin <<< <SSH password>
-+        passwd: $ENCYRPTED_SSH_PASSWORD
++        passwd: $ENCRYPTED_SSH_PASSWORD
          groups: [adm, cdrom, dip, plugdev, lxd, sudo]
          lock-passwd: false
          sudo: ALL=(ALL) NOPASSWD:ALL
@@ -704,7 +704,7 @@ index 4de39804a..35b601024 100644
 -        # openssl passwd -6 -stdin <<< builder
 -        passwd: $6$xyz$UtXVazU08Q5b8AW.TJ3MPYZglyXa3Ttf2RCel8MCUPlEYO1evWxeWBhZ2QqivU/Ij4tqYAxMCqc2ujEM4dMSe1
 +        # openssl passwd -6 -salt <random salt> -stdin <<< <SSH password>
-+        passwd: $ENCYRPTED_SSH_PASSWORD
++        passwd: $ENCRYPTED_SSH_PASSWORD
          groups: [adm, cdrom, dip, plugdev, lxd, sudo]
          lock-passwd: false
          sudo: ALL=(ALL) NOPASSWD:ALL
@@ -799,7 +799,7 @@ index 5092fe034..40d8c7076 100644
 -        # openssl passwd -6 -stdin <<< builder
 -        passwd: $6$xyz$UtXVazU08Q5b8AW.TJ3MPYZglyXa3Ttf2RCel8MCUPlEYO1evWxeWBhZ2QqivU/Ij4tqYAxMCqc2ujEM4dMSe1
 +        # openssl passwd -6 -salt <random salt> -stdin <<< <SSH password>
-+        passwd: $ENCYRPTED_SSH_PASSWORD
++        passwd: $ENCRYPTED_SSH_PASSWORD
          groups: [adm, cdrom, dip, plugdev, lxd, sudo]
          lock-passwd: false
          sudo: ALL=(ALL) NOPASSWD:ALL
@@ -817,7 +817,7 @@ index 8af863154..d241348dc 100644
 -        # openssl passwd -6 -stdin <<< builder
 -        passwd: $6$xyz$UtXVazU08Q5b8AW.TJ3MPYZglyXa3Ttf2RCel8MCUPlEYO1evWxeWBhZ2QqivU/Ij4tqYAxMCqc2ujEM4dMSe1
 +        # openssl passwd -6 -salt <random salt> -stdin <<< <SSH password>
-+        passwd: $ENCYRPTED_SSH_PASSWORD
++        passwd: $ENCRYPTED_SSH_PASSWORD
          groups: [adm, cdrom, dip, plugdev, lxd, sudo]
          lock-passwd: false
          sudo: ALL=(ALL) NOPASSWD:ALL
@@ -860,7 +860,7 @@ index 0df503993..87883864b 100644
  users:
    - name: builder
 -    passwd: $6$xyz$UtXVazU08Q5b8AW.TJ3MPYZglyXa3Ttf2RCel8MCUPlEYO1evWxeWBhZ2QqivU/Ij4tqYAxMCqc2ujEM4dMSe1
-+    passwd: $ENCYRPTED_SSH_PASSWORD
++    passwd: $ENCRYPTED_SSH_PASSWORD
      groups: [adm, cdrom, dip, plugdev, lxd, sudo]
      lock-passwd: false
      sudo: ALL=(ALL) NOPASSWD:ALL
@@ -990,7 +990,7 @@ index adad49044..9183bbae5 100644
 -        # openssl passwd -6 -stdin <<< builder
 -        passwd: $6$xyz$UtXVazU08Q5b8AW.TJ3MPYZglyXa3Ttf2RCel8MCUPlEYO1evWxeWBhZ2QqivU/Ij4tqYAxMCqc2ujEM4dMSe1
 +        # openssl passwd -6 -salt <random salt> -stdin <<< <SSH password>
-+        passwd: $ENCYRPTED_SSH_PASSWORD
++        passwd: $ENCRYPTED_SSH_PASSWORD
          groups: [adm, cdrom, dip, plugdev, lxd, sudo]
          lock-passwd: false
          sudo: ALL=(ALL) NOPASSWD:ALL
@@ -1008,7 +1008,7 @@ index 743abae99..4df289f37 100644
 -        # openssl passwd -6 -stdin <<< builder
 -        passwd: $6$xyz$UtXVazU08Q5b8AW.TJ3MPYZglyXa3Ttf2RCel8MCUPlEYO1evWxeWBhZ2QqivU/Ij4tqYAxMCqc2ujEM4dMSe1
 +        # openssl passwd -6 -salt <random salt> -stdin <<< <SSH password>
-+        passwd: $ENCYRPTED_SSH_PASSWORD
++        passwd: $ENCRYPTED_SSH_PASSWORD
          groups: [adm, cdrom, dip, plugdev, lxd, sudo]
          lock-passwd: false
          sudo: ALL=(ALL) NOPASSWD:ALL
@@ -1026,7 +1026,7 @@ index 3fe63c5fe..24ef485cd 100644
 -        # openssl passwd -6 -stdin <<< builder
 -        passwd: $6$xyz$UtXVazU08Q5b8AW.TJ3MPYZglyXa3Ttf2RCel8MCUPlEYO1evWxeWBhZ2QqivU/Ij4tqYAxMCqc2ujEM4dMSe1
 +        # openssl passwd -6 -salt <random salt> -stdin <<< <SSH password>
-+        passwd: $ENCYRPTED_SSH_PASSWORD
++        passwd: $ENCRYPTED_SSH_PASSWORD
          groups: [adm, cdrom, dip, plugdev, lxd, sudo]
          lock-passwd: false
          sudo: ALL=(ALL) NOPASSWD:ALL
@@ -1044,7 +1044,7 @@ index e6b1fc77a..11bcda99d 100644
 -        # openssl passwd -6 -stdin <<< builder
 -        passwd: $6$xyz$UtXVazU08Q5b8AW.TJ3MPYZglyXa3Ttf2RCel8MCUPlEYO1evWxeWBhZ2QqivU/Ij4tqYAxMCqc2ujEM4dMSe1
 +        # openssl passwd -6 -salt <random salt> -stdin <<< <SSH password>
-+        passwd: $ENCYRPTED_SSH_PASSWORD
++        passwd: $ENCRYPTED_SSH_PASSWORD
          groups: [adm, cdrom, dip, plugdev, lxd, sudo]
          lock-passwd: false
          sudo: ALL=(ALL) NOPASSWD:ALL
@@ -1062,7 +1062,7 @@ index b1ad45b2b..94ee5dc05 100644
 -        # openssl passwd -6 -stdin <<< builder
 -        passwd: $6$xyz$UtXVazU08Q5b8AW.TJ3MPYZglyXa3Ttf2RCel8MCUPlEYO1evWxeWBhZ2QqivU/Ij4tqYAxMCqc2ujEM4dMSe1
 +        # openssl passwd -6 -salt <random salt> -stdin <<< <SSH password>
-+        passwd: $ENCYRPTED_SSH_PASSWORD
++        passwd: $ENCRYPTED_SSH_PASSWORD
          groups: [adm, cdrom, dip, plugdev, lxd, sudo]
          lock-passwd: false
          sudo: ALL=(ALL) NOPASSWD:ALL
@@ -1080,7 +1080,7 @@ index e6b1fc77a..11bcda99d 100644
 -        # openssl passwd -6 -stdin <<< builder
 -        passwd: $6$xyz$UtXVazU08Q5b8AW.TJ3MPYZglyXa3Ttf2RCel8MCUPlEYO1evWxeWBhZ2QqivU/Ij4tqYAxMCqc2ujEM4dMSe1
 +        # openssl passwd -6 -salt <random salt> -stdin <<< <SSH password>
-+        passwd: $ENCYRPTED_SSH_PASSWORD
++        passwd: $ENCRYPTED_SSH_PASSWORD
          groups: [adm, cdrom, dip, plugdev, lxd, sudo]
          lock-passwd: false
          sudo: ALL=(ALL) NOPASSWD:ALL
@@ -1209,7 +1209,7 @@ index d14d0fa49..6aedd8389 100644
 -        # openssl passwd -6 -stdin <<< builder
 -        passwd: $6$xyz$UtXVazU08Q5b8AW.TJ3MPYZglyXa3Ttf2RCel8MCUPlEYO1evWxeWBhZ2QqivU/Ij4tqYAxMCqc2ujEM4dMSe1
 +        # openssl passwd -6 -salt <random salt> -stdin <<< <SSH password>
-+        passwd: $ENCYRPTED_SSH_PASSWORD
++        passwd: $ENCRYPTED_SSH_PASSWORD
          groups: [adm, cdrom, dip, plugdev, lxd, sudo]
          lock-passwd: false
          sudo: ALL=(ALL) NOPASSWD:ALL
@@ -1227,7 +1227,7 @@ index a5ed32346..50a20ac13 100644
 -        # openssl passwd -6 -stdin <<< builder
 -        passwd: $6$xyz$UtXVazU08Q5b8AW.TJ3MPYZglyXa3Ttf2RCel8MCUPlEYO1evWxeWBhZ2QqivU/Ij4tqYAxMCqc2ujEM4dMSe1
 +        # openssl passwd -6 -salt <random salt> -stdin <<< <SSH password>
-+        passwd: $ENCYRPTED_SSH_PASSWORD
++        passwd: $ENCRYPTED_SSH_PASSWORD
          groups: [adm, cdrom, dip, plugdev, lxd, sudo]
          lock-passwd: false
          sudo: ALL=(ALL) NOPASSWD:ALL


### PR DESCRIPTION
Fix typo in password env var in autoinstall script

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
