### PR TITLE
Skip CAPI upgrade on release branches

### DIFF
--- a/tools/version-tracker/pkg/commands/upgrade/upgrade.go
+++ b/tools/version-tracker/pkg/commands/upgrade/upgrade.go
@@ -72,8 +72,8 @@ func Run(upgradeOptions *types.UpgradeOptions) error {
 	}
 	client := gogithub.NewTokenClient(context.Background(), githubToken)
 
-	// Skip project upgrade if it is in the packages list and branch is not main
-	if branchName != constants.MainBranchName && slices.Contains(constants.UpstreamPackagesProjects, projectName) {
+	// Skip project upgrade if it is in the ProjectsUpgradedOnlyOnMainBranch list and branch is not main
+	if branchName != constants.MainBranchName && slices.Contains(constants.ProjectsUpgradedOnlyOnMainBranch, projectName) {
 		logger.Info(fmt.Sprintf("Skipping upgrade for project %s on %s branch", projectName, branchName))
 		return nil
 	}

--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -391,7 +391,7 @@ var (
 	ProjectsSupportingPrereleaseTags = []string{"kubernetes-sigs/cluster-api-provider-cloudstack"}
 
 	// These projects will be upgraded only on main and won't be triggered on release branches.
-	UpstreamPackagesProjects = []string{
+	ProjectsUpgradedOnlyOnMainBranch = []string{
 		"aquasecurity/harbor-scanner-trivy",
 		"aquasecurity/trivy",
 		"aws/rolesanywhere-credential-helper",
@@ -402,6 +402,7 @@ var (
 		"goharbor/harbor",
 		"kubernetes/autoscaler",
 		"kubernetes/cloud-provider-aws",
+		"kubernetes-sigs/cluster-api",
 		"kubernetes-sigs/metrics-server",
 		"metallb/metallb",
 		"prometheus/node_exporter",


### PR DESCRIPTION
*Description of changes:*
We have observed in the past that CAPI sometimes introduces breaking changes even for patch releases. Due to this, all our tests failed when we upgraded the CAPI patch version on a release branch. So, we decided not to upgrade CAPI anymore on release branches unless some customer requires some critical fix and they are still on a supported release branch. This PR updates the project upgrader tool to skip upgrading CAPI on release branches.

*Testing:*
```
make -C tools/version-tracker build
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
