### PR TITLE
Update ADOT image digest when bumping Git tag

### DIFF
--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -386,6 +386,8 @@ var (
 
 	CiliumImageDirectories = []string{"cilium", "operator-generic", "cilium-chart"}
 
+	ADOTImageDirectories = []string{"collector"}
+
 	ProjectsSupportingPrereleaseTags = []string{"kubernetes-sigs/cluster-api-provider-cloudstack"}
 
 	// These projects will be upgraded only on main and won't be triggered on release branches.


### PR DESCRIPTION
*Description of changes:*
We have the `IMAGE_DIGEST` ADOT image digest checked into the repo, but this is tied to a particular ADOT version, so we need to update the image digest when bumping the ADOT Git tag.

*Testing:*
`make -C tools/version-tracker build`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
