### PR TITLE
Update kindnetd and storage helper images for Kind node image build

### DIFF
--- a/projects/kubernetes-sigs/kind/README.md
+++ b/projects/kubernetes-sigs/kind/README.md
@@ -55,7 +55,7 @@ and/or automatically update between eks-anywhere version reach out to @jaxesn.
 1. Compare the old tag to the new, looking specifically for Makefile changes. 
 ex: [0.17.0 compared to 0.18.0](https://github.com/kubernetes-sigs/kind/compare/v0.17.0...v0.18.0). Check the `kind` target for
 any build flag changes, tag changes, dependencies, etc in the `Makefile` in the root of the repo.  Pay close attention to
-`images/base/Dockerfile` for changes when updating the patch.  Update constants in [node-image-build-args.sh](./build/node-image-build-args.sh#48).
+`images/base/Dockerfile` for changes when updating the patch.  Update constants in [node-image-build-args.sh](./build/node-image-build-args.sh#L52).
 If new yum packages are added to the base image, update the [minimal-base-kind](https://github.com/aws/eks-distro-build-tooling/blob/main/eks-distro-base/Dockerfile.minimal-base-kind)
 image to include it (this is not a blocker for updating). Review changes to [buildcontext.go](https://github.com/kubernetes-sigs/kind/blob/main/pkg/build/nodeimage/buildcontext.go)
 closely to ensure there are no changes neccessary in our build scripts.

--- a/projects/kubernetes-sigs/kind/build/node-image-build-args.sh
+++ b/projects/kubernetes-sigs/kind/build/node-image-build-args.sh
@@ -51,13 +51,13 @@ ETCD_VERSION=$(build::eksd_releases::get_eksd_component_version "etcd" $EKSD_REL
 
 # Expected versions provided by kind which are replaced in the docker build with our versions
 # when updating kind check the following, they may need to be updated
-# https://github.com/kubernetes-sigs/kind/blob/v0.24.0/pkg/build/nodeimage/const_cni.go#L23
-KINDNETD_IMAGE_TAG="docker.io/kindest/kindnetd:v20240813-c6f155d6"
-# https://github.com/kubernetes-sigs/kind/blob/v0.24.0/pkg/build/nodeimage/const_storage.go#L28
-LOCAL_PATH_PROVISONER_IMAGE_TAG="docker.io/kindest/local-path-provisioner:v20240813-c6f155d6"
-# https://github.com/kubernetes-sigs/kind/blob/v0.24.0/pkg/build/nodeimage/const_storage.go#L29
+# https://github.com/kubernetes-sigs/kind/blob/v0.25.0/pkg/build/nodeimage/const_cni.go#L23
+KINDNETD_IMAGE_TAG="docker.io/kindest/kindnetd:v20241108-5c6d2daf"
+# https://github.com/kubernetes-sigs/kind/blob/v0.25.0/pkg/build/nodeimage/const_storage.go#L28
+LOCAL_PATH_PROVISONER_IMAGE_TAG="docker.io/kindest/local-path-provisioner:v20241108-5c6d2daf"
+# https://github.com/kubernetes-sigs/kind/blob/v0.25.0/pkg/build/nodeimage/const_storage.go#L29
 LOCAL_PATH_HELPER_IMAGE_TAG="docker.io/kindest/local-path-helper:v20230510-486859a6"
-# https://github.com/kubernetes-sigs/kind/blob/v0.24.0/images/base/files/etc/containerd/config.toml#L37
+# https://github.com/kubernetes-sigs/kind/blob/v0.25.0/images/base/files/etc/containerd/config.toml#L37
 PAUSE_IMAGE_TAG="registry.k8s.io/pause:3.10"
 
 mkdir -p $(dirname $OUTPUT_FILE)


### PR DESCRIPTION
Updating kindnetd and storage provisioner/helper images for Kind node image build. In the future, we should have the automation do this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
