### PR TITLE
Update kind manifest image tags during upgrade flow

### DIFF
--- a/projects/kubernetes-sigs/kind/Makefile
+++ b/projects/kubernetes-sigs/kind/Makefile
@@ -173,6 +173,10 @@ $(FIX_LICENSES_KINDNETD_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
 #go-licenses requires a LICENSE file in each folder with the go.mod
 	cp $(REPO)/LICENSE $@
 
+.PHONY: update-manifest-images
+update-manifest-images:
+	build/update_manifest_images.sh $(GIT_TAG)
+
 .PHONY: create-kind-cluster-%
 create-kind-cluster-%:
 	build/create-kind-cluster.sh $(IMAGE_REPO)/$(KIND_NODE_IMAGE_COMPONENT):$(NODE_IMAGE_LATEST_TAG) $* $(RELEASE_BRANCH)

--- a/projects/kubernetes-sigs/kind/build/update_manifest_images.sh
+++ b/projects/kubernetes-sigs/kind/build/update_manifest_images.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -x
+set -o errexit
+set -o pipefail
+
+GIT_TAG="${1?Specify first argument - Kind Git tag}"
+
+MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+BUILD_LIB="${MAKE_ROOT}/../../../build/lib"
+SED=$(source $BUILD_LIB/common.sh && build::find::gnu_variant_on_mac sed)
+
+declare -A image_name_source_of_truth=(
+    ["docker.io/kindest/kindnetd"]="pkg/build/nodeimage/const_cni.go"
+    ["docker.io/kindest/local-path-provisioner"]="pkg/build/nodeimage/const_storage.go"
+    ["docker.io/kindest/local-path-helper"]="pkg/build/nodeimage/const_storage.go"
+    ["registry.k8s.io/pause"]="images/base/files/etc/containerd/config.toml"
+)
+
+for image in "${!image_name_source_of_truth[@]}"; do
+    upstream_image_match=$(grep -on "\"$image:.*\"" $MAKE_ROOT/kind/${image_name_source_of_truth[$image]})
+    upstream_image_match_line=$(echo $upstream_image_match | cut -d: -f1)
+    upstream_image_uri=$(echo $upstream_image_match | cut -d: -f2-)
+    echo $upstream_image_match_line
+    echo $upstream_image_uri
+
+    $SED -i "s,\"$image:.*\",$upstream_image_uri," $MAKE_ROOT/build/node-image-build-args.sh
+    $SED -i "s,https://github.com/kubernetes-sigs/kind/blob/.*/${image_name_source_of_truth[$image]}.*,https://github.com/kubernetes-sigs/kind/blob/$GIT_TAG/${image_name_source_of_truth[$image]}#L${upstream_image_match_line}," $MAKE_ROOT/build/node-image-build-args.sh
+done

--- a/tools/version-tracker/pkg/commands/upgrade/upgrade.go
+++ b/tools/version-tracker/pkg/commands/upgrade/upgrade.go
@@ -174,6 +174,7 @@ func Run(upgradeOptions *types.UpgradeOptions) error {
 			if err != nil {
 				return fmt.Errorf("getting default EKS Distro release branch: %v", err)
 			}
+			os.Setenv(constants.ReleaseBranchEnvvar, releaseBranch)
 		}
 		if isReleaseBranched {
 			supportedReleaseBranches, err := getSupportedReleaseBranches(buildToolingRepoPath)
@@ -333,7 +334,7 @@ func Run(upgradeOptions *types.UpgradeOptions) error {
 
 				// If project has patches, attempt to apply them. Track failed patches and files that failed to apply, if any.
 				if projectHasPatches {
-					appliedPatchesCount, failedPatch, applyFailedFiles, err := applyPatchesToRepo(projectRootFilepath, projectRepo, releaseBranch, totalPatchCount)
+					appliedPatchesCount, failedPatch, applyFailedFiles, err := applyPatchesToRepo(projectRootFilepath, projectRepo, totalPatchCount)
 					if appliedPatchesCount == totalPatchCount {
 						patchApplySucceeded = true
 					}
@@ -356,7 +357,7 @@ func Run(upgradeOptions *types.UpgradeOptions) error {
 					}
 					if _, err := os.Stat(projectChecksumsFile); err == nil {
 						logger.Info("Updating project checksums and attribution files")
-						err = updateChecksumsAttributionFiles(projectRootFilepath, releaseBranch)
+						err = updateChecksumsAttributionFiles(projectRootFilepath)
 						if err != nil {
 							failedSteps["Checksums and attribution generation"] = err
 						} else {
@@ -379,30 +380,13 @@ func Run(upgradeOptions *types.UpgradeOptions) error {
 					}
 				}
 
-				if projectName == "cilium/cilium" {
-					updatedCiliumImageDigestFiles, err := updateCiliumImageDigestFiles(projectRootFilepath, projectPath)
+				op, message := getProjectSpecificUpdateOperation(projectName)
+				if op != nil {
+					updatedProjectFiles, err := op(projectRootFilepath, projectPath)
 					if err != nil {
-						failedSteps["Cilium image digest update"] = err
+						failedSteps[message] = err
 					} else {
-						updatedFiles = append(updatedFiles, updatedCiliumImageDigestFiles...)
-					}
-				}
-
-				if projectName == "aws-observability/aws-otel-collector" {
-					updatedADOTImageDigestFiles, err := updateADOTImageDigestFiles(projectRootFilepath, projectPath)
-					if err != nil {
-						failedSteps["ADOT image digest update"] = err
-					} else {
-						updatedFiles = append(updatedFiles, updatedADOTImageDigestFiles...)
-					}
-				}
-
-				if projectName == "cert-manager/cert-manager" {
-					err := updateCertManagerManifestFile(projectRootFilepath)
-					if err != nil {
-						failedSteps["Cert-manager manifest file update"] = err
-					} else {
-						updatedFiles = append(updatedFiles, filepath.Join(projectPath, constants.ManifestsDirectory, constants.CertManagerManifestYAMLFile))
+						updatedFiles = append(updatedFiles, updatedProjectFiles...)
 					}
 				}
 			}
@@ -683,12 +667,12 @@ func updateUpstreamProjectsTrackerFile(projectsList *types.ProjectsList, buildTo
 
 // applyPatchesToRepo runs a Make command to apply patches to the cloned repository of the project
 // being upgraded.
-func applyPatchesToRepo(projectRootFilepath, projectRepo, releaseBranch string, totalPatchCount int) (int, string, string, error) {
+func applyPatchesToRepo(projectRootFilepath, projectRepo string, totalPatchCount int) (int, string, string, error) {
 	var patchesApplied int
 	var failedPatch, failedFilesInPatch string
 	patchApplySucceeded := true
 
-	applyPatchesCommandSequence := fmt.Sprintf("RELEASE_BRANCH=%s make -C %s patch-repo", releaseBranch, projectRootFilepath)
+	applyPatchesCommandSequence := fmt.Sprintf("make -C %s patch-repo", projectRootFilepath)
 	applyPatchesCmd := exec.Command("bash", "-c", applyPatchesCommandSequence)
 	applyPatchesOutput, err := command.ExecCommand(applyPatchesCmd)
 	if err != nil {
@@ -738,8 +722,8 @@ func applyPatchesToRepo(projectRootFilepath, projectRepo, releaseBranch string, 
 
 // updateChecksumsAttributionFiles runs a Make command to update the checksums and attribution files
 // corresponding to the project being upgraded.
-func updateChecksumsAttributionFiles(projectRootFilepath, releaseBranch string) error {
-	updateChecksumsAttributionCommandSequence := fmt.Sprintf("RELEASE_BRANCH=%s make -C %s attribution-checksums", releaseBranch, projectRootFilepath)
+func updateChecksumsAttributionFiles(projectRootFilepath string) error {
+	updateChecksumsAttributionCommandSequence := fmt.Sprintf("make -C %s attribution-checksums", projectRootFilepath)
 	updateChecksumsAttributionCmd := exec.Command("bash", "-c", updateChecksumsAttributionCommandSequence)
 	_, err := command.ExecCommand(updateChecksumsAttributionCmd)
 	if err != nil {
@@ -793,15 +777,26 @@ func updateADOTImageDigestFiles(projectRootFilepath, projectPath string) ([]stri
 	return updateADOTFiles, nil
 }
 
-func updateCertManagerManifestFile(projectRootFilepath string) error {
+func updateCertManagerManifestFile(projectRootFilepath, projectPath string) ([]string, error) {
 	updateCertManagerManifestCommandSequence := fmt.Sprintf("make -C %s update-cert-manager-manifest", projectRootFilepath)
 	updateCertManagerManifestCmd := exec.Command("bash", "-c", updateCertManagerManifestCommandSequence)
 	_, err := command.ExecCommand(updateCertManagerManifestCmd)
 	if err != nil {
-		return fmt.Errorf("running update-cert-manager-manifest Make command: %v", err)
+		return nil, fmt.Errorf("running update-cert-manager-manifest Make command: %v", err)
 	}
 
-	return nil
+	return []string{filepath.Join(projectPath, constants.ManifestsDirectory, constants.CertManagerManifestYAMLFile)}, nil
+}
+
+func updateKindManifestImages(projectRootFilepath, projectPath string) ([]string, error) {
+	updateKindManifestImagesCommandSequence := fmt.Sprintf("make -C %s update-manifest-images", projectRootFilepath)
+	updateKindManifestImagesCmd := exec.Command("bash", "-c", updateKindManifestImagesCommandSequence)
+	_, err := command.ExecCommand(updateKindManifestImagesCmd)
+	if err != nil {
+		return nil, fmt.Errorf("running update-manifest-images Make command: %v", err)
+	}
+
+	return []string{filepath.Join(projectPath, constants.BuildDirectory, constants.KindNodeImageBuildArgsScriptFile)}, nil
 }
 
 func updateBottlerocketVersionFiles(client *gogithub.Client, projectRootFilepath, projectPath, branchName string) (string, string, []string, error) {
@@ -1006,4 +1001,19 @@ func getDefaultReleaseBranch(buildToolingRepoPath string) (string, error) {
 	}
 
 	return defaultReleaseBranch, nil
+}
+
+func getProjectSpecificUpdateOperation(projectName string) (func(projectRootFilepath, projectPath string) ([]string, error), string) {
+	switch projectName {
+	case "aws-observability/aws-otel-collector":
+		return updateADOTImageDigestFiles, "ADOT image digest update"
+	case "cert-manager/cert-manager":
+		return updateCertManagerManifestFile, "Cert-manager manifest file update"
+	case "cilium/cilium":
+		return updateCiliumImageDigestFiles, "Cilium image digest update"
+	case "kubernetes-sigs/kind":
+		return updateKindManifestImages, "Kind manifest images update"
+	default:
+		return nil, ""
+	}
 }

--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -31,6 +31,7 @@ const (
 	GoVersionFile                           = "GOLANG_VERSION"
 	ChecksumsFile                           = "CHECKSUMS"
 	AttributionsFilePattern                 = "*ATTRIBUTION.txt"
+	BuildDirectory                          = "build"
 	ManifestsDirectory                      = "manifests"
 	PatchesDirectory                        = "patches"
 	FailedPatchApplyMarker                  = "patch does not apply"
@@ -44,6 +45,7 @@ const (
 	BottlerocketHostContainersTOMLFile      = "sources/shared-defaults/public-host-containers.toml"
 	CertManagerManifestYAMLFile             = "cert-manager.yaml"
 	CiliumImageRepository                   = "public.ecr.aws/isovalent/cilium"
+	KindNodeImageBuildArgsScriptFile        = "node-image-build-args.sh"
 	GithubPerPage                           = 100
 	datetimeFormat                          = "%Y-%m-%dT%H:%M:%SZ"
 	MainBranchName                          = "main"


### PR DESCRIPTION
We maintain a [list of images](https://github.com/aws/eks-anywhere-build-tooling/blob/main/projects/kubernetes-sigs/kind/build/node-image-build-args.sh#L52-L61) that are referenced upstream in Kind's CNI and PV storage manifests and containerd config file. We use this list for [find-and-replace operations](https://github.com/aws/eks-anywhere-build-tooling/blob/main/projects/kubernetes-sigs/kind/build/build-kind-node-image.sh#L189-L194) on certain files on the Kind node image, to replace them with EKS-A kindnetd and local-path-provisioner/local-path-helper images and EKS-D pause image. When bumping Kind versions, the upstream tags may change, which requires us to update the image tags list otherwise the find-and-replace will fail.

This PR adds logic to update this image list whenever we bump the Kind version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
