### PR TITLE
Fix Helm sedfile template for Tinkerbell charts

### DIFF
--- a/projects/tinkerbell/charts/helm/sedfile.template
+++ b/projects/tinkerbell/charts/helm/sedfile.template
@@ -1,1 +1,1 @@
-s,v0.6.2,${IMAGE_TAG},g
+s,^version: 0.6.2,version: ${IMAGE_TAG},g


### PR DESCRIPTION
In order for the `sed` command to work correctly, the sedfile should not have a leading `v` in the semver.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
