### PR TITLE
Update opentelemetry-collector chart to v0.106.1

### DIFF
--- a/projects/aws-observability/aws-otel-collector/HELM_GIT_TAG
+++ b/projects/aws-observability/aws-otel-collector/HELM_GIT_TAG
@@ -1,1 +1,1 @@
-opentelemetry-collector-0.93.1
+opentelemetry-collector-0.106.1

--- a/projects/aws-observability/aws-otel-collector/helm/patches/0001-Update-image-repo.patch
+++ b/projects/aws-observability/aws-otel-collector/helm/patches/0001-Update-image-repo.patch
@@ -1,4 +1,4 @@
-From 3a182dac081aeae1ce2b57af50df277443d52911 Mon Sep 17 00:00:00 2001
+From 74422b6fa0a4f081e9332742e17ca079db9c2901 Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
 Date: Wed, 10 Jan 2024 15:27:04 -0800
 Subject: [PATCH 1/3] Update image repo
@@ -10,10 +10,10 @@ Subject: [PATCH 1/3] Update image repo
  3 files changed, 10 insertions(+), 5 deletions(-)
 
 diff --git a/charts/opentelemetry-collector/templates/_pod.tpl b/charts/opentelemetry-collector/templates/_pod.tpl
-index a1c40f67..c94d9963 100644
+index 07332ccc..39522776 100644
 --- a/charts/opentelemetry-collector/templates/_pod.tpl
 +++ b/charts/opentelemetry-collector/templates/_pod.tpl
-@@ -31,9 +31,9 @@ containers:
+@@ -34,9 +34,9 @@ containers:
        {{- toYaml .Values.securityContext | nindent 6 }}
        {{- end }}
      {{- if .Values.image.digest }}
@@ -26,7 +26,7 @@ index a1c40f67..c94d9963 100644
      imagePullPolicy: {{ .Values.image.pullPolicy }}
  
 diff --git a/charts/opentelemetry-collector/values.schema.json b/charts/opentelemetry-collector/values.schema.json
-index 9c812c12..55e9c66b 100644
+index 7ecfe75c..e8bfddc6 100644
 --- a/charts/opentelemetry-collector/values.schema.json
 +++ b/charts/opentelemetry-collector/values.schema.json
 @@ -23,6 +23,10 @@
@@ -41,7 +41,7 @@ index 9c812c12..55e9c66b 100644
        "description": "Override name of the chart used in Kubernetes object names.",
        "type": "string"
 diff --git a/charts/opentelemetry-collector/values.yaml b/charts/opentelemetry-collector/values.yaml
-index 62dfb9a3..36358f1e 100644
+index 3a0484fa..dbc3f25b 100644
 --- a/charts/opentelemetry-collector/values.yaml
 +++ b/charts/opentelemetry-collector/values.yaml
 @@ -2,6 +2,7 @@
@@ -52,7 +52,7 @@ index 62dfb9a3..36358f1e 100644
  nameOverride: ""
  fullnameOverride: ""
  
-@@ -164,17 +165,17 @@ config:
+@@ -188,17 +189,17 @@ alternateConfig: {}
  
  image:
    # If you want to use the core image `otel/opentelemetry-collector`, you also need to change `command.name` value to `otelcol`.

--- a/projects/aws-observability/aws-otel-collector/helm/patches/0002-Add-namespace-to-charts.patch
+++ b/projects/aws-observability/aws-otel-collector/helm/patches/0002-Add-namespace-to-charts.patch
@@ -1,4 +1,4 @@
-From 001eec218dd5e9511c4fb5bced360d702a7a1b19 Mon Sep 17 00:00:00 2001
+From 41b0dc72bba94a3d459a6e1cbec230dbeef7c28c Mon Sep 17 00:00:00 2001
 From: "Ostosh, Ivy" <ivyjin@amazon.com>
 Date: Fri, 27 Jan 2023 14:53:53 -0600
 Subject: [PATCH 2/3] Add namespace to charts
@@ -23,7 +23,7 @@ Subject: [PATCH 2/3] Add namespace to charts
  16 files changed, 19 insertions(+), 14 deletions(-)
 
 diff --git a/charts/opentelemetry-collector/templates/configmap-agent.yaml b/charts/opentelemetry-collector/templates/configmap-agent.yaml
-index dde2b52d..2658f7b3 100644
+index 5e07daae..6dc67aa8 100644
 --- a/charts/opentelemetry-collector/templates/configmap-agent.yaml
 +++ b/charts/opentelemetry-collector/templates/configmap-agent.yaml
 @@ -3,7 +3,7 @@ apiVersion: v1
