### PR TITLE
Fix remove-addon-resizer patch for metrics-server

### DIFF
--- a/projects/kubernetes-sigs/metrics-server/1-27/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-27/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
@@ -1,4 +1,4 @@
-From 6a11127259db3b523e3d4330a6f1e931cc622018 Mon Sep 17 00:00:00 2001
+From 7eac08471142e4cf65c716b5032900744810cc54 Mon Sep 17 00:00:00 2001
 From: Jonathan Meier <jwmeier@amazon.com>
 Date: Fri, 23 Sep 2022 12:17:23 -0400
 Subject: [PATCH 1/2] Conform helm chart to packages standards
@@ -101,5 +101,5 @@ index be843db4..340c3640 100644
  nameOverride: ""
  fullnameOverride: ""
 -- 
-2.46.2
+2.44.0
 

--- a/projects/kubernetes-sigs/metrics-server/1-27/helm/patches/0002-Remove-Addon-Resizer.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-27/helm/patches/0002-Remove-Addon-Resizer.patch
@@ -1,6 +1,6 @@
-From c7343600fda37356310744408172059751f3b50c Mon Sep 17 00:00:00 2001
-From: Prow Bot <prow@amazonaws.com>
-Date: Sun, 2 Jun 2024 17:37:38 -0700
+From 2bc53abc0591dc8b1da6c17163f28a864d4b8049 Mon Sep 17 00:00:00 2001
+From: Jhaanvi Golani <jhaanvi@amazon.com>
+Date: Fri, 18 Oct 2024 12:09:20 -0700
 Subject: [PATCH 2/2] Remove Addon Resizer
 
 ---
@@ -10,12 +10,14 @@ Subject: [PATCH 2/2] Remove Addon Resizer
  .../templates/configmaps-nanny.yaml           | 17 --------
  .../metrics-server/templates/deployment.yaml  | 39 -------------------
  .../metrics-server/templates/role-nanny.yaml  | 27 -------------
+ .../templates/rolebinding-nanny.yaml          | 19 ---------
  charts/metrics-server/values.yaml             | 34 ----------------
- 7 files changed, 169 deletions(-)
+ 8 files changed, 188 deletions(-)
  delete mode 100644 charts/metrics-server/templates/clusterrole-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/clusterrolebinding-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/configmaps-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/role-nanny.yaml
+ delete mode 100644 charts/metrics-server/templates/rolebinding-nanny.yaml
 
 diff --git a/charts/metrics-server/templates/_helpers.tpl b/charts/metrics-server/templates/_helpers.tpl
 index 492e4623..e9b47284 100644
@@ -201,6 +203,31 @@ index f0bf8fce..00000000
 -  - patch
 -{{- end -}}
 -{{- end -}}
+diff --git a/charts/metrics-server/templates/rolebinding-nanny.yaml b/charts/metrics-server/templates/rolebinding-nanny.yaml
+deleted file mode 100644
+index 228c0cfe..00000000
+--- a/charts/metrics-server/templates/rolebinding-nanny.yaml
++++ /dev/null
+@@ -1,19 +0,0 @@
+-{{- if .Values.rbac.create -}}
+-{{- if .Values.addonResizer.enabled -}}
+-apiVersion: rbac.authorization.k8s.io/v1
+-kind: RoleBinding
+-metadata:
+-  name: {{ printf "%s-nanny" (include "metrics-server.fullname" .)  }}
+-  namespace: {{ .Release.Namespace }}
+-  labels:
+-    {{- include "metrics-server.labels" . | nindent 4 }}
+-roleRef:
+-  apiGroup: rbac.authorization.k8s.io
+-  kind: Role
+-  name: {{ include "metrics-server.addonResizer.role" . }}
+-subjects:
+-  - kind: ServiceAccount
+-    name: {{ include "metrics-server.serviceAccountName" . }}
+-    namespace: {{ .Release.Namespace }}
+-{{- end -}}
+-{{- end -}}
 diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
 index 340c3640..0008cee1 100644
 --- a/charts/metrics-server/values.yaml
@@ -254,5 +281,5 @@ index 340c3640..0008cee1 100644
  extraVolumeMounts: []
  
 -- 
-2.46.2
+2.44.0
 

