### PR TITLE
Fix checksums for replicatedhq/troubleshoot

### DIFF
--- a/projects/replicatedhq/troubleshoot/CHECKSUMS
+++ b/projects/replicatedhq/troubleshoot/CHECKSUMS
@@ -1,2 +1,2 @@
 4bd7166c2e3dd5077e5e13837338ba8915e8d733e80d341dde484e0608950a8d  _output/bin/troubleshoot/linux-amd64/support-bundle
-3290b26ed7f3f800d3034b97cc5267dd5a57eb1b30ef1e7a57536ac460123201  _output/bin/troubleshoot/linux-arm64/support-bundle
+d7603c76ace1fa218abf1a3228748843d82e73ee8f9b1ad3f00020545cd05792  _output/bin/troubleshoot/linux-arm64/support-bundle


### PR DESCRIPTION
The troubleshoot presubmit on #4042 first failed stating incorrect checksums, and then the checksums in the failure logs were used to update the CHECKSUMS file, but these failed in CodeBuild. This PR fixes the checksums with the correct ones reported in CodeBuild.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
