### PR TITLE
Add containerd, CAPX, runc projects to upgrade skip list

### DIFF
--- a/tools/version-tracker/SKIPPED_PROJECTS
+++ b/tools/version-tracker/SKIPPED_PROJECTS
@@ -1,0 +1,3 @@
+containerd/containerd
+nutanix-cloud-native/cluster-api-provider-nutanix
+opencontainers/runc


### PR DESCRIPTION
Add containerd, CAPX, runc projects to upgrade skip list since the latest versions are not compatible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