--- a/projects/kubernetes-sigs/metrics-server/1-28/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-28/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
@@ -1,4 +1,4 @@
-From 6a11127259db3b523e3d4330a6f1e931cc622018 Mon Sep 17 00:00:00 2001
+From 7eac08471142e4cf65c716b5032900744810cc54 Mon Sep 17 00:00:00 2001
 From: Jonathan Meier <jwmeier@amazon.com>
 Date: Fri, 23 Sep 2022 12:17:23 -0400
 Subject: [PATCH 1/2] Conform helm chart to packages standards
@@ -101,5 +101,5 @@ index be843db4..340c3640 100644
  nameOverride: ""
  fullnameOverride: ""
 -- 
-2.46.2
+2.44.0
 

--- a/projects/kubernetes-sigs/metrics-server/1-28/helm/patches/0002-Remove-Addon-Resizer.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-28/helm/patches/0002-Remove-Addon-Resizer.patch
@@ -1,6 +1,6 @@
-From c7343600fda37356310744408172059751f3b50c Mon Sep 17 00:00:00 2001
-From: Prow Bot <prow@amazonaws.com>
-Date: Sun, 2 Jun 2024 17:37:38 -0700
+From dde9ebc3a806df48d587e9e38eaa4cc78ab3474c Mon Sep 17 00:00:00 2001
+From: Jhaanvi Golani <jhaanvi@amazon.com>
+Date: Fri, 18 Oct 2024 12:11:17 -0700
 Subject: [PATCH 2/2] Remove Addon Resizer
 
 ---
@@ -10,12 +10,14 @@ Subject: [PATCH 2/2] Remove Addon Resizer
  .../templates/configmaps-nanny.yaml           | 17 --------
  .../metrics-server/templates/deployment.yaml  | 39 -------------------
  .../metrics-server/templates/role-nanny.yaml  | 27 -------------
+ .../templates/rolebinding-nanny.yaml          | 19 ---------
  charts/metrics-server/values.yaml             | 34 ----------------
- 7 files changed, 169 deletions(-)
+ 8 files changed, 188 deletions(-)
  delete mode 100644 charts/metrics-server/templates/clusterrole-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/clusterrolebinding-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/configmaps-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/role-nanny.yaml
+ delete mode 100644 charts/metrics-server/templates/rolebinding-nanny.yaml
 
 diff --git a/charts/metrics-server/templates/_helpers.tpl b/charts/metrics-server/templates/_helpers.tpl
 index 492e4623..e9b47284 100644
@@ -201,6 +203,31 @@ index f0bf8fce..00000000
 -  - patch
 -{{- end -}}
 -{{- end -}}
+diff --git a/charts/metrics-server/templates/rolebinding-nanny.yaml b/charts/metrics-server/templates/rolebinding-nanny.yaml
+deleted file mode 100644
+index 228c0cfe..00000000
+--- a/charts/metrics-server/templates/rolebinding-nanny.yaml
++++ /dev/null
+@@ -1,19 +0,0 @@
+-{{- if .Values.rbac.create -}}
+-{{- if .Values.addonResizer.enabled -}}
+-apiVersion: rbac.authorization.k8s.io/v1
+-kind: RoleBinding
+-metadata:
+-  name: {{ printf "%s-nanny" (include "metrics-server.fullname" .)  }}
+-  namespace: {{ .Release.Namespace }}
+-  labels:
+-    {{- include "metrics-server.labels" . | nindent 4 }}
+-roleRef:
+-  apiGroup: rbac.authorization.k8s.io
+-  kind: Role
+-  name: {{ include "metrics-server.addonResizer.role" . }}
+-subjects:
+-  - kind: ServiceAccount
+-    name: {{ include "metrics-server.serviceAccountName" . }}
+-    namespace: {{ .Release.Namespace }}
+-{{- end -}}
+-{{- end -}}
 diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
 index 340c3640..0008cee1 100644
 --- a/charts/metrics-server/values.yaml
@@ -254,5 +281,5 @@ index 340c3640..0008cee1 100644
  extraVolumeMounts: []
  
 -- 
-2.46.2
+2.44.0
 

