### PR TITLE
improves hook build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,12 +183,12 @@ stop-docker-builder:
 
 .PHONY: run-buildkit-and-registry
 run-buildkit-and-registry:
-	docker run --rm -d --name buildkitd --net host --privileged moby/buildkit:v0.12.2-rootless
+	docker buildx create --name multiarch --driver docker-container --use --driver-opt network=host
 	docker run --rm -d --name registry  --net host registry:2
 
 .PHONY: stop-buildkit-and-registry
 stop-buildkit-and-registry:
-	docker rm -v --force buildkitd
+	docker buildx rm multiarch
 	docker rm -v --force registry
 
 .PHONY: generate-project-list

--- a/docs/development/building-locally.md
+++ b/docs/development/building-locally.md
@@ -73,10 +73,12 @@ Each project folder contains a Makefile with the following build targets.
 ## Pre-requisites for building container images
 
 * There are two options for building container images
-	* (Experimental) `docker buildx` can be used which may be easier to setup since docker now ships with the buildx plugin.
+	* (Default) `docker buildx` can be used which may be easier to setup since docker now ships with the buildx plugin.
 	docker buildx also uses buildkit behind the scenes so it should result in creating an image which is the same as using `buildctl` directly as prow does.
-		* You need to create a builder using either the `docker-container` or `remote` driver. For example: `docker buildx create --name multiarch --driver docker-container --use`
-	* `buildctl` can be used instead of docker to match our prow builds.  Running `local-images` targets 
+		* You need to create a builder using either the `docker-container` or `remote` driver.
+		* Use `make run-buildkit-and-registry` to create the buildx builder and a local registry. Set `IMAGE_REPO=localhost:5000` when building to push to local registry
+		* To manually create the buildx builder: `docker buildx create --name multiarch --driver docker-container --use`
+	* (Legacy) `buildctl` can be used instead of docker to match our prow builds.  Running `local-images` targets 
 	will export images to a tar, but if running `images` targets which push images, a registry is required.  By default,
 	an ECR repo in the currently logged in AWS account will be used.  A common alternative is to run docker registry locally and override
 	this default behavior. This can be done with `IMAGE_REPO=localhost:5000 make images`. To run buildkit and the docker registry run from the repo root (or a specific project folder):

