### PR TITLE
Add patch to fix state for Ansible RHSM repository module

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
@@ -1,4 +1,4 @@
-From cde1d25f3ae5df91693864e3f6951f763902f692 Mon Sep 17 00:00:00 2001
+From 8e342fbd8e1dd4c9ef3eabd0b08e80b6a8388e1d Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:05:13 -0800
 Subject: [PATCH 01/13] OVA improvements

--- a/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
@@ -1,4 +1,4 @@
-From eaadf42883d29722e6e5e8765889e1f409c838dd Mon Sep 17 00:00:00 2001
+From 9429abbf6cb7fa20d5718a7ac1457f079bdafece Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 18:36:56 -0800
 Subject: [PATCH 02/13] EKS-D support and changes

--- a/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
@@ -1,4 +1,4 @@
-From 13d67020c08dbdb7020464203927b1ca03fa8420 Mon Sep 17 00:00:00 2001
+From cc2b924f212c875714edf201588637e6f4e53798 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Feb 2023 01:39:15 -0800
 Subject: [PATCH 03/13] Snow AMI support

--- a/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22.04-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0004-Ubuntu-22.04-support-and-improvements.patch
@@ -1,4 +1,4 @@
-From ec3ebee7cfa9a8d2a7f4c4fe8465788716ca5cc1 Mon Sep 17 00:00:00 2001
+From 7f61c8f53b014241c5ff4337ddedff6c3868a601 Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Fri, 23 Jun 2023 10:50:08 -0500
 Subject: [PATCH 04/13] Ubuntu 22.04 support and improvements

--- a/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
@@ -1,4 +1,4 @@
-From 2042ff34b064e217ff955ddc1765e116fff3c43d Mon Sep 17 00:00:00 2001
+From 9d99446c06654487aed896f4a4554dbdf4dc9c86 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 6 Dec 2022 15:42:02 -0600
 Subject: [PATCH 05/13] RHEL support and improvements
@@ -9,14 +9,16 @@ Subject: [PATCH 05/13] RHEL support and improvements
 - Remove old kernels
 - Add dracut cmd to generate initramfs with all drivers for rhel raw
 - Add proxy, register with satellite, and pull packages from satellite support to redhat subscription manager
+- Fix state for Ansible RHSM repository module
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---
  images/capi/ansible/roles/node/tasks/main.yml |  3 +
  .../capi/ansible/roles/node/tasks/redhat.yml  | 32 +++++++
  .../capi/ansible/roles/setup/tasks/redhat.yml | 83 +++++++++++++++++++
+ .../ansible/roles/sysprep/tasks/redhat.yml    |  2 +-
  images/capi/packer/config/ansible-args.json   |  2 +-
- 4 files changed, 119 insertions(+), 1 deletion(-)
+ 5 files changed, 120 insertions(+), 2 deletions(-)
  create mode 100644 images/capi/ansible/roles/node/tasks/redhat.yml
 
 diff --git a/images/capi/ansible/roles/node/tasks/main.yml b/images/capi/ansible/roles/node/tasks/main.yml
@@ -170,6 +172,19 @@ index 5716fff78..c1fc46769 100644
 +    state: present
 +    lock_timeout: 60
 +  when: ansible_os_family == "RedHat" and ansible_distribution == "RedHat" and ansible_distribution_major_version == "9"
+diff --git a/images/capi/ansible/roles/sysprep/tasks/redhat.yml b/images/capi/ansible/roles/sysprep/tasks/redhat.yml
+index 0ec89322d..1bfac2e6f 100644
+--- a/images/capi/ansible/roles/sysprep/tasks/redhat.yml
++++ b/images/capi/ansible/roles/sysprep/tasks/redhat.yml
+@@ -58,7 +58,7 @@
+     - name: Remove subscriptions
+       community.general.rhsm_repository:
+         name: "*"
+-        state: absent
++        state: disabled
+     - name: Unregister system
+       community.general.redhat_subscription:
+         state: absent
 diff --git a/images/capi/packer/config/ansible-args.json b/images/capi/packer/config/ansible-args.json
 index 92481888b..d7040dc58 100644
 --- a/images/capi/packer/config/ansible-args.json

--- a/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-improvements.patch
@@ -1,4 +1,4 @@
-From 3233c337829c5cb2b3eaf75b4fe64f21f97b07ac Mon Sep 17 00:00:00 2001
+From b55783834e2acd76561a447d365890510a2707c3 Mon Sep 17 00:00:00 2001
 From: Ilya Alekseyev <ilya.alekseyev@nutanix.com>
 Date: Wed, 11 Oct 2023 22:07:22 -0400
 Subject: [PATCH 06/13] Nutanix improvements

--- a/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
@@ -1,4 +1,4 @@
-From c86ba630ad083a15658d375234f38dac1cbbf3ea Mon Sep 17 00:00:00 2001
+From 445b9af6daf52ad00e3a4a781b16c2d86f86ff6d Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Mon, 21 Aug 2023 18:40:07 -0500
 Subject: [PATCH 07/13] adds retries and timeout to packer image-builder