--- a/projects/kubernetes-sigs/metrics-server/1-29/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-29/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
@@ -1,4 +1,4 @@
-From 6a11127259db3b523e3d4330a6f1e931cc622018 Mon Sep 17 00:00:00 2001
+From 7eac08471142e4cf65c716b5032900744810cc54 Mon Sep 17 00:00:00 2001
 From: Jonathan Meier <jwmeier@amazon.com>
 Date: Fri, 23 Sep 2022 12:17:23 -0400
 Subject: [PATCH 1/2] Conform helm chart to packages standards
@@ -101,5 +101,5 @@ index be843db4..340c3640 100644
  nameOverride: ""
  fullnameOverride: ""
 -- 
-2.46.2
+2.44.0
 

--- a/projects/kubernetes-sigs/metrics-server/1-29/helm/patches/0002-Remove-Addon-Resizer.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-29/helm/patches/0002-Remove-Addon-Resizer.patch
@@ -1,6 +1,6 @@
-From c7343600fda37356310744408172059751f3b50c Mon Sep 17 00:00:00 2001
-From: Prow Bot <prow@amazonaws.com>
-Date: Sun, 2 Jun 2024 17:37:38 -0700
+From c5a794e88d0bceac0e16370d4f76baade4e0ccf6 Mon Sep 17 00:00:00 2001
+From: Jhaanvi Golani <jhaanvi@amazon.com>
+Date: Fri, 18 Oct 2024 12:11:41 -0700
 Subject: [PATCH 2/2] Remove Addon Resizer
 
 ---
@@ -10,12 +10,14 @@ Subject: [PATCH 2/2] Remove Addon Resizer
  .../templates/configmaps-nanny.yaml           | 17 --------
  .../metrics-server/templates/deployment.yaml  | 39 -------------------
  .../metrics-server/templates/role-nanny.yaml  | 27 -------------
+ .../templates/rolebinding-nanny.yaml          | 19 ---------
  charts/metrics-server/values.yaml             | 34 ----------------
- 7 files changed, 169 deletions(-)
+ 8 files changed, 188 deletions(-)
  delete mode 100644 charts/metrics-server/templates/clusterrole-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/clusterrolebinding-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/configmaps-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/role-nanny.yaml
+ delete mode 100644 charts/metrics-server/templates/rolebinding-nanny.yaml
 
 diff --git a/charts/metrics-server/templates/_helpers.tpl b/charts/metrics-server/templates/_helpers.tpl
 index 492e4623..e9b47284 100644
@@ -201,6 +203,31 @@ index f0bf8fce..00000000
 -  - patch
 -{{- end -}}
 -{{- end -}}
+diff --git a/charts/metrics-server/templates/rolebinding-nanny.yaml b/charts/metrics-server/templates/rolebinding-nanny.yaml
+deleted file mode 100644
+index 228c0cfe..00000000
+--- a/charts/metrics-server/templates/rolebinding-nanny.yaml
++++ /dev/null
+@@ -1,19 +0,0 @@
+-{{- if .Values.rbac.create -}}
+-{{- if .Values.addonResizer.enabled -}}
+-apiVersion: rbac.authorization.k8s.io/v1
+-kind: RoleBinding
+-metadata:
+-  name: {{ printf "%s-nanny" (include "metrics-server.fullname" .)  }}
+-  namespace: {{ .Release.Namespace }}
+-  labels:
+-    {{- include "metrics-server.labels" . | nindent 4 }}
+-roleRef:
+-  apiGroup: rbac.authorization.k8s.io
+-  kind: Role
+-  name: {{ include "metrics-server.addonResizer.role" . }}
+-subjects:
+-  - kind: ServiceAccount
+-    name: {{ include "metrics-server.serviceAccountName" . }}
+-    namespace: {{ .Release.Namespace }}
+-{{- end -}}
+-{{- end -}}
 diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
 index 340c3640..0008cee1 100644
 --- a/charts/metrics-server/values.yaml
@@ -254,5 +281,5 @@ index 340c3640..0008cee1 100644
  extraVolumeMounts: []
  
 -- 
-2.46.2
+2.44.0
 

--- a/projects/kubernetes-sigs/metrics-server/1-30/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-30/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
@@ -1,4 +1,4 @@
-From 6a11127259db3b523e3d4330a6f1e931cc622018 Mon Sep 17 00:00:00 2001
+From 7eac08471142e4cf65c716b5032900744810cc54 Mon Sep 17 00:00:00 2001
 From: Jonathan Meier <jwmeier@amazon.com>
 Date: Fri, 23 Sep 2022 12:17:23 -0400
 Subject: [PATCH 1/2] Conform helm chart to packages standards
