### PR TITLE
Always download Nutanix source images and delete them after build

### DIFF
--- a/projects/aws/image-builder/builder/types.go
+++ b/projects/aws/image-builder/builder/types.go
@@ -119,7 +119,6 @@ type NutanixConfig struct {
 	ImageName         string `json:"image_name"`
 	ImageUrl          string `json:"image_url,omitempty"`
 	ImageExport       string `json:"image_export,omitempty"`
-	SourceImageName   string `json:"source_image_name,omitempty"`
 	NutanixEndpoint   string `json:"nutanix_endpoint"`
 	NutanixInsecure   string `json:"nutanix_insecure"`
 	NutanixPort       string `json:"nutanix_port"`

--- a/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0005-RHEL-support-and-improvements.patch
@@ -1,4 +1,4 @@
-From 9d99446c06654487aed896f4a4554dbdf4dc9c86 Mon Sep 17 00:00:00 2001
+From a21b747bec93b12163136887703cd1d9b0adaaf7 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 6 Dec 2022 15:42:02 -0600
 Subject: [PATCH 05/13] RHEL support and improvements

--- a/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0006-Nutanix-improvements.patch
@@ -1,18 +1,18 @@
-From b55783834e2acd76561a447d365890510a2707c3 Mon Sep 17 00:00:00 2001
+From 2afd159589243181289bbb8ca0b524450a385e4a Mon Sep 17 00:00:00 2001
 From: Ilya Alekseyev <ilya.alekseyev@nutanix.com>
 Date: Wed, 11 Oct 2023 22:07:22 -0400
 Subject: [PATCH 06/13] Nutanix improvements
 
 - Fetch Nutanix RHEL source image URL from environment
 - Force-delete Nutanix builder VMs on failure
-
+- Always download Nutanix source images and delete them after build
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---
  images/capi/packer/nutanix/.gitignore       | 2 +-
- images/capi/packer/nutanix/packer.json.tmpl | 1 +
+ images/capi/packer/nutanix/packer.json.tmpl | 5 +++--
  images/capi/packer/nutanix/rhel-8.json      | 1 -
  images/capi/packer/nutanix/rhel-9.json      | 1 -
- 4 files changed, 2 insertions(+), 3 deletions(-)
+ 4 files changed, 4 insertions(+), 5 deletions(-)
 
 diff --git a/images/capi/packer/nutanix/.gitignore b/images/capi/packer/nutanix/.gitignore
 index f5f595899..b39358b5e 100644
@@ -23,7 +23,7 @@ index f5f595899..b39358b5e 100644
 -user-data.tmpl
 +user-data
 diff --git a/images/capi/packer/nutanix/packer.json.tmpl b/images/capi/packer/nutanix/packer.json.tmpl
-index f53c51514..c5e150dbd 100644
+index f53c51514..3d4e875b0 100644
 --- a/images/capi/packer/nutanix/packer.json.tmpl
 +++ b/images/capi/packer/nutanix/packer.json.tmpl
 @@ -132,6 +132,7 @@
@@ -34,6 +34,17 @@ index f53c51514..c5e150dbd 100644
      "kubernetes_cni_deb_version": null,
      "kubernetes_cni_http_source": null,
      "kubernetes_cni_semver": null,
+@@ -160,8 +161,8 @@
+     "nutanix_username": "{{env `NUTANIX_USERNAME`}}",
+     "python_path": "",
+     "scp_extra_vars": "",
+-    "source_image_delete": "false",
+-    "source_image_force": "false",
++    "source_image_delete": "true",
++    "source_image_force": "true",
+     "ssh_password": "$SSH_PASSWORD",
+     "ssh_username": "builder",
+     "vm_force_delete": "true"
 diff --git a/images/capi/packer/nutanix/rhel-8.json b/images/capi/packer/nutanix/rhel-8.json
 index 9aba21d66..b2bef7674 100644
 --- a/images/capi/packer/nutanix/rhel-8.json

--- a/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0007-adds-retries-and-timeout-to-packer-image-builder.patch
@@ -1,4 +1,4 @@
-From 445b9af6daf52ad00e3a4a781b16c2d86f86ff6d Mon Sep 17 00:00:00 2001
+From ed4ddcbe24b243fba1240c45666d5d509d5cd900 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Mon, 21 Aug 2023 18:40:07 -0500
 Subject: [PATCH 07/13] adds retries and timeout to packer image-builder

--- a/projects/kubernetes-sigs/image-builder/patches/0008-Networking-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0008-Networking-improvements.patch
@@ -1,4 +1,4 @@
-From 57a15c0b40a236b15234264dab8968445e65156d Mon Sep 17 00:00:00 2001
+From ef513c911f062f11c0a4a899fccaaba9aa36ad57 Mon Sep 17 00:00:00 2001
 From: Taylor Neyland <tneyla@amazon.com>
 Date: Wed, 19 Jul 2023 12:51:30 -0500
 Subject: [PATCH 08/13] Networking improvements

--- a/projects/kubernetes-sigs/image-builder/patches/0009-Support-and-improvements-for-RHEL-9-EFI.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0009-Support-and-improvements-for-RHEL-9-EFI.patch
@@ -1,4 +1,4 @@
-From 4091348b5187ca6108dc8a36bb7a2cb178d43be5 Mon Sep 17 00:00:00 2001
+From 71c142521d1831bc054be32ae0d36e2f8e43c35b Mon Sep 17 00:00:00 2001
 From: Shizhao Liu <lshizhao@amazon.com>
 Date: Mon, 19 Aug 2024 10:14:26 -0700
 Subject: [PATCH 09/13] Support and improvements for RHEL 9 EFI

--- a/projects/kubernetes-sigs/image-builder/patches/0010-Pin-Packer-Goss-plugin-version-to-3.1.4.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0010-Pin-Packer-Goss-plugin-version-to-3.1.4.patch
@@ -1,4 +1,4 @@
-From d4e9c247a20de87ee5b9e2d16ffd73b1b20c3c59 Mon Sep 17 00:00:00 2001
+From ec02c52ae5b968f6187e4cd9fa7697b9aede1c4d Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 19 Sep 2024 15:36:00 -0700
 Subject: [PATCH 10/13] Pin Packer Goss plugin version to 3.1.4

--- a/projects/kubernetes-sigs/image-builder/patches/0011-Remove-containerd-configuration-for-hosts.toml-paths.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0011-Remove-containerd-configuration-for-hosts.toml-paths.patch
@@ -1,4 +1,4 @@
-From 0f8e88a6ffa5dc30233ef1a84de996fa0a4486b5 Mon Sep 17 00:00:00 2001
+From d2b744ec479a33432d319f6b525c3c6f1298be36 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 19 Sep 2024 16:04:19 -0700
 Subject: [PATCH 11/13] Remove containerd configuration for hosts.toml paths

--- a/projects/kubernetes-sigs/image-builder/patches/0012-Revert-updating-preseed-and-cloud-init-to-use-CD-for.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0012-Revert-updating-preseed-and-cloud-init-to-use-CD-for.patch
@@ -1,4 +1,4 @@
-From 6ea8dd405e58493c6369d63d7d61504bd9701123 Mon Sep 17 00:00:00 2001
+From 84476d2ad3c940ff82c047a6c66a037ccc6b03ce Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 19 Sep 2024 18:52:00 -0700
 Subject: [PATCH 12/13] Revert updating preseed and cloud-init to use CD for

--- a/projects/kubernetes-sigs/image-builder/patches/0013-Revert-Optionally-source-etc-default-kubelet-in-kube.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0013-Revert-Optionally-source-etc-default-kubelet-in-kube.patch
@@ -1,4 +1,4 @@
-From c00f08072de2bca6fefe33eb9a721ea057b3c100 Mon Sep 17 00:00:00 2001
+From 18b1771fe5565472aa31a2abd7a39745517f769a Mon Sep 17 00:00:00 2001
 From: Saurabh Parekh <sjparekh@amazon.com>
 Date: Thu, 3 Oct 2024 21:24:40 -0700
 Subject: [PATCH 13/13] Revert "Optionally source /etc/default/kubelet in


### PR DESCRIPTION
Configuring Nutanix builds to always download the source images and delete them after build so that each build doesn't leave behind a copy of it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
