### PR TITLE
Add identifying label to PRs upgrading curated packages

### DIFF
--- a/tools/version-tracker/pkg/commands/upgrade/upgrade.go
+++ b/tools/version-tracker/pkg/commands/upgrade/upgrade.go
@@ -232,7 +232,11 @@ func Run(upgradeOptions *types.UpgradeOptions) error {
 			}
 		}
 
-		pullRequestBody = fmt.Sprintf(constants.DefaultUpgradePullRequestBody, projectOrg, projectRepo, currentRevision, latestRevision)
+		prLabels := constants.DefaultProjectUpgradePRLabels
+		if slices.Contains(constants.CuratedPackagesProjects, projectName) {
+			prLabels = constants.PackagesProjectUpgradePRLabels
+		}
+		pullRequestBody = fmt.Sprintf(constants.DefaultUpgradePullRequestBody, projectOrg, projectRepo, currentRevision, latestRevision, prLabels)
 
 		// Upgrade project if latest commit was made after current commit and the semver of the latest revision is
 		// greater than the semver of the current version.
@@ -471,7 +475,7 @@ func Run(upgradeOptions *types.UpgradeOptions) error {
 
 	if len(failedSteps) > 0 {
 		var failedStepsList []string
-		var errorsList[] string
+		var errorsList []string
 		for step, err := range failedSteps {
 			if step == "Patch application" {
 				step = fmt.Sprintf("%s\n%s", step, patchesWarningComment)

--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -59,8 +59,7 @@ By submitting this pull request, I confirm that you can use, modify, copy, and r
 [Compare changes](https://github.com/%[1]s/%[2]s/compare/%[3]s...%[4]s)
 [Release notes](https://github.com/%[1]s/%[2]s/releases/%[4]s)
 
-/hold
-/area dependencies
+%s
 
 By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.`
 	BottlerocketUpgradePullRequestBody = `This PR bumps Bottlerocket releases to the latest Git revision.
@@ -375,6 +374,9 @@ var (
 		},
 	}
 
+	DefaultProjectUpgradePRLabels  = []string{"/hold", "/area dependencies"}
+	PackagesProjectUpgradePRLabels = []string{"/hold", "/area dependencies", "/sig curated-packages"}
+
 	ProjectsWithUnconventionalUpgradeFlows = []string{
 		"cilium/cilium",
 		"kubernetes-sigs/image-builder",
@@ -391,7 +393,7 @@ var (
 	ProjectsSupportingPrereleaseTags = []string{"kubernetes-sigs/cluster-api-provider-cloudstack"}
 
 	// These projects will be upgraded only on main and won't be triggered on release branches.
-	ProjectsUpgradedOnlyOnMainBranch = []string{
+	CuratedPackagesProjects = []string{
 		"aquasecurity/harbor-scanner-trivy",
 		"aquasecurity/trivy",
 		"aws/rolesanywhere-credential-helper",
@@ -402,11 +404,17 @@ var (
 		"goharbor/harbor",
 		"kubernetes/autoscaler",
 		"kubernetes/cloud-provider-aws",
-		"kubernetes-sigs/cluster-api",
 		"kubernetes-sigs/metrics-server",
 		"metallb/metallb",
 		"prometheus/node_exporter",
 		"prometheus/prometheus",
 		"redis/redis",
 	}
+
+	ProjectsUpgradedOnlyOnMainBranch = append(
+		[]string{
+			"kubernetes-sigs/cluster-api",
+		},
+		CuratedPackagesProjects...,
+	)
 )


### PR DESCRIPTION
Add identifying label `sig/curated-packages` to pull requests that upgrade curated packages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