@@ -101,5 +101,5 @@ index be843db4..340c3640 100644
  nameOverride: ""
  fullnameOverride: ""
 -- 
-2.46.2
+2.44.0
 

--- a/projects/kubernetes-sigs/metrics-server/1-30/helm/patches/0002-Remove-Addon-Resizer.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-30/helm/patches/0002-Remove-Addon-Resizer.patch
@@ -1,6 +1,6 @@
-From c7343600fda37356310744408172059751f3b50c Mon Sep 17 00:00:00 2001
-From: Prow Bot <prow@amazonaws.com>
-Date: Sun, 2 Jun 2024 17:37:38 -0700
+From 467db22328a4958b0ea1d6b106ce3bd324033201 Mon Sep 17 00:00:00 2001
+From: Jhaanvi Golani <jhaanvi@amazon.com>
+Date: Fri, 18 Oct 2024 12:22:26 -0700
 Subject: [PATCH 2/2] Remove Addon Resizer
 
 ---
@@ -10,12 +10,14 @@ Subject: [PATCH 2/2] Remove Addon Resizer
  .../templates/configmaps-nanny.yaml           | 17 --------
  .../metrics-server/templates/deployment.yaml  | 39 -------------------
  .../metrics-server/templates/role-nanny.yaml  | 27 -------------
+ .../templates/rolebinding-nanny.yaml          | 19 ---------
  charts/metrics-server/values.yaml             | 34 ----------------
- 7 files changed, 169 deletions(-)
+ 8 files changed, 188 deletions(-)
  delete mode 100644 charts/metrics-server/templates/clusterrole-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/clusterrolebinding-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/configmaps-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/role-nanny.yaml
+ delete mode 100644 charts/metrics-server/templates/rolebinding-nanny.yaml
 
 diff --git a/charts/metrics-server/templates/_helpers.tpl b/charts/metrics-server/templates/_helpers.tpl
 index 492e4623..e9b47284 100644
@@ -201,6 +203,31 @@ index f0bf8fce..00000000
 -  - patch
 -{{- end -}}
 -{{- end -}}
+diff --git a/charts/metrics-server/templates/rolebinding-nanny.yaml b/charts/metrics-server/templates/rolebinding-nanny.yaml
+deleted file mode 100644
+index 228c0cfe..00000000
+--- a/charts/metrics-server/templates/rolebinding-nanny.yaml
++++ /dev/null
+@@ -1,19 +0,0 @@
+-{{- if .Values.rbac.create -}}
+-{{- if .Values.addonResizer.enabled -}}
+-apiVersion: rbac.authorization.k8s.io/v1
+-kind: RoleBinding
+-metadata:
+-  name: {{ printf "%s-nanny" (include "metrics-server.fullname" .)  }}
+-  namespace: {{ .Release.Namespace }}
+-  labels:
+-    {{- include "metrics-server.labels" . | nindent 4 }}
+-roleRef:
+-  apiGroup: rbac.authorization.k8s.io
+-  kind: Role
+-  name: {{ include "metrics-server.addonResizer.role" . }}
+-subjects:
+-  - kind: ServiceAccount
+-    name: {{ include "metrics-server.serviceAccountName" . }}
+-    namespace: {{ .Release.Namespace }}
+-{{- end -}}
+-{{- end -}}
 diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
 index 340c3640..0008cee1 100644
 --- a/charts/metrics-server/values.yaml
@@ -254,5 +281,5 @@ index 340c3640..0008cee1 100644
  extraVolumeMounts: []
  
 -- 
-2.46.2
+2.44.0
 

--- a/projects/kubernetes-sigs/metrics-server/1-31/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-31/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
@@ -1,4 +1,4 @@
-From 6a11127259db3b523e3d4330a6f1e931cc622018 Mon Sep 17 00:00:00 2001
+From 7eac08471142e4cf65c716b5032900744810cc54 Mon Sep 17 00:00:00 2001
 From: Jonathan Meier <jwmeier@amazon.com>
 Date: Fri, 23 Sep 2022 12:17:23 -0400
 Subject: [PATCH 1/2] Conform helm chart to packages standards