--- a/projects/kubernetes-sigs/image-builder/patches/0008-Networking-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0008-Networking-improvements.patch
@@ -1,4 +1,4 @@
-From b30bb7289cb90c34fd2514b38d29413f5cf9cc23 Mon Sep 17 00:00:00 2001
+From 57a15c0b40a236b15234264dab8968445e65156d Mon Sep 17 00:00:00 2001
 From: Taylor Neyland <tneyla@amazon.com>
 Date: Wed, 19 Jul 2023 12:51:30 -0500
 Subject: [PATCH 08/13] Networking improvements

--- a/projects/kubernetes-sigs/image-builder/patches/0009-Support-and-improvements-for-RHEL-9-EFI.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0009-Support-and-improvements-for-RHEL-9-EFI.patch
@@ -1,4 +1,4 @@
-From 527054c602708283b096cfccd6148e53c7f3f629 Mon Sep 17 00:00:00 2001
+From 4091348b5187ca6108dc8a36bb7a2cb178d43be5 Mon Sep 17 00:00:00 2001
 From: Shizhao Liu <lshizhao@amazon.com>
 Date: Mon, 19 Aug 2024 10:14:26 -0700
 Subject: [PATCH 09/13] Support and improvements for RHEL 9 EFI

--- a/projects/kubernetes-sigs/image-builder/patches/0010-Pin-Packer-Goss-plugin-version-to-3.1.4.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0010-Pin-Packer-Goss-plugin-version-to-3.1.4.patch
@@ -1,4 +1,4 @@
-From 3e436f35aa14213f2d5694e29acdbfcb135c50db Mon Sep 17 00:00:00 2001
+From d4e9c247a20de87ee5b9e2d16ffd73b1b20c3c59 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 19 Sep 2024 15:36:00 -0700
 Subject: [PATCH 10/13] Pin Packer Goss plugin version to 3.1.4

--- a/projects/kubernetes-sigs/image-builder/patches/0011-Remove-containerd-configuration-for-hosts.toml-paths.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0011-Remove-containerd-configuration-for-hosts.toml-paths.patch
@@ -1,4 +1,4 @@
-From 50a1268496df4bdaca0a56288e748aed98cd13cd Mon Sep 17 00:00:00 2001
+From 0f8e88a6ffa5dc30233ef1a84de996fa0a4486b5 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 19 Sep 2024 16:04:19 -0700
 Subject: [PATCH 11/13] Remove containerd configuration for hosts.toml paths

--- a/projects/kubernetes-sigs/image-builder/patches/0012-Revert-updating-preseed-and-cloud-init-to-use-CD-for.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0012-Revert-updating-preseed-and-cloud-init-to-use-CD-for.patch
@@ -1,4 +1,4 @@
-From d040396db9c029afa35ee9f440641c84817f8b5b Mon Sep 17 00:00:00 2001
+From 6ea8dd405e58493c6369d63d7d61504bd9701123 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 19 Sep 2024 18:52:00 -0700
 Subject: [PATCH 12/13] Revert updating preseed and cloud-init to use CD for

--- a/projects/kubernetes-sigs/image-builder/patches/0013-Revert-Optionally-source-etc-default-kubelet-in-kube.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0013-Revert-Optionally-source-etc-default-kubelet-in-kube.patch
@@ -1,4 +1,4 @@
-From 22bf6061876965bc4b23b5f55c90874dca33e0da Mon Sep 17 00:00:00 2001
+From c00f08072de2bca6fefe33eb9a721ea057b3c100 Mon Sep 17 00:00:00 2001
 From: Saurabh Parekh <sjparekh@amazon.com>
 Date: Thu, 3 Oct 2024 21:24:40 -0700
 Subject: [PATCH 13/13] Revert "Optionally source /etc/default/kubelet in


### PR DESCRIPTION
I observed this in all the RedHat raw and CloudStack image builds
```console
qemu: TASK [sysprep : Remove subscriptions] ******************************************
qemu: fatal: [default]: FAILED! => {"changed": false, "msg": "value of state must be one of: enabled, disabled, got: absent"}
```
This task is defined [here](https://github.com/kubernetes-sigs/image-builder/blob/main/images/capi/ansible/roles/sysprep/tasks/redhat.yml#L58-L61).

The `community.general.rhsm_repository` is provided by the Ansible collection `community.general` and in version v10.0.0 of this collection, they removed the state `absent` and instead we need to use `disabled`.

In our builder-base image used in CI we have version `v9.4.0` of `community.general` collection which still supports `absent` state (although deprecated), that's why RedHat Nutanix and RedHat OVA builds which run on builder-base in Codebuild don't face this error.

But in the EC2 KVM AMI used for Raw and CloudStack builds, we have version `v10.0.0` installed, so we're seeing this failure. So in this PR, I'm adding a patch to fix the state used in the Ansible RHSM repository module.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
