### PR TITLE
Include files not in index in patch application failure comment

### DIFF
--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -34,9 +34,11 @@ const (
 	ManifestsDirectory                      = "manifests"
 	PatchesDirectory                        = "patches"
 	FailedPatchApplyMarker                  = "patch does not apply"
+	DoesNotExistInIndexMarker               = "does not exist in index"
 	SemverRegex                             = `v?(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?`
 	FailedPatchApplyRegex                   = "Patch failed at .*"
 	FailedPatchFilesRegex                   = "error: (.*): patch does not apply"
+	DoesNotExistInIndexFilesRegex           = "error: (.*): does not exist in index"
 	BottlerocketReleasesFile                = "BOTTLEROCKET_RELEASES"
 	BottlerocketContainerMetadataFileFormat = "BOTTLEROCKET_%s_CONTAINER_METADATA"
 	BottlerocketHostContainersTOMLFile      = "sources/shared-defaults/public-host-containers.toml"


### PR DESCRIPTION
Sometimes patch application can fail not only due to merge conflicts but also because the file that the patch is applying doesn't exist on the target repo. For example, we saw this happening for the kubernetes-sigs/image-builder project's v0.1.39 tag which includes kubernetes-sigs/image-builder#1607, which renames some files to templates with `.tmpl` extension. The upgrade command needs to handle this specific error message so that it adds the proper patch warning comment on PRs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