@@ -101,5 +101,5 @@ index be843db4..340c3640 100644
  nameOverride: ""
  fullnameOverride: ""
 -- 
-2.46.2
+2.44.0
 

--- a/projects/kubernetes-sigs/metrics-server/1-31/helm/patches/0002-Remove-Addon-Resizer.patch
+++ b/projects/kubernetes-sigs/metrics-server/1-31/helm/patches/0002-Remove-Addon-Resizer.patch
@@ -1,6 +1,6 @@
-From c7343600fda37356310744408172059751f3b50c Mon Sep 17 00:00:00 2001
-From: Prow Bot <prow@amazonaws.com>
-Date: Sun, 2 Jun 2024 17:37:38 -0700
+From 06918cab2990ad4dc8f7536335163dc4a1d4788b Mon Sep 17 00:00:00 2001
+From: Jhaanvi Golani <jhaanvi@amazon.com>
+Date: Fri, 18 Oct 2024 12:25:24 -0700
 Subject: [PATCH 2/2] Remove Addon Resizer
 
 ---
@@ -10,12 +10,14 @@ Subject: [PATCH 2/2] Remove Addon Resizer
  .../templates/configmaps-nanny.yaml           | 17 --------
  .../metrics-server/templates/deployment.yaml  | 39 -------------------
  .../metrics-server/templates/role-nanny.yaml  | 27 -------------
+ .../templates/rolebinding-nanny.yaml          | 19 ---------
  charts/metrics-server/values.yaml             | 34 ----------------
- 7 files changed, 169 deletions(-)
+ 8 files changed, 188 deletions(-)
  delete mode 100644 charts/metrics-server/templates/clusterrole-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/clusterrolebinding-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/configmaps-nanny.yaml
  delete mode 100644 charts/metrics-server/templates/role-nanny.yaml
+ delete mode 100644 charts/metrics-server/templates/rolebinding-nanny.yaml
 
 diff --git a/charts/metrics-server/templates/_helpers.tpl b/charts/metrics-server/templates/_helpers.tpl
 index 492e4623..e9b47284 100644
@@ -201,6 +203,31 @@ index f0bf8fce..00000000
 -  - patch
 -{{- end -}}
 -{{- end -}}
+diff --git a/charts/metrics-server/templates/rolebinding-nanny.yaml b/charts/metrics-server/templates/rolebinding-nanny.yaml
+deleted file mode 100644
+index 228c0cfe..00000000
+--- a/charts/metrics-server/templates/rolebinding-nanny.yaml
++++ /dev/null
+@@ -1,19 +0,0 @@
+-{{- if .Values.rbac.create -}}
+-{{- if .Values.addonResizer.enabled -}}
+-apiVersion: rbac.authorization.k8s.io/v1
+-kind: RoleBinding
+-metadata:
+-  name: {{ printf "%s-nanny" (include "metrics-server.fullname" .)  }}
+-  namespace: {{ .Release.Namespace }}
+-  labels:
+-    {{- include "metrics-server.labels" . | nindent 4 }}
+-roleRef:
+-  apiGroup: rbac.authorization.k8s.io
+-  kind: Role
+-  name: {{ include "metrics-server.addonResizer.role" . }}
+-subjects:
+-  - kind: ServiceAccount
+-    name: {{ include "metrics-server.serviceAccountName" . }}
+-    namespace: {{ .Release.Namespace }}
+-{{- end -}}
+-{{- end -}}
 diff --git a/charts/metrics-server/values.yaml b/charts/metrics-server/values.yaml
 index 340c3640..0008cee1 100644
 --- a/charts/metrics-server/values.yaml
@@ -254,5 +281,5 @@ index 340c3640..0008cee1 100644
  extraVolumeMounts: []
  
 -- 
-2.46.2
+2.44.0
 


### PR DESCRIPTION
*Description of changes:*
This PR fixes 'remove-addon-resizer' patch and removes `rolebinding_nanny.yaml` file

*Testing*
* helm install of built chart on existing cluster
`helm install metrics-server oci://public.ecr.aws/registry_alias/metrics-server/charts/metrics-server --version 0.7.2-eks-1-29-23-8c6cb61c206f03c401b2799fc1291054eac7fb9d --set sourceRegistry=public.ecr.aws/registry_alias`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
