### PR TITLE
Invoke attribution-checksums Make target with release branch environment variable

### DIFF
--- a/tools/version-tracker/pkg/commands/upgrade/upgrade.go
+++ b/tools/version-tracker/pkg/commands/upgrade/upgrade.go
@@ -356,7 +356,7 @@ func Run(upgradeOptions *types.UpgradeOptions) error {
 					}
 					if _, err := os.Stat(projectChecksumsFile); err == nil {
 						logger.Info("Updating project checksums and attribution files")
-						err = updateChecksumsAttributionFiles(projectRootFilepath)
+						err = updateChecksumsAttributionFiles(projectRootFilepath, releaseBranch)
 						if err != nil {
 							failedSteps["Checksums and attribution generation"] = err
 						} else {
@@ -738,8 +738,8 @@ func applyPatchesToRepo(projectRootFilepath, projectRepo, releaseBranch string, 
 
 // updateChecksumsAttributionFiles runs a Make command to update the checksums and attribution files
 // corresponding to the project being upgraded.
-func updateChecksumsAttributionFiles(projectRootFilepath string) error {
-	updateChecksumsAttributionCommandSequence := fmt.Sprintf("make -C %s attribution-checksums", projectRootFilepath)
+func updateChecksumsAttributionFiles(projectRootFilepath, releaseBranch string) error {
+	updateChecksumsAttributionCommandSequence := fmt.Sprintf("RELEASE_BRANCH=%s make -C %s attribution-checksums", releaseBranch, projectRootFilepath)
 	updateChecksumsAttributionCmd := exec.Command("bash", "-c", updateChecksumsAttributionCommandSequence)
 	_, err := command.ExecCommand(updateChecksumsAttributionCmd)
 	if err != nil {


### PR DESCRIPTION
Invoking `attribution-checksums` Make target with `RELEASE_BRANCH` environment variable.
Fixes this issue in Kind version upgrade
```
When running targets for this project other than ` build release clean clean-extra clean-go-cache help start-docker-builder stop-docker-builder create-ecr-repos all-attributions all-checksums all-attributions-checksums update-patch-numbers check-for-release-branch-skip run-buildkit-and-registry  helm/push` a `RELEASE_BRANCH` is required.  Stop.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