--- a/projects/tinkerbell/hook/Makefile
+++ b/projects/tinkerbell/hook/Makefile
@@ -72,6 +72,10 @@ EMBEDDED_IMAGES=$(foreach platform,$(HOOK_PLATFORMS),$(OUTPUT_DIR)/hook-embedded
 LINUXKIT_VERSION=$(shell cat $(MAKE_ROOT)/../../linuxkit/linuxkit/GIT_TAG | cut -c2-)
 LINUXKIT_CACHE_FILE=$(REPO)/cache/linuxkit-linux-$(BUILDER_PLATFORM_ARCH)-$(LINUXKIT_VERSION)
 LINUXKIT_IMAGE_REPO?=$(IMAGE_REPO)
+EMBEDDED_IMAGES_REPO?=$(IMAGE_REPO)
+
+HOOK_TEMPLATE_FILE=$(OUTPUT_DIR)/hook.template.yaml
+POPULATE_LINUXKIT_CACHE_FILE=$(REPO)/cache/linuxkit/index.json
 
 # we need to set IMAGE_BUILD_ARGS here even though its the same as the default. 
 # it is set in Common.mk on the images target (https://github.com/aws/eks-anywhere-build-tooling/blob/8b6d6d66974e881b22e3c9c8ea29adc26f7df5fd/Common.mk#L799)
@@ -143,6 +147,23 @@ $(LINUXKIT_CACHE_FILE): $(PROJECT_DEPENDENCIES_TARGETS)
 	@mkdir -p $(@D)
 	cp $(BINARY_DEPS_DIR)/linux-$(BUILDER_PLATFORM_ARCH)/eksa/linuxkit/linuxkit/linuxkit $@
 
+$(HOOK_TEMPLATE_FILE):
+	mkdir -p $(@D) 
+	git -C $(REPO) checkout -- linuxkit-templates/hook.template.yaml
+	sed 's/[^ ]*linuxkit\/\([^:]*\)\(:.*$$\)/$(subst /,\/,$(LINUXKIT_IMAGE_REPO))\/linuxkit\/\1:$(LATEST_TAG)/' $(REPO)/linuxkit-templates/hook.template.yaml > $@
+
+$(POPULATE_LINUXKIT_CACHE_FILE): $(HOOK_TEMPLATE_FILE) | $$(ENABLE_LOGGING)
+	@source $(BUILD_LIB)/common.sh; \
+	images=(); \
+	while read -r image; do \
+		if [[ "$$image" == *"sshd"* ]]; then continue; fi; \
+		images+=($$image); \
+	done < <(sed -n 's/.*\($(subst /,\/,$(LINUXKIT_IMAGE_REPO)).*$$\)/\1/p' $(HOOK_TEMPLATE_FILE)); \
+	for image in hook-bootkit hook-docker hook-runc hook-containerd hook-kernel hook-ip hook-mdev hook-embedded; do \
+		images+=($(IMAGE_REPO)/tinkerbell/$$image:$(LATEST_TAG)$(IMAGE_TAG_SUFFIX)); \
+	done; \
+	for image in "$${images[@]}"; do build::common::echo_and_run retry $(LINUXKIT_CACHE_FILE) cache pull --cache $(REPO)/cache/linuxkit $$image; done
+
 # We use the linuxkit built from eks-a build tooling
 # This includes the linuxkit bin and the images
 # The hook linuxkit-template has two sets of images it pulls in
@@ -156,19 +177,10 @@ $(LINUXKIT_CACHE_FILE): $(PROJECT_DEPENDENCIES_TARGETS)
 # Using sed they are pulled back out so that we can run cache pull with retries since we tend to see
 # issues from time to time pulling from ecr
 $(CREATE_HOOK_FILES_PATTERN)-%: BUILD_ARCH=$(if $(findstring x86_64,$*),amd64,arm64)
-$(CREATE_HOOK_FILES_PATTERN)-%: $(LINUXKIT_CACHE_FILE) | $$(ENABLE_DOCKER)
+$(CREATE_HOOK_FILES_PATTERN)-%: $(LINUXKIT_CACHE_FILE) $(POPULATE_LINUXKIT_CACHE_FILE) | $$(ENABLE_DOCKER)
 	@source $(BUILD_LIB)/common.sh && build::common::use_go_version $(GOLANG_VERSION); \
-	if [ -f $(REPO)/out/linuxkit-hook-default-$(BUILD_ARCH)/hook-cmdline ]; then echo "remove hook/out before continuing"; exit 1; fi; \
-	sed -i 's/[^ ]*linuxkit\/\([^:]*\)\(:.*$$\)/$(subst /,\/,$(LINUXKIT_IMAGE_REPO))\/linuxkit\/\1:$(LATEST_TAG)/' $(REPO)/linuxkit-templates/hook.template.yaml; \
-	images=(); \
-	while read -r image; do \
-		if [[ "$$image" == *"sshd"* ]]; then continue; fi; \
-		images+=($$image); \
-	done < <(sed -n 's/.*\($(subst /,\/,$(LINUXKIT_IMAGE_REPO)).*$$\)/\1/p' $(REPO)/linuxkit-templates/hook.template.yaml); \
-	for image in hook-bootkit hook-docker hook-runc hook-containerd hook-kernel hook-ip hook-mdev hook-embedded; do \
-		images+=($(IMAGE_REPO)/tinkerbell/$$image:$(LATEST_TAG)$(IMAGE_TAG_SUFFIX)); \
-	done; \
-	for image in "$${images[@]}"; do build::common::echo_and_run retry $(LINUXKIT_CACHE_FILE) cache pull --cache $(REPO)/cache/linuxkit $$image; done; \
+	if [ -f $(REPO)/out/linuxkit-hook-default-$(BUILD_ARCH)/hook-cmdline ]; then echo "rm -rf hook/out before continuing"; exit 1; fi; \
+	cp $(HOOK_TEMPLATE_FILE) $(REPO)/linuxkit-templates/hook.template.yaml; \
 	cd $(REPO); \
 	DEBUG=yes LINUXKIT_VERSION_DEFAULT=$(LINUXKIT_VERSION) HOOK_KERNEL_OCI_BASE=$(IMAGE_REPO)/$(KERNEL_IMAGE_COMPONENT) \
 		HOOK_LK_CONTAINERS_OCI_BASE=$(IMAGE_REPO)/tinkerbell/ \
@@ -194,9 +206,9 @@ $(OUTPUT_DIR)/hook-embedded/linux-%/images: IMAGE_TAG_SUFFIX=
 $(OUTPUT_DIR)/hook-embedded/linux-%/images: DIND_IMAGE=$(shell $(MAKE) var-value-LATEST_IMAGE IMAGE_NAME=hook-dind)
 $(OUTPUT_DIR)/hook-embedded/linux-%/images: $(GIT_PATCH_TARGET)
 	mkdir -p $(@D)
-	echo "$$($(MAKE) -C $(MAKE_ROOT)/../tink var-value-LATEST_IMAGE IMAGE_NAME=tink-worker) 127.0.0.1/embedded/tink-worker true" > $@.txt
+	echo "$$($(MAKE) -C $(MAKE_ROOT)/../tink var-value-LATEST_IMAGE IMAGE_NAME=tink-worker IMAGE_REPO=$(EMBEDDED_IMAGES_REPO)) 127.0.0.1/embedded/tink-worker true" > $@.txt
 	for action in cexec kexec image2disk oci2disk writefile reboot; do \
-		echo "$$($(MAKE) -C $(MAKE_ROOT)/../hub var-value-LATEST_IMAGE IMAGE_NAME=$$action) 127.0.0.1/embedded/$$action true" >> $@.txt; \
+		echo "$$($(MAKE) -C $(MAKE_ROOT)/../hub var-value-LATEST_IMAGE IMAGE_NAME=$$action IMAGE_REPO=$(EMBEDDED_IMAGES_REPO)) 127.0.0.1/embedded/$$action true" >> $@.txt; \
 	done
 	cat $@.txt
 	@if [[ "$(JOB_TYPE)" == "presubmit" ]] && [[ "$(DOCKER_AVAILABLE)" == "false" ]]; then \
@@ -243,6 +255,10 @@ clean-repo: clean-extra
 .PHONY: clean-extra
 clean-extra:	
 	sudo rm -rf $(EMBEDDED_IMAGES) $(REPO)/out
+
+.PHONY: clean-hook
+clean-hook:
+	sudo rm -rf $(REPO)/out $(REPO)/cache $(OUTPUT_DIR)/hook $(HOOK_TEMPLATE_FILE)
 
 ########### DO NOT EDIT #############################
 # To update call: make add-generated-help-block

--- a/projects/tinkerbell/hook/README.md
+++ b/projects/tinkerbell/hook/README.md
@@ -22,7 +22,18 @@ We only support building with one golang version per project, pick the latest fr
 ### Development
 
 1. The project consists of 3 images. `hook-bootkit`, `hoot-containerd`, `hook-docker`, `hook-embedded`, `hook-runc` and `kernel`.
-1. For building the in-memory OS files (vmlinuz and initramfs), `hook` uses [linuxkit](https://github.com/linuxkit/linuxkit). `linuxkit build` expects the project images to be present in the repository represented by `IMAGE_REPO` variable.
+1. For building the in-memory OS files (vmlinuz and initramfs), `hook` uses [linuxkit](https://github.com/linuxkit/linuxkit). 
+    * `linuxkit build` expects a number of images to be present in the repository represented by `IMAGE_REPO` variable:
+        * images built via this project listed above
+        * images built via [linuxkit](../../linuxkit/linuxkit/Makefile)
+        * images built via [tink](../tink/Makefile)
+        * images built via [hub](../hub/Makefile)
+    * One option is to run `make images` in each of the above project folders to populate your local/ecr registry.
+    * Alternatively you can pull these images from the EKS-A build account ecr using the following variables:
+        * `LINUXKIT_IMAGE_REPO=857151390494.dkr.ecr.us-west-2.amazonaws.com`
+        * `EMBEDDED_IMAGES_REPO=857151390494.dkr.ecr.us-west-2.amazonaws.com`
+    * After running `make images` in this project, to rerun the vmlinuz/initramfs target quickly use `make hook/out/hook/vmlinuz-x86_64` or `make hook/out/hook/vmlinuz-aarch64`
+    * If you change your image repos or make code changes and want rebuild these files run `make clean-hook` to remove the edited template/image cache/output folders/etc. 
 1. For `kernel`, the image builds from the kernel source version defined in the `LINUX_KERNEL_VERSION` file. The upstream's [Dockerfile](https://github.com/tinkerbell/hook/blob/main/kernel/Dockerfile) is patched to use AL23 instead of alpine.
 This image is used by linuxkit build and ends up on the "host" via the built vmlinuz. This should be kept to the latest patch for the choosen minor.
 1. The `hook-bootkit`, `hoot-containerd` and `hook-runc` images are used during the linuxkit build process and ends up on the "host" via the built initramfs.
@@ -32,6 +43,7 @@ This image is used by linuxkit build and ends up on the "host" via the built vml
 These embedded images allow customers to point our "latest" action images without neededing to update their cluster specs and avoids pulling these images at runtime.
 1. To build locally, we suggest using a local registry, or your personal public ecr repos, and setting `IMAGE_REPO` variable.
     - To assist in creating the ecr repos, you can run `make create-ecr-repos`. If using public ecr, be sure to set `IMAGE_REPO`
+    - Refer to [building-locally](../../../docs/development/building-locally.md) for building images locally
 
 #### Kernel
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This improves the building of hook locally. Hook requires a number of images from other projects.  Currently this requires building them all locally and pushing to your regi.  Also because the linuxkit part is run within a docker container pulling from local/private regi was not possible.  

This introduces a new env var to set the image repo for these images so you can pull these from the eksa build account, assuming you have ecr creds.  Images are also pulled on the host before calling linuxkit in the container to allow for "any" regi to work since we do not have to worry about auth.

Updates the helper that creates the buildkitd container to use buildx, since we have been using that for a while by default, and also sets network=host to allow for that container to push to a locally running regi.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
