### PR TITLE
breaks kind batch build up even more

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -103,7 +103,7 @@ SUPPORTED_K8S_VERSIONS=$(shell cat $(BASE_DIRECTORY)/release/SUPPORTED_RELEASE_B
 SKIPPED_K8S_VERSIONS?=
 BINARIES_ARE_RELEASE_BRANCHED?=true
 IS_RELEASE_BRANCH_BUILD=$(filter true,$(HAS_RELEASE_BRANCHES))
-UNRELEASE_BRANCH_BINARY_TARGETS=patch-repo binaries attribution checksums
+UNRELEASE_BRANCH_BINARY_TARGETS=patch-repo binaries attribution checksums validate-checksums
 IS_UNRELEASE_BRANCH_TARGET=$(and $(filter false,$(BINARIES_ARE_RELEASE_BRANCHED)),$(filter $(UNRELEASE_BRANCH_BINARY_TARGETS) $(foreach target,$(UNRELEASE_BRANCH_BINARY_TARGETS),run-$(target)-in-docker run-in-docker/$(target)),$(MAKECMDGOALS)))
 TARGETS_ALLOWED_WITH_NO_RELEASE_BRANCH?=
 TARGETS_ALLOWED_WITH_NO_RELEASE_BRANCH+=build release clean clean-extra clean-go-cache help start-docker-builder stop-docker-builder create-ecr-repos all-attributions all-checksums all-attributions-checksums update-patch-numbers check-for-release-branch-skip run-buildkit-and-registry $(if $(filter false, $(HAS_LICENSES)),attribution,) $(if $(filter true, $(HAS_HELM_CHART)),,helm/push)
@@ -851,6 +851,8 @@ PHONY: combine-images
 combine-images: IMAGE_BUILD_ARGS=IMAGE
 combine-images: DOCKERFILE_FOLDER=$(BUILD_LIB)/docker/linux/combine
 combine-images: IMAGE_EXPORT_CACHE=--export-cache type=inline
+combine-images: IMAGE_TARGET=
+combine-images: IMAGE_CONTEXT_DIR=.
 combine-images: images
 
 ## Helm Targets

--- a/projects/kubernetes-sigs/kind/Makefile
+++ b/projects/kubernetes-sigs/kind/Makefile
@@ -33,8 +33,8 @@ EKSD_KUBE_VERSION=
 # Overriding since kind is released branch it will try to add git_tag to latest tag
 LATEST_TAG=$(LATEST)
 
-UNVERSIONED_BASE_IMAGE=$(IMAGE_REPO)/$(KIND_BASE_IMAGE_COMPONENT):$(GIT_TAG)-$(GIT_HASH)
-VERSIONED_BASE_IMAGE=$(IMAGE_REPO)/$(KIND_BASE_IMAGE_COMPONENT):$(EKSD_KUBE_VERSION)-$(GIT_TAG)-$(GIT_HASH)
+UNVERSIONED_BASE_IMAGE=$(IMAGE_REPO)/$(KIND_BASE_IMAGE_COMPONENT):$(GIT_TAG)-$(GIT_HASH)$(IMAGE_TAG_SUFFIX)
+VERSIONED_BASE_IMAGE=$(IMAGE_REPO)/$(KIND_BASE_IMAGE_COMPONENT):$(EKSD_KUBE_VERSION)-$(GIT_TAG)-$(GIT_HASH)$(IMAGE_TAG_SUFFIX)
 
 HAS_S3_ARTIFACTS?=true
 HAS_RELEASE_BRANCHES=true
@@ -52,17 +52,49 @@ IMAGE_NAMES?=haproxy kindnetd kind-base
 
 FIX_LICENSES_KINDNETD_TARGET=$(REPO)/images/kindnetd/LICENSE
 
-BUILDSPECS=buildspecs/binaries.yml buildspecs/images.yml
+# we need to set IMAGE_BUILD_ARGS here even though its the same as the default. 
+# it is set in Common.mk on the images target (https://github.com/aws/eks-anywhere-build-tooling/blob/8b6d6d66974e881b22e3c9c8ea29adc26f7df5fd/Common.mk#L799)
+# and the combine-images target (https://github.com/aws/eks-anywhere-build-tooling/blob/8b6d6d66974e881b22e3c9c8ea29adc26f7df5fd/Common.mk#L846)
+# since combine-images has images as prereq target, the ?= does not really behavior as one might expect.
+# the images target being the actual action, its version of the set takes prioirty and resets to empty
+# setting it explicitly to empty here takes allows the combine-images override to take proirty
+IMAGE_BUILD_ARGS=
+
+# We are using this pattern of setting the dockerfile_folder instead of local to the target
+# because this project uses the combine-images target which overrides the dockerfile_folder
+# to the standard combine-images dockerfile
+# If we setup our override in this Makefile at the target it does not allow the combine-images
+# to override it
+DOCKERFILE_FOLDER=$(strip $(if $(findstring kind-base,$(IMAGE_NAME)),$(REPO)/images/base,$(if $(filter kind-node,$(IMAGE_NAME)),./images/node,./images/$(IMAGE_NAME))))
+
+# setting image_tarrget similiar to how we set dockerfile_folder as to be able to override it in combine-images
+KIND_BASE_IMAGE_TARGET=base
+KIND_BASE_VERSIONED_IMAGE_TARGET=base-versioned
+KIND_NODE_IMAGE_TARGET=node
+IMAGE_TARGET=$(call IF_OVERRIDE_VARIABLE,$(call TO_UPPER,$(IMAGE_NAME))_IMAGE_TARGET,)
+
+KIND_BASE_IMAGE_CONTEXT_DIR=$(REPO)/images/base
+KIND_BASE_VERSIONED_IMAGE_CONTEXT_DIR=$(OUTPUT_DIR)/$(RELEASE_BRANCH)/images/base
+KIND_NODE_IMAGE_CONTEXT_DIR=$(BINARY_DEPS_DIR)
+KIND_IF_OVERRIDE_VARIABLE=$(if $(filter undefined,$(origin $1)),$(2),$($(1)))
+IMAGE_CONTEXT_DIR=$(call KIND_IF_OVERRIDE_VARIABLE,$(call TO_UPPER,$(IMAGE_NAME))_IMAGE_CONTEXT_DIR,.)
+
+BUILDSPECS=projects/kubernetes-sigs/kind/buildspecs/binaries.yml projects/kubernetes-sigs/kind/buildspecs/base-images.yml projects/kubernetes-sigs/kind/buildspecs/node-images.yml buildspecs/combine-images.yml
 BUILDSPEC_1_PLATFORM=ARM_CONTAINER
 BUILDSPEC_1_DEPENDS_ON_OVERRIDE=none
-BUILDSPEC_2_PLATFORM=LINUX_CONTAINER
-BUILDSPEC_2_COMPUTE_TYPE=BUILD_GENERAL1_LARGE
-BUILDSPEC_2_VARS_KEYS=RELEASE_BRANCH
-BUILDSPEC_2_VARS_VALUES=SUPPORTED_K8S_VERSIONS
-
+BUILDSPEC_2_VARS_KEYS=IMAGE_PLATFORMS
+BUILDSPEC_2_VARS_VALUES=IMAGE_PLATFORMS
+BUILDSPEC_3_VARS_KEYS=RELEASE_BRANCH IMAGE_PLATFORMS
+BUILDSPEC_3_VARS_VALUES=SUPPORTED_K8S_VERSIONS IMAGE_PLATFORMS
+BUILDSPEC_3_DEPENDS_ON_OVERRIDE=kubernetes_sigs_kind_linux_amd64 kubernetes_sigs_kind_linux_arm64
+BUILDSPEC_4_VARS_KEYS=RELEASE_BRANCH
+BUILDSPEC_4_VARS_VALUES=SUPPORTED_K8S_VERSIONS
+BUILDSPEC_4_DEPENDS_ON_OVERRIDE=$(foreach version,$(SUPPORTED_K8S_VERSIONS),$(foreach arch,arm64 amd64,kubernetes_sigs_kind_$(subst -,_,$(version))_linux_$(arch)_node_images))
+BUILDSPEC_COMPUTE_TYPE=BUILD_GENERAL1_LARGE
 
 
 include $(BASE_DIRECTORY)/Common.mk
+
 
 # Do not need to import if running clean or any var-value-% targets
 ifneq ($(and $(RELEASE_BRANCH),$(filter-out clean help-list add-generated-help-block,$(MAKECMDGOALS_WITHOUT_VAR_VALUE))),)
@@ -82,7 +114,6 @@ create-ecr-repos: kind-node/create-ecr-repo
 $(OUTPUT_BIN_DIR)/%/kind: EXTRA_GO_LDFLAGS=-X=sigs.k8s.io/kind/pkg/cmd/kind/version.gitCommit=$(shell git -C $(REPO) rev-list -n 1  "${GIT_TAG}")
 
 # haproxy
-haproxy/images/%: DOCKERFILE_FOLDER=./images/haproxy
 haproxy/images/%: BASE_IMAGE_NAME=$(MINIMAL_BASE_HAPROXY_IMAGE_NAME)
 $(call IMAGE_TARGETS_FOR_NAME, haproxy): $(HAPROXY_CFG)
 
@@ -91,44 +122,32 @@ $(HAPROXY_CFG): $(GIT_PATCH_TARGET)
 	cp $(REPO)/images/haproxy/haproxy.cfg $@
 
 # Kindnetd
-kindnetd/images/%: DOCKERFILE_FOLDER=./images/kindnetd
 kindnetd/images/%: BASE_IMAGE_NAME=$(MINIMAL_BASE_IPTABLES_IMAGE_NAME)
 
 # Kind-base
-kind-base/images/% kind-base-versioned/images/%: DOCKERFILE_FOLDER=$(REPO)/images/base
 kind-base/images/% kind-base-versioned/images/%: BASE_IMAGE_NAME=$(MINIMAL_BASE_KIND_IMAGE_NAME)
 kind-base/images/% kind-base-versioned/images/%: BASE_IMAGE_OS_VERSION=$(MINIMAL_BASE_KIND_IMAGE_NAME_OS_VERSION)
-kind-base/images/% kind-base-versioned/images/%: IMAGE_BUILD_ARGS=CNI_PLUGINS_AMD64_URL CNI_PLUGINS_ARM64_URL CNI_PLUGINS_AMD64_SHA256SUM \
-	CNI_PLUGINS_ARM64_SHA256SUM
+kind-base-versioned/images/%: IMAGE_BUILD_ARGS+=CNI_PLUGINS_AMD64_URL CNI_PLUGINS_ARM64_URL CNI_PLUGINS_AMD64_SHA256SUM CNI_PLUGINS_ARM64_SHA256SUM
 
-kind-base/images/%: IMAGE_TARGET=base
-kind-base/images/%: IMAGE_CONTEXT_DIR=$(REPO)/images/base
-$(call IMAGE_TARGETS_FOR_NAME, kind-base): $(KIND_BASE_IMAGE_BUILD_ARGS)
-
-kind-base-versioned/images/%: IMAGE_TARGET=base-versioned
 kind-base-versioned/images/%: IMAGE_TAG:=$(EKSD_KUBE_VERSION)-$(IMAGE_TAG)
 kind-base-versioned/images/%: LATEST_TAG:=$(EKSD_KUBE_VERSION)-$(LATEST_TAG)
-kind-base-versioned/images/%: IMAGE_CONTEXT_DIR=$(OUTPUT_DIR)/$(RELEASE_BRANCH)/images/base
 kind-base-versioned/images/%: BUILDER_IMAGE=$(UNVERSIONED_BASE_IMAGE)
-$(call IMAGE_TARGETS_FOR_NAME, kind-base-versioned): $(KIND_BASE_KUBEADM_OVERRIDE)
+$(call IMAGE_TARGETS_FOR_NAME, kind-base-versioned): $(KIND_BASE_IMAGE_BUILD_ARGS) $(KIND_BASE_KUBEADM_OVERRIDE)
 
 # Kind-node
-kind-node/images/push: DOCKERFILE_FOLDER=./images/node
-kind-node/images/push: IMAGE_CONTEXT_DIR=$(BINARY_DEPS_DIR)
 kind-node/images/push: BASE_IMAGE=$(VERSIONED_BASE_IMAGE)
 # We are fully overriding the base_image above, setting the name is to ensure the builder image is set correctly
 kind-node/images/push: BASE_IMAGE_NAME=$(MINIMAL_BASE_KIND_IMAGE_NAME)
 kind-node/images/push: BASE_IMAGE_OS_VERSION=$(MINIMAL_BASE_KIND_IMAGE_NAME_OS_VERSION)
 kind-node/images/push: IMAGE_TAG=$(NODE_IMAGE_TAG)
 kind-node/images/push: LATEST_TAG=$(NODE_IMAGE_LATEST_TAG)
-kind-node/images/push: IMAGE_TARGET=node
-kind-node/images/push: $(KIND_NODE_BUILD_AMD64_TARGET) $(KIND_NODE_BUILD_ARM64_TARGET) $(ARM_ENV_CONF_TARGET)
+kind-node/images/push: $(if $(filter linux/amd64,$(IMAGE_PLATFORMS)),$(KIND_NODE_BUILD_AMD64_TARGET),) $(if $(filter linux/arm64,$(IMAGE_PLATFORMS)),$(KIND_NODE_BUILD_ARM64_TARGET) $(ARM_ENV_CONF_TARGET),)
 
 $(KIND_BASE_IMAGE_BUILD_ARGS): | ensure-yq $$(ENABLE_LOGGING)
 	@build/base-image-build-args.sh $(RELEASE_BRANCH) $(ARTIFACTS_BUCKET) $@ $(LATEST)
 
 $(KIND_NODE_IMAGE_BUILD_ARGS): | ensure-yq $$(ENABLE_LOGGING)
-	@build/node-image-build-args.sh $(RELEASE_BRANCH) $(KINDNETD_IMAGE_COMPONENT) $(IMAGE_REPO) "$(ARTIFACTS_BUCKET)" $(IMAGE_TAG) $(LATEST) $@
+	@build/node-image-build-args.sh $(RELEASE_BRANCH) $(KINDNETD_IMAGE_COMPONENT) $(IMAGE_REPO) "$(ARTIFACTS_BUCKET)" $(IMAGE_TAG) $(LATEST) $@ $(IMAGE_TAG_SUFFIX)
 
 # Tweak the kind/base image to have a hardcode kubeadm config
 # so that during the image pull phase it pulls eks-d images
@@ -151,7 +170,9 @@ $(KIND_NODE_BUILD_AMD64_TARGET): $(KIND_NODE_IMAGE_BUILD_ARGS) $(ORGANIZE_BINARI
 	$(MAKE) $(KIND_CLI) BINARY_PLATFORMS=$(BUILDER_PLATFORM)
 	build/build-kind-node-image.sh $(RELEASE_BRANCH) $(VERSIONED_BASE_IMAGE) amd64 $(BUILDER_PLATFORM_ARCH)
 
+$(KIND_NODE_BUILD_ARM64_TARGET): KIND_CLI=./$(OUTPUT_BIN_DIR)/$(subst /,-,$(BUILDER_PLATFORM))/kind
 $(KIND_NODE_BUILD_ARM64_TARGET): $(KIND_NODE_IMAGE_BUILD_ARGS) $(ORGANIZE_BINARIES_ARM64_TARGET) | ensure-jq
+	$(MAKE) $(KIND_CLI) BINARY_PLATFORMS=$(BUILDER_PLATFORM)
 	build/build-kind-node-image.sh $(RELEASE_BRANCH) $(VERSIONED_BASE_IMAGE) arm64 $(BUILDER_PLATFORM_ARCH)
 
 $(ORGANIZE_BINARIES_AMD64_TARGET): $(HANDLE_DEPENDENCIES_TARGET)

--- a/projects/kubernetes-sigs/kind/build/node-image-build-args.sh
+++ b/projects/kubernetes-sigs/kind/build/node-image-build-args.sh
@@ -23,6 +23,7 @@ ARTIFACTS_BUCKET="$4"
 IMAGE_TAG="$5"
 LATEST="$6"
 OUTPUT_FILE="$7"
+IMAGE_TAG_SUFFIX="$8"
 
 MAKE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 BUILD_LIB="${MAKE_ROOT}/../../../build/lib"
@@ -33,7 +34,7 @@ AL2_HELPER_IMAGE="public.ecr.aws/amazonlinux/amazonlinux:2"
 LOCAL_PATH_PROVISONER_IMAGE_TAG_OVERRIDE="$IMAGE_REPO/rancher/local-path-provisioner:$LATEST"
 LOCAL_PATH_PROVISONER_RELEASE_OVERRIDE="public.ecr.aws/eks-anywhere/rancher/local-path-provisioner:$(cat $MAKE_ROOT/../../rancher/local-path-provisioner/GIT_TAG)"
 KIND_KINDNETD_RELEASE_OVERRIDE="public.ecr.aws/eks-anywhere/kubernetes-sigs/kind/kindnetd:$(cat $MAKE_ROOT/GIT_TAG)"
-KIND_KINDNETD_IMAGE_OVERRIDE="$IMAGE_REPO/$KINDNETD_IMAGE_COMPONENT:$LATEST"
+KIND_KINDNETD_IMAGE_OVERRIDE="$IMAGE_REPO/$KINDNETD_IMAGE_COMPONENT:$LATEST$IMAGE_TAG_SUFFIX"
 
 # Preload release yaml
 build::eksd_releases::load_release_yaml $EKSD_RELEASE_BRANCH

--- a/projects/kubernetes-sigs/kind/buildspecs/base-images.yml
+++ b/projects/kubernetes-sigs/kind/buildspecs/base-images.yml
@@ -1,0 +1,14 @@
+version: 0.2
+
+env:
+  variables:
+    HAS_S3_ARTIFACTS: ""
+
+phases:
+  pre_build:
+    commands:
+    - ./build/lib/setup.sh
+
+  build:
+    commands:
+    - if $(make check-project-path-exists); then make binaries haproxy/images/push kindnetd/images/push kind-base/images/push -C $PROJECT_PATH; fi

--- a/projects/kubernetes-sigs/kind/buildspecs/batch-build.yml
+++ b/projects/kubernetes-sigs/kind/buildspecs/batch-build.yml
@@ -18,37 +18,245 @@ batch:
   fast-fail: true
   build-graph:
     - identifier: kubernetes_sigs_kind
-      buildspec: buildspecs/binaries.yml
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/binaries.yml
       env:
         type: ARM_CONTAINER
-        compute-type: BUILD_GENERAL1_SMALL
-    - identifier: kubernetes_sigs_kind_1_27
+        compute-type: BUILD_GENERAL1_LARGE
+    - identifier: kubernetes_sigs_kind_linux_amd64
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/base-images.yml
+      env:
+        type: LINUX_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          IMAGE_PLATFORMS: linux/amd64
+          BINARY_PLATFORMS: linux/amd64
+          IMAGE_TAG_SUFFIX: -amd64
+    - identifier: kubernetes_sigs_kind_linux_arm64
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/base-images.yml
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          IMAGE_PLATFORMS: linux/arm64
+          BINARY_PLATFORMS: linux/arm64
+          IMAGE_TAG_SUFFIX: -arm64
+    - identifier: kubernetes_sigs_kind_1_27_linux_amd64_node_images
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/node-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_linux_amd64
+        - kubernetes_sigs_kind_linux_arm64
       env:
         type: LINUX_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           RELEASE_BRANCH: 1-27
-    - identifier: kubernetes_sigs_kind_1_28
+          IMAGE_PLATFORMS: linux/amd64
+          BINARY_PLATFORMS: linux/amd64
+          IMAGE_TAG_SUFFIX: -amd64
+    - identifier: kubernetes_sigs_kind_1_27_linux_arm64_node_images
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/node-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_linux_amd64
+        - kubernetes_sigs_kind_linux_arm64
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          RELEASE_BRANCH: 1-27
+          IMAGE_PLATFORMS: linux/arm64
+          BINARY_PLATFORMS: linux/arm64
+          IMAGE_TAG_SUFFIX: -arm64
+    - identifier: kubernetes_sigs_kind_1_28_linux_amd64_node_images
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/node-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_linux_amd64
+        - kubernetes_sigs_kind_linux_arm64
       env:
         type: LINUX_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           RELEASE_BRANCH: 1-28
-    - identifier: kubernetes_sigs_kind_1_29
+          IMAGE_PLATFORMS: linux/amd64
+          BINARY_PLATFORMS: linux/amd64
+          IMAGE_TAG_SUFFIX: -amd64
+    - identifier: kubernetes_sigs_kind_1_28_linux_arm64_node_images
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/node-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_linux_amd64
+        - kubernetes_sigs_kind_linux_arm64
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          RELEASE_BRANCH: 1-28
+          IMAGE_PLATFORMS: linux/arm64
+          BINARY_PLATFORMS: linux/arm64
+          IMAGE_TAG_SUFFIX: -arm64
+    - identifier: kubernetes_sigs_kind_1_29_linux_amd64_node_images
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/node-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_linux_amd64
+        - kubernetes_sigs_kind_linux_arm64
       env:
         type: LINUX_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           RELEASE_BRANCH: 1-29
-    - identifier: kubernetes_sigs_kind_1_30
+          IMAGE_PLATFORMS: linux/amd64
+          BINARY_PLATFORMS: linux/amd64
+          IMAGE_TAG_SUFFIX: -amd64
+    - identifier: kubernetes_sigs_kind_1_29_linux_arm64_node_images
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/node-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_linux_amd64
+        - kubernetes_sigs_kind_linux_arm64
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          RELEASE_BRANCH: 1-29
+          IMAGE_PLATFORMS: linux/arm64
+          BINARY_PLATFORMS: linux/arm64
+          IMAGE_TAG_SUFFIX: -arm64
+    - identifier: kubernetes_sigs_kind_1_30_linux_amd64_node_images
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/node-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_linux_amd64
+        - kubernetes_sigs_kind_linux_arm64
       env:
         type: LINUX_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           RELEASE_BRANCH: 1-30
-    - identifier: kubernetes_sigs_kind_1_31
+          IMAGE_PLATFORMS: linux/amd64
+          BINARY_PLATFORMS: linux/amd64
+          IMAGE_TAG_SUFFIX: -amd64
+    - identifier: kubernetes_sigs_kind_1_30_linux_arm64_node_images
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/node-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_linux_amd64
+        - kubernetes_sigs_kind_linux_arm64
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          RELEASE_BRANCH: 1-30
+          IMAGE_PLATFORMS: linux/arm64
+          BINARY_PLATFORMS: linux/arm64
+          IMAGE_TAG_SUFFIX: -arm64
+    - identifier: kubernetes_sigs_kind_1_31_linux_amd64_node_images
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/node-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_linux_amd64
+        - kubernetes_sigs_kind_linux_arm64
       env:
         type: LINUX_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          RELEASE_BRANCH: 1-31
+          IMAGE_PLATFORMS: linux/amd64
+          BINARY_PLATFORMS: linux/amd64
+          IMAGE_TAG_SUFFIX: -amd64
+    - identifier: kubernetes_sigs_kind_1_31_linux_arm64_node_images
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/node-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_linux_amd64
+        - kubernetes_sigs_kind_linux_arm64
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          RELEASE_BRANCH: 1-31
+          IMAGE_PLATFORMS: linux/arm64
+          BINARY_PLATFORMS: linux/arm64
+          IMAGE_TAG_SUFFIX: -arm64
+    - identifier: kubernetes_sigs_kind_1_27
+      buildspec: buildspecs/combine-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_1_27_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_27_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_28_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_28_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_29_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_29_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_30_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_30_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_31_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_31_linux_amd64_node_images
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          RELEASE_BRANCH: 1-27
+    - identifier: kubernetes_sigs_kind_1_28
+      buildspec: buildspecs/combine-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_1_27_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_27_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_28_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_28_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_29_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_29_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_30_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_30_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_31_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_31_linux_amd64_node_images
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          RELEASE_BRANCH: 1-28
+    - identifier: kubernetes_sigs_kind_1_29
+      buildspec: buildspecs/combine-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_1_27_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_27_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_28_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_28_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_29_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_29_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_30_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_30_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_31_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_31_linux_amd64_node_images
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          RELEASE_BRANCH: 1-29
+    - identifier: kubernetes_sigs_kind_1_30
+      buildspec: buildspecs/combine-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_1_27_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_27_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_28_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_28_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_29_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_29_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_30_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_30_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_31_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_31_linux_amd64_node_images
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          RELEASE_BRANCH: 1-30
+    - identifier: kubernetes_sigs_kind_1_31
+      buildspec: buildspecs/combine-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_1_27_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_27_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_28_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_28_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_29_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_29_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_30_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_30_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_31_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_31_linux_amd64_node_images
+      env:
+        type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           RELEASE_BRANCH: 1-31

--- a/projects/kubernetes-sigs/kind/buildspecs/binaries.yml
+++ b/projects/kubernetes-sigs/kind/buildspecs/binaries.yml
@@ -1,0 +1,10 @@
+version: 0.2
+
+phases:
+  pre_build:
+    commands:
+    - ./build/lib/setup.sh
+
+  build:
+    commands:
+    - if $(make check-project-path-exists); then make validate-checksums upload-artifacts -C $PROJECT_PATH; fi

--- a/projects/kubernetes-sigs/kind/buildspecs/node-images.yml
+++ b/projects/kubernetes-sigs/kind/buildspecs/node-images.yml
@@ -1,0 +1,14 @@
+version: 0.2
+
+env:
+  variables:
+    HAS_S3_ARTIFACTS: ""
+
+phases:
+  pre_build:
+    commands:
+    - ./build/lib/setup.sh
+
+  build:
+    commands:
+    - if $(make check-project-path-exists); then make binaries kind-base-versioned/images/push kind-node/images/push BINARY_TARGET_FILES=kind HAS_LICENSES=false -C $PROJECT_PATH; fi

--- a/release/checksums-build.yml
+++ b/release/checksums-build.yml
@@ -378,7 +378,7 @@ batch:
     - identifier: kubernetes_sigs_kind
       env:
         type: ARM_CONTAINER
-        compute-type: BUILD_GENERAL1_SMALL
+        compute-type: BUILD_GENERAL1_LARGE
         variables:
           PROJECT_PATH: projects/kubernetes-sigs/kind
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind

--- a/release/staging-build.yml
+++ b/release/staging-build.yml
@@ -564,19 +564,48 @@ batch:
           RELEASE_BRANCH: 1-31
           IMAGE_OS_VERSION: "1"
     - identifier: kubernetes_sigs_kind
-      buildspec: buildspecs/binaries.yml
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/binaries.yml
       env:
         type: ARM_CONTAINER
-        compute-type: BUILD_GENERAL1_SMALL
+        compute-type: BUILD_GENERAL1_LARGE
         variables:
           PROJECT_PATH: projects/kubernetes-sigs/kind
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
-    - identifier: kubernetes_sigs_kind_1_27
-      buildspec: buildspecs/images.yml
+    - identifier: kubernetes_sigs_kind_linux_amd64
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/base-images.yml
       depend-on:
         - kubernetes_sigs_etcdadm
         - kubernetes_sigs_cri_tools
         - rancher_local_path_provisioner
+      env:
+        type: LINUX_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          PROJECT_PATH: projects/kubernetes-sigs/kind
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
+          IMAGE_PLATFORMS: linux/amd64
+          BINARY_PLATFORMS: linux/amd64
+          IMAGE_TAG_SUFFIX: -amd64
+    - identifier: kubernetes_sigs_kind_linux_arm64
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/base-images.yml
+      depend-on:
+        - kubernetes_sigs_etcdadm
+        - kubernetes_sigs_cri_tools
+        - rancher_local_path_provisioner
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          PROJECT_PATH: projects/kubernetes-sigs/kind
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
+          IMAGE_PLATFORMS: linux/arm64
+          BINARY_PLATFORMS: linux/arm64
+          IMAGE_TAG_SUFFIX: -arm64
+    - identifier: kubernetes_sigs_kind_1_27_linux_amd64_node_images
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/node-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_linux_amd64
+        - kubernetes_sigs_kind_linux_arm64
       env:
         type: LINUX_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
@@ -584,12 +613,29 @@ batch:
           PROJECT_PATH: projects/kubernetes-sigs/kind
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
           RELEASE_BRANCH: 1-27
-    - identifier: kubernetes_sigs_kind_1_28
-      buildspec: buildspecs/images.yml
+          IMAGE_PLATFORMS: linux/amd64
+          BINARY_PLATFORMS: linux/amd64
+          IMAGE_TAG_SUFFIX: -amd64
+    - identifier: kubernetes_sigs_kind_1_27_linux_arm64_node_images
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/node-images.yml
       depend-on:
-        - kubernetes_sigs_etcdadm
-        - kubernetes_sigs_cri_tools
-        - rancher_local_path_provisioner
+        - kubernetes_sigs_kind_linux_amd64
+        - kubernetes_sigs_kind_linux_arm64
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          PROJECT_PATH: projects/kubernetes-sigs/kind
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
+          RELEASE_BRANCH: 1-27
+          IMAGE_PLATFORMS: linux/arm64
+          BINARY_PLATFORMS: linux/arm64
+          IMAGE_TAG_SUFFIX: -arm64
+    - identifier: kubernetes_sigs_kind_1_28_linux_amd64_node_images
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/node-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_linux_amd64
+        - kubernetes_sigs_kind_linux_arm64
       env:
         type: LINUX_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
@@ -597,12 +643,29 @@ batch:
           PROJECT_PATH: projects/kubernetes-sigs/kind
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
           RELEASE_BRANCH: 1-28
-    - identifier: kubernetes_sigs_kind_1_29
-      buildspec: buildspecs/images.yml
+          IMAGE_PLATFORMS: linux/amd64
+          BINARY_PLATFORMS: linux/amd64
+          IMAGE_TAG_SUFFIX: -amd64
+    - identifier: kubernetes_sigs_kind_1_28_linux_arm64_node_images
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/node-images.yml
       depend-on:
-        - kubernetes_sigs_etcdadm
-        - kubernetes_sigs_cri_tools
-        - rancher_local_path_provisioner
+        - kubernetes_sigs_kind_linux_amd64
+        - kubernetes_sigs_kind_linux_arm64
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          PROJECT_PATH: projects/kubernetes-sigs/kind
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
+          RELEASE_BRANCH: 1-28
+          IMAGE_PLATFORMS: linux/arm64
+          BINARY_PLATFORMS: linux/arm64
+          IMAGE_TAG_SUFFIX: -arm64
+    - identifier: kubernetes_sigs_kind_1_29_linux_amd64_node_images
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/node-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_linux_amd64
+        - kubernetes_sigs_kind_linux_arm64
       env:
         type: LINUX_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
@@ -610,12 +673,29 @@ batch:
           PROJECT_PATH: projects/kubernetes-sigs/kind
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
           RELEASE_BRANCH: 1-29
-    - identifier: kubernetes_sigs_kind_1_30
-      buildspec: buildspecs/images.yml
+          IMAGE_PLATFORMS: linux/amd64
+          BINARY_PLATFORMS: linux/amd64
+          IMAGE_TAG_SUFFIX: -amd64
+    - identifier: kubernetes_sigs_kind_1_29_linux_arm64_node_images
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/node-images.yml
       depend-on:
-        - kubernetes_sigs_etcdadm
-        - kubernetes_sigs_cri_tools
-        - rancher_local_path_provisioner
+        - kubernetes_sigs_kind_linux_amd64
+        - kubernetes_sigs_kind_linux_arm64
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          PROJECT_PATH: projects/kubernetes-sigs/kind
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
+          RELEASE_BRANCH: 1-29
+          IMAGE_PLATFORMS: linux/arm64
+          BINARY_PLATFORMS: linux/arm64
+          IMAGE_TAG_SUFFIX: -arm64
+    - identifier: kubernetes_sigs_kind_1_30_linux_amd64_node_images
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/node-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_linux_amd64
+        - kubernetes_sigs_kind_linux_arm64
       env:
         type: LINUX_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
@@ -623,14 +703,149 @@ batch:
           PROJECT_PATH: projects/kubernetes-sigs/kind
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
           RELEASE_BRANCH: 1-30
-    - identifier: kubernetes_sigs_kind_1_31
-      buildspec: buildspecs/images.yml
+          IMAGE_PLATFORMS: linux/amd64
+          BINARY_PLATFORMS: linux/amd64
+          IMAGE_TAG_SUFFIX: -amd64
+    - identifier: kubernetes_sigs_kind_1_30_linux_arm64_node_images
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/node-images.yml
       depend-on:
-        - kubernetes_sigs_etcdadm
-        - kubernetes_sigs_cri_tools
-        - rancher_local_path_provisioner
+        - kubernetes_sigs_kind_linux_amd64
+        - kubernetes_sigs_kind_linux_arm64
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          PROJECT_PATH: projects/kubernetes-sigs/kind
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
+          RELEASE_BRANCH: 1-30
+          IMAGE_PLATFORMS: linux/arm64
+          BINARY_PLATFORMS: linux/arm64
+          IMAGE_TAG_SUFFIX: -arm64
+    - identifier: kubernetes_sigs_kind_1_31_linux_amd64_node_images
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/node-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_linux_amd64
+        - kubernetes_sigs_kind_linux_arm64
       env:
         type: LINUX_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          PROJECT_PATH: projects/kubernetes-sigs/kind
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
+          RELEASE_BRANCH: 1-31
+          IMAGE_PLATFORMS: linux/amd64
+          BINARY_PLATFORMS: linux/amd64
+          IMAGE_TAG_SUFFIX: -amd64
+    - identifier: kubernetes_sigs_kind_1_31_linux_arm64_node_images
+      buildspec: projects/kubernetes-sigs/kind/buildspecs/node-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_linux_amd64
+        - kubernetes_sigs_kind_linux_arm64
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          PROJECT_PATH: projects/kubernetes-sigs/kind
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
+          RELEASE_BRANCH: 1-31
+          IMAGE_PLATFORMS: linux/arm64
+          BINARY_PLATFORMS: linux/arm64
+          IMAGE_TAG_SUFFIX: -arm64
+    - identifier: kubernetes_sigs_kind_1_27
+      buildspec: buildspecs/combine-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_1_27_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_27_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_28_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_28_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_29_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_29_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_30_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_30_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_31_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_31_linux_amd64_node_images
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          PROJECT_PATH: projects/kubernetes-sigs/kind
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
+          RELEASE_BRANCH: 1-27
+    - identifier: kubernetes_sigs_kind_1_28
+      buildspec: buildspecs/combine-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_1_27_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_27_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_28_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_28_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_29_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_29_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_30_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_30_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_31_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_31_linux_amd64_node_images
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          PROJECT_PATH: projects/kubernetes-sigs/kind
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
+          RELEASE_BRANCH: 1-28
+    - identifier: kubernetes_sigs_kind_1_29
+      buildspec: buildspecs/combine-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_1_27_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_27_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_28_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_28_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_29_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_29_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_30_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_30_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_31_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_31_linux_amd64_node_images
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          PROJECT_PATH: projects/kubernetes-sigs/kind
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
+          RELEASE_BRANCH: 1-29
+    - identifier: kubernetes_sigs_kind_1_30
+      buildspec: buildspecs/combine-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_1_27_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_27_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_28_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_28_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_29_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_29_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_30_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_30_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_31_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_31_linux_amd64_node_images
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_LARGE
+        variables:
+          PROJECT_PATH: projects/kubernetes-sigs/kind
+          CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind
+          RELEASE_BRANCH: 1-30
+    - identifier: kubernetes_sigs_kind_1_31
+      buildspec: buildspecs/combine-images.yml
+      depend-on:
+        - kubernetes_sigs_kind_1_27_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_27_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_28_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_28_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_29_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_29_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_30_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_30_linux_amd64_node_images
+        - kubernetes_sigs_kind_1_31_linux_arm64_node_images
+        - kubernetes_sigs_kind_1_31_linux_amd64_node_images
+      env:
+        type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_LARGE
         variables:
           PROJECT_PATH: projects/kubernetes-sigs/kind

--- a/tools/version-tracker/buildspecs/upgrade.yml
+++ b/tools/version-tracker/buildspecs/upgrade.yml
@@ -354,7 +354,7 @@ batch:
     - identifier: kubernetes_sigs_kind
       env:
         type: ARM_CONTAINER
-        compute-type: BUILD_GENERAL1_SMALL
+        compute-type: BUILD_GENERAL1_LARGE
         variables:
           PROJECT_PATH: projects/kubernetes-sigs/kind
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/kubernetes-sigs.kind


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We appear to be hitting some kind of qemu issue in codebuild when building the arm kind node image on an amd host. This attempts to work around this by breaking the builds out even further.  Instead of just by kube version, they are now by kube version and platform...

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
