### PR TITLE
Update patches and CHECKSUMS for CAPC v0.5.0

### DIFF
--- a/projects/kubernetes-sigs/cluster-api-provider-cloudstack/CHECKSUMS
+++ b/projects/kubernetes-sigs/cluster-api-provider-cloudstack/CHECKSUMS
@@ -1,2 +1,2 @@
-b845065c9fde77c5a1c0330bbd0d64524e6f5621c2579314709b4baf63bd70f4  _output/bin/cluster-api-provider-cloudstack/linux-amd64/manager
-c5f2c85da4b5083d30b0468cfea289f30b9dbe6a6a55af8e5725b8860838bfdb  _output/bin/cluster-api-provider-cloudstack/linux-arm64/manager
+ea61faa64455af634fee9210b25be70ee630606f4e97fe87fa56631ddceff4e2  _output/bin/cluster-api-provider-cloudstack/linux-amd64/manager
+c95d63f8448c10168c674ef398b30d6d44f499e23e77bf453b124f47c429fc5d  _output/bin/cluster-api-provider-cloudstack/linux-arm64/manager

--- a/projects/kubernetes-sigs/cluster-api-provider-cloudstack/patches/0001-Support-re-assignment-of-another-failure-domain-when.patch
+++ b/projects/kubernetes-sigs/cluster-api-provider-cloudstack/patches/0001-Support-re-assignment-of-another-failure-domain-when.patch
@@ -1,7 +1,7 @@
-From b955446b9e03c0958c6e1e8a54e5021437689e66 Mon Sep 17 00:00:00 2001
+From 063b631cdeeb718048e7282f6895183c5dbaa7a6 Mon Sep 17 00:00:00 2001
 From: Jhaanvi Golani <jhaanvi@amazon.com>
 Date: Mon, 11 Mar 2024 17:32:24 -0700
-Subject: [PATCH] Support re-assignment of another failure domain when the
+Subject: [PATCH 1/2] Support re-assignment of another failure domain when the
  machine failed to provision
 
 Signed-off-by: Jhaanvi Golani <jhaanvi@amazon.com>
@@ -18,7 +18,6 @@ Signed-off-by: Jhaanvi Golani <jhaanvi@amazon.com>
  ...loudstackmachinestatechecker_controller.go |   2 +-
  controllers/controllers_suite_test.go         |  18 +-
  controllers/utils/failuredomains.go           |  44 +--
- metadata.yaml                                 |   2 +-
  pkg/cloud/instance.go                         |  76 +++--
  pkg/cloud/network.go                          |  24 ++
  pkg/errors/cloudstack.go                      |  85 +++++
@@ -30,7 +29,7 @@ Signed-off-by: Jhaanvi Golani <jhaanvi@amazon.com>
  pkg/failuredomains/client_test.go             | 159 +++++++++
  .../failuredomains_suite_test.go              |  33 ++
  pkg/metrics/metrics.go                        |  22 +-
- 24 files changed, 1245 insertions(+), 110 deletions(-)
+ 23 files changed, 1244 insertions(+), 109 deletions(-)
  create mode 100644 pkg/errors/cloudstack.go
  create mode 100644 pkg/errors/cloudstack_test.go
  create mode 100644 pkg/errors/errors_suite_test.go
@@ -557,17 +556,6 @@ index bf66c25..5ca3e97 100644
 +func (c *CloudClientImplementation) GetCloudClientAndUser(ctx context.Context, fdSpec *infrav1.CloudStackFailureDomainSpec) (csClient cloud.Client, csUser cloud.Client, err error) {
 +	return c.fdClientFactory.GetCloudClientAndUser(ctx, fdSpec)
 +}
-diff --git a/metadata.yaml b/metadata.yaml
-index bd61395..a030a70 100644
---- a/metadata.yaml
-+++ b/metadata.yaml
-@@ -7,5 +7,5 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
- kind: Metadata
- releaseSeries:
-   - major: 0
--    minor: 4
-+    minor: 5
-     contract: v1beta1
 diff --git a/pkg/cloud/instance.go b/pkg/cloud/instance.go
 index 6fb5857..e622920 100644
 --- a/pkg/cloud/instance.go
@@ -1852,5 +1840,5 @@ index 77e9413..7f7ce3b 100644
 +	return errorCode
  }
 -- 
-2.46.0
+2.47.0
 

--- a/projects/kubernetes-sigs/cluster-api-provider-cloudstack/patches/0002-Add-latest-CAPC-minor-release-v0.5.0-to-metadata.yam.patch
+++ b/projects/kubernetes-sigs/cluster-api-provider-cloudstack/patches/0002-Add-latest-CAPC-minor-release-v0.5.0-to-metadata.yam.patch
@@ -1,0 +1,23 @@
+From b8f110820a5f503f3a948c92d06df77f1bf678d7 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Wed, 23 Oct 2024 13:02:26 -0700
+Subject: [PATCH 2/2] Add latest CAPC minor release v0.5.0 to metadata.yaml
+
+---
+ metadata.yaml | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/metadata.yaml b/metadata.yaml
+index bd61395..836f295 100644
+--- a/metadata.yaml
++++ b/metadata.yaml
+@@ -9,3 +9,6 @@ releaseSeries:
+   - major: 0
+     minor: 4
+     contract: v1beta1
++  - major: 0
++    minor: 5
++    contract: v1beta1
+-- 
+2.47.0
+


### PR DESCRIPTION
*Issue #, if available:*
[#2399](https://github.com/aws/eks-anywhere-internal/issues/2399)

*Description of changes:*
A patch to update the minor version in metadata.yaml was added in [#3741](https://github.com/aws/eks-anywhere-build-tooling/pull/3741) to fix the CloudStack tests failing with a version validation error. But that fixed only the cluster creation tests. In order to fix the cluster upgrade tests, we need to have both the minor release version 4 and 5 in the metadata.yaml to pass the validations as currently the CloudStack OIDC tests fail with the following error:
```
Error: invalid provider metadata: version v0.4.10-rc1+d263e1a (the current version) for 
the provider capc-system/infrastructure-cloudstack does not match any release series
```

This PR adds a new patch updating the release series to include both the minor versions in order to fix the upgrade tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
