### PR TITLE
Retry Nutanix image builds in case of internal server errors

### DIFF
--- a/projects/kubernetes-sigs/image-builder/build/build_image.sh
+++ b/projects/kubernetes-sigs/image-builder/build/build_image.sh
@@ -58,6 +58,8 @@ function retry_image_builder() {
     ["Cancelling provisioner after a timeout"]="Provisioner timed out"
     ["image size mistmatch"]="Nutanix image size mismatch"
     ["Connection timed out during banner exchange"]="Ansible SSH connection timed out"
+    ["error while findImageByUUID"]="Nutanix image search by UUID failed"
+    ["error while ListAllImage"]="Nutanix image listing failed"
   )
 
   until [ $n -eq $max ]; do


### PR DESCRIPTION
This PR adds the logic to retry Nutanix image builds in case of internal server errors, since we have observed that these usually pass when retried.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