@@ -36,7 +36,7 @@ index dde2b52d..2658f7b3 100644
      {{- include "opentelemetry-collector.labels" . | nindent 4 }}
  data:
 diff --git a/charts/opentelemetry-collector/templates/configmap-statefulset.yaml b/charts/opentelemetry-collector/templates/configmap-statefulset.yaml
-index 5b6daedd..70d4ffed 100644
+index 157f6a07..183b699c 100644
 --- a/charts/opentelemetry-collector/templates/configmap-statefulset.yaml
 +++ b/charts/opentelemetry-collector/templates/configmap-statefulset.yaml
 @@ -3,7 +3,7 @@ apiVersion: v1
@@ -49,7 +49,7 @@ index 5b6daedd..70d4ffed 100644
      {{- include "opentelemetry-collector.labels" . | nindent 4 }}
  data:
 diff --git a/charts/opentelemetry-collector/templates/configmap.yaml b/charts/opentelemetry-collector/templates/configmap.yaml
-index b0c77473..610179b7 100644
+index c72c50cb..212b5f80 100644
 --- a/charts/opentelemetry-collector/templates/configmap.yaml
 +++ b/charts/opentelemetry-collector/templates/configmap.yaml
 @@ -3,7 +3,7 @@ apiVersion: v1
@@ -62,7 +62,7 @@ index b0c77473..610179b7 100644
      {{- include "opentelemetry-collector.labels" . | nindent 4 }}
  data:
 diff --git a/charts/opentelemetry-collector/templates/daemonset.yaml b/charts/opentelemetry-collector/templates/daemonset.yaml
-index 2fe385ec..b9a51e8b 100644
+index de563e56..9ca4b8a4 100644
 --- a/charts/opentelemetry-collector/templates/daemonset.yaml
 +++ b/charts/opentelemetry-collector/templates/daemonset.yaml
 @@ -3,7 +3,7 @@ apiVersion: apps/v1
@@ -75,7 +75,7 @@ index 2fe385ec..b9a51e8b 100644
      {{- include "opentelemetry-collector.labels" . | nindent 4 }}
    {{- if .Values.annotations }}
 diff --git a/charts/opentelemetry-collector/templates/deployment.yaml b/charts/opentelemetry-collector/templates/deployment.yaml
-index 113d11ca..af29c94c 100644
+index 110130a9..014948ec 100644
 --- a/charts/opentelemetry-collector/templates/deployment.yaml
 +++ b/charts/opentelemetry-collector/templates/deployment.yaml
 @@ -3,7 +3,7 @@ apiVersion: apps/v1
@@ -179,7 +179,7 @@ index 3240acba..b45d4e8f 100644
      {{- include "opentelemetry-collector.labels" . | nindent 4 }}
    {{- if .Values.serviceAccount.annotations }}
 diff --git a/charts/opentelemetry-collector/templates/servicemonitor.yaml b/charts/opentelemetry-collector/templates/servicemonitor.yaml
-index 8acca4c5..c81e28a0 100644
+index 04fe55b2..6f1c923a 100644
 --- a/charts/opentelemetry-collector/templates/servicemonitor.yaml
 +++ b/charts/opentelemetry-collector/templates/servicemonitor.yaml
 @@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
@@ -192,7 +192,7 @@ index 8acca4c5..c81e28a0 100644
      {{- include "opentelemetry-collector.labels" . | nindent 4 }}
      {{- range $key, $value := .Values.serviceMonitor.extraLabels }}
 diff --git a/charts/opentelemetry-collector/templates/statefulset.yaml b/charts/opentelemetry-collector/templates/statefulset.yaml
-index a6cb030b..2eb44757 100644
+index 7a2cb964..e33d20c4 100644
 --- a/charts/opentelemetry-collector/templates/statefulset.yaml
 +++ b/charts/opentelemetry-collector/templates/statefulset.yaml
 @@ -3,7 +3,7 @@ apiVersion: apps/v1
@@ -205,7 +205,7 @@ index a6cb030b..2eb44757 100644
      {{- include "opentelemetry-collector.labels" . | nindent 4 }}
    {{- if .Values.annotations }}
 diff --git a/charts/opentelemetry-collector/values.schema.json b/charts/opentelemetry-collector/values.schema.json
-index 74bb8e39..b078a440 100644
+index e8bfddc6..f8ad699a 100644
 --- a/charts/opentelemetry-collector/values.schema.json
 +++ b/charts/opentelemetry-collector/values.schema.json
 @@ -35,6 +35,10 @@
@@ -220,7 +220,7 @@ index 74bb8e39..b078a440 100644
        "type": "string",
        "enum": ["daemonset", "deployment", "statefulset", ""]
 diff --git a/charts/opentelemetry-collector/values.yaml b/charts/opentelemetry-collector/values.yaml
-index 3118de31..4786c054 100644
+index dbc3f25b..35fbdc58 100644
 --- a/charts/opentelemetry-collector/values.yaml
 +++ b/charts/opentelemetry-collector/values.yaml
 @@ -5,6 +5,7 @@

--- a/projects/aws-observability/aws-otel-collector/helm/patches/0003-Update-default-values.patch
+++ b/projects/aws-observability/aws-otel-collector/helm/patches/0003-Update-default-values.patch
@@ -1,6 +1,6 @@
-From 4f976750a86fbee6cf4683f55f071a9c4bce1dbd Mon Sep 17 00:00:00 2001
+From 27d3544212def5e6d568c03d52846f352c7b55b9 Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
-Date: Mon, 27 May 2024 20:49:57 -0700
+Date: Thu, 19 Dec 2024 02:08:32 -0800
 Subject: [PATCH 3/3] Update default values
 
 ---
@@ -8,7 +8,7 @@ Subject: [PATCH 3/3] Update default values
  1 file changed, 6 insertions(+), 55 deletions(-)
 
 diff --git a/charts/opentelemetry-collector/values.yaml b/charts/opentelemetry-collector/values.yaml
-index 4786c054..1d911725 100644
+index 35fbdc58..d1a43f2f 100644
 --- a/charts/opentelemetry-collector/values.yaml
 +++ b/charts/opentelemetry-collector/values.yaml
 @@ -8,7 +8,7 @@ fullnameOverride: ""
@@ -20,7 +20,7 @@ index 4786c054..1d911725 100644
  
  # Specify which namespace should be used to deploy the resources into
  namespaceOverride: ""
-@@ -88,7 +88,10 @@ configMap:
+@@ -94,7 +94,10 @@ configMap:
  # For example, {{ REDACTED_EMAIL }} becomes {{` {{ REDACTED_EMAIL }} `}}.
  config:
    exporters:
@@ -32,9 +32,9 @@ index 4786c054..1d911725 100644
    extensions:
      # The health_check extension is mandatory for this chart.
      # Without the health_check extension the collector will fail the readiness and liveliness probes.
-@@ -101,14 +104,6 @@ config:
-     # If set to null, will be overridden with values based on k8s resource limits
-     memory_limiter: null
+@@ -112,14 +115,6 @@ config:
+       # By default spike_limit_mib is set to 25% of ".Values.resources.limits.memory"
+       spike_limit_percentage: 25
    receivers:
 -    jaeger:
 -      protocols:
@@ -47,7 +47,7 @@ index 4786c054..1d911725 100644
      otlp:
        protocols:
          grpc:
-@@ -123,8 +118,6 @@ config:
+@@ -134,8 +129,6 @@ config:
              static_configs:
                - targets:
                    - ${env:MY_POD_IP}:8888
@@ -56,9 +56,9 @@ index 4786c054..1d911725 100644
    service:
      telemetry:
        metrics:
-@@ -133,33 +126,15 @@ config:
+@@ -143,33 +136,15 @@ config:
+     extensions:
        - health_check
-       - memory_ballast
      pipelines:
 -      logs:
 -        exporters:
@@ -89,9 +89,9 @@ index 4786c054..1d911725 100644
 -          - jaeger
 -          - zipkin
  
- image:
-   # If you want to use the core image `otel/opentelemetry-collector`, you also need to change `command.name` value to `otelcol`.
-@@ -252,30 +227,6 @@ ports:
+ # Helm currently has an issue (https://github.com/helm/helm/pull/12879) when using null to remove
+ # default configuration from a subchart. The result is that you cannot remove default configuration
+@@ -282,30 +257,6 @@ ports:
      servicePort: 4318
      hostPort: 4318
      protocol: TCP


### PR DESCRIPTION
### Description of changes:
This PR updates opentelemetry-collector chart to v0.106.1.

### Upstream source of truth:
* Upstream GIT_TAG: https://github.com/aws-observability/aws-otel-collector/releases/tag/v0.41.1
* OpenTelemetry Collector version: `v0.109.0`
* Upstream HELM_GIT_TAG: https://github.com/open-telemetry/opentelemetry-helm-charts/blob/opentelemetry-collector-0.106.1/charts/opentelemetry-collector/Chart.yaml#L3


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
