### PR TITLE
Updated helm patch to include properties for eksa-packages in values.schema.json.

### DIFF
--- a/projects/cert-manager/cert-manager/helm/patches/0001-Use-sourceRegistry-and-digest-in-chart.patch
+++ b/projects/cert-manager/cert-manager/helm/patches/0001-Use-sourceRegistry-and-digest-in-chart.patch
@@ -1,7 +1,7 @@
-From 0701686157636e31c75f56a0645a7db7781b32f5 Mon Sep 17 00:00:00 2001
+From 9789c63066865ae6982491a3fe36e981caaef967 Mon Sep 17 00:00:00 2001
 From: Abdullahi Abdinur <acool@amazon.com>
 Date: Thu, 6 Oct 2022 12:55:27 -0700
-Subject: [PATCH 1/4] Use-sourceRegistry-and-digest-in-chart
+Subject: [PATCH 1/5] Use-sourceRegistry-and-digest-in-chart
 
 ---
  deploy/charts/cert-manager/Chart.yaml         |  20 ++
@@ -298,10 +298,10 @@ index 000000000..0aa7482c9
 +
 +This chart is maintained at [github.com/cert-manager/cert-manager](https://github.com/cert-manager/cert-manager/tree/master/deploy/charts/cert-manager).
 diff --git a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
-index 8f9f7f331..e6867c88e 100644
+index 65e658940..42e481c98 100644
 --- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
 +++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
-@@ -59,7 +59,7 @@ spec:
+@@ -67,7 +67,7 @@ spec:
        {{- end }}
        containers:
          - name: {{ .Chart.Name }}-cainjector
@@ -337,7 +337,7 @@ index 000000000..b49644d70
 +spec: {}
 +status: {}
 diff --git a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
-index 311b4c48e..daf358d57 100644
+index 183cff4e3..681187aac 100644
 --- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
 +++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
 @@ -47,7 +47,7 @@ spec:
@@ -350,10 +350,10 @@ index 311b4c48e..daf358d57 100644
            args:
            - check
 diff --git a/deploy/charts/cert-manager/templates/webhook-deployment.yaml b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
-index ae5399e90..af80a79c1 100644
+index 1535589ff..ae7b7c032 100644
 --- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
 +++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
-@@ -64,7 +64,7 @@ spec:
+@@ -72,7 +72,7 @@ spec:
        {{- end }}
        containers:
          - name: {{ .Chart.Name }}-webhook
@@ -363,7 +363,7 @@ index ae5399e90..af80a79c1 100644
            args:
            {{- /* The if statement below is equivalent to {{- if $value }} but will also return true for 0. */ -}}
 diff --git a/deploy/charts/cert-manager/values.yaml b/deploy/charts/cert-manager/values.yaml
-index 7630c048e..5b6b94a62 100644
+index 7a1c29530..f828c3b8a 100644
 --- a/deploy/charts/cert-manager/values.yaml
 +++ b/deploy/charts/cert-manager/values.yaml
 @@ -3,6 +3,8 @@
@@ -375,7 +375,7 @@ index 7630c048e..5b6b94a62 100644
  global:
    # Reference to one or more secrets to be used when pulling images.
    # For more information, see [Pull an Image from a Private Registry](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
-@@ -142,7 +144,7 @@ image:
+@@ -144,7 +146,7 @@ image:
  
    # The container image for the cert-manager controller.
    # +docs:property
@@ -384,7 +384,7 @@ index 7630c048e..5b6b94a62 100644
  
    # Override the image tag to deploy by setting this variable.
    # If no value is set, the chart's appVersion is used.
-@@ -154,6 +156,7 @@ image:
+@@ -156,6 +158,7 @@ image:
    # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
  
    # Kubernetes imagePullPolicy on Deployment.
@@ -392,7 +392,7 @@ index 7630c048e..5b6b94a62 100644
    pullPolicy: IfNotPresent
  
  # Override the namespace used to store DNS provider credentials etc. for ClusterIssuer
-@@ -808,7 +811,7 @@ webhook:
+@@ -867,7 +870,7 @@ webhook:
  
      # The container image for the cert-manager webhook
      # +docs:property
@@ -401,7 +401,7 @@ index 7630c048e..5b6b94a62 100644
  
      # Override the image tag to deploy by setting this variable.
      # If no value is set, the chart's appVersion will be used.
-@@ -820,6 +823,7 @@ webhook:
+@@ -879,6 +882,7 @@ webhook:
      # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
  
      # Kubernetes imagePullPolicy on Deployment.
@@ -409,7 +409,7 @@ index 7630c048e..5b6b94a62 100644
      pullPolicy: IfNotPresent
  
    serviceAccount:
-@@ -1091,7 +1095,7 @@ cainjector:
+@@ -1176,7 +1180,7 @@ cainjector:
  
      # The container image for the cert-manager cainjector
      # +docs:property
@@ -418,7 +418,7 @@ index 7630c048e..5b6b94a62 100644
  
      # Override the image tag to deploy by setting this variable.
      # If no value is set, the chart's appVersion will be used.
-@@ -1103,6 +1107,7 @@ cainjector:
+@@ -1188,6 +1192,7 @@ cainjector:
      # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
  
      # Kubernetes imagePullPolicy on Deployment.
@@ -426,7 +426,7 @@ index 7630c048e..5b6b94a62 100644
      pullPolicy: IfNotPresent
  
    serviceAccount:
-@@ -1150,7 +1155,7 @@ acmesolver:
+@@ -1235,7 +1240,7 @@ acmesolver:
  
      # The container image for the cert-manager acmesolver.
      # +docs:property
@@ -435,7 +435,7 @@ index 7630c048e..5b6b94a62 100644
  
      # Override the image tag to deploy by setting this variable.
      # If no value is set, the chart's appVersion is used.
-@@ -1162,6 +1167,7 @@ acmesolver:
+@@ -1247,6 +1252,7 @@ acmesolver:
      # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
  
      # Kubernetes imagePullPolicy on Deployment.
@@ -443,7 +443,7 @@ index 7630c048e..5b6b94a62 100644
      pullPolicy: IfNotPresent
  
  # +docs:section=Startup API Check
-@@ -1276,7 +1282,7 @@ startupapicheck:
+@@ -1368,7 +1374,7 @@ startupapicheck:
  
      # The container image for the cert-manager startupapicheck.
      # +docs:property
@@ -452,7 +452,7 @@ index 7630c048e..5b6b94a62 100644
  
      # Override the image tag to deploy by setting this variable.
      # If no value is set, the chart's appVersion is used.
-@@ -1288,6 +1294,7 @@ startupapicheck:
+@@ -1380,6 +1386,7 @@ startupapicheck:
      # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
  
      # Kubernetes imagePullPolicy on Deployment.
@@ -461,5 +461,5 @@ index 7630c048e..5b6b94a62 100644
  
    rbac:
 -- 
-2.46.0
+2.44.0
 

--- a/projects/cert-manager/cert-manager/helm/patches/0002-Add-cert-manager-CRDs.patch
+++ b/projects/cert-manager/cert-manager/helm/patches/0002-Add-cert-manager-CRDs.patch
@@ -1,7 +1,7 @@
-From 4a1de91d4b04246acec707e966684b00e1b700ab Mon Sep 17 00:00:00 2001
+From eea64541e78c374ea7c1871543bee5b919af38a8 Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
 Date: Thu, 23 Jun 2022 07:01:26 -0600
-Subject: [PATCH 2/4] Add cert-manager CRDs
+Subject: [PATCH 2/5] Add cert-manager CRDs
 
 ---
  .../cert-manager/crds/cert-manager.crds.yaml  | 4178 +++++++++++++++++
@@ -4193,5 +4193,5 @@ index 000000000..af016f11e
 +      served: true
 +      storage: true
 -- 
-2.46.0
+2.44.0
 

--- a/projects/cert-manager/cert-manager/helm/patches/0003-Remove-namespace-from-chart.patch
+++ b/projects/cert-manager/cert-manager/helm/patches/0003-Remove-namespace-from-chart.patch
@@ -1,7 +1,7 @@
-From 801c03988911c3a69274c81c6776a2ecd683c0bf Mon Sep 17 00:00:00 2001
+From 5fc73acbcb558df1ac47c4b6147e21a5464551eb Mon Sep 17 00:00:00 2001
 From: Abdullahi Abdinur <acool@amazon.com>
 Date: Thu, 6 Oct 2022 12:58:13 -0700
-Subject: [PATCH 3/4] Remove namespace from chart
+Subject: [PATCH 3/5] Remove namespace from chart
 
 ---
  deploy/charts/cert-manager/templates/namespace.yaml | 7 -------
@@ -22,5 +22,5 @@ index b49644d70..000000000
 -spec: {}
 -status: {}
 -- 
-2.46.0
+2.44.0
 

--- a/projects/cert-manager/cert-manager/helm/patches/0004-Update-cert-manager-namespace-config.patch
+++ b/projects/cert-manager/cert-manager/helm/patches/0004-Update-cert-manager-namespace-config.patch
@@ -1,7 +1,7 @@
-From 4e9235022d09390ebd58d517b4ba0a5982a30e92 Mon Sep 17 00:00:00 2001
+From bd6734ff105e04929c0842ee7424d8f5de80a39f Mon Sep 17 00:00:00 2001
 From: Abdullahi Abdinur <acool@amazon.com>
 Date: Wed, 19 Oct 2022 10:58:28 -0700
-Subject: [PATCH 4/4] Update cert manager namespace config
+Subject: [PATCH 4/5] Update cert manager namespace config
 
 ---
  deploy/charts/cert-manager/templates/_helpers.tpl            | 2 +-
@@ -13,7 +13,7 @@ Subject: [PATCH 4/4] Update cert manager namespace config
  6 files changed, 13 insertions(+), 10 deletions(-)
 
 diff --git a/deploy/charts/cert-manager/templates/_helpers.tpl b/deploy/charts/cert-manager/templates/_helpers.tpl
-index 9902c089f..047373e1f 100644
+index e15fa1910..e936fca34 100644
 --- a/deploy/charts/cert-manager/templates/_helpers.tpl
 +++ b/deploy/charts/cert-manager/templates/_helpers.tpl
 @@ -170,7 +170,7 @@ This gets around an problem within helm discussed here
@@ -89,7 +89,7 @@ index dff5c0672..eec438f38 100644
  {{- end }}
  {{- end }}
 diff --git a/deploy/charts/cert-manager/values.yaml b/deploy/charts/cert-manager/values.yaml
-index 5b6b94a62..ee12021b4 100644
+index f828c3b8a..2c1c2c2bb 100644
 --- a/deploy/charts/cert-manager/values.yaml
 +++ b/deploy/charts/cert-manager/values.yaml
 @@ -5,6 +5,9 @@
@@ -112,5 +112,5 @@ index 5b6b94a62..ee12021b4 100644
    # Labels to apply to all resources.
    # Please note that this does not add labels to the resources created dynamically by the controllers.
 -- 
-2.46.0
+2.44.0
 

--- a/projects/cert-manager/cert-manager/helm/patches/0005-Update-values.schema.json-for-schema-validation.patch
+++ b/projects/cert-manager/cert-manager/helm/patches/0005-Update-values.schema.json-for-schema-validation.patch
@@ -1,0 +1,56 @@
+From 6cee8f83c06bcefa18e508b497ba3f46e08dee36 Mon Sep 17 00:00:00 2001
+From: Prow Bot <prow@amazonaws.com>
+Date: Mon, 23 Dec 2024 15:51:42 -0800
+Subject: [PATCH 5/5] Update values.schema.json for schema validation
+
+---
+ deploy/charts/cert-manager/values.schema.json | 33 +++++++++++++++++++
+ 1 file changed, 33 insertions(+)
+
+diff --git a/deploy/charts/cert-manager/values.schema.json b/deploy/charts/cert-manager/values.schema.json
+index d04da90c2..e28d34045 100644
+--- a/deploy/charts/cert-manager/values.schema.json
++++ b/deploy/charts/cert-manager/values.schema.json
+@@ -3,6 +3,39 @@
+     "helm-values": {
+       "additionalProperties": false,
+       "properties": {
++        "imagePullSecrets": {
++          "type": "array",
++          "default": [],
++          "title": "The imagePullSecrets Schema",
++          "items": {},
++          "examples": [
++            []
++          ]
++        },
++        "defaultNamespace": {
++          "type": "string",
++          "default": "",
++          "title": "Override default namespace of the helm chart and managed resources",
++          "examples": [
++            ""
++          ]
++        },
++        "sourceRegistry": {
++          "type": "string",
++          "default": "",
++          "title": "Override source registry of the helm chart",
++          "examples": [
++            "public.ecr.aws/eks-anywhere"
++          ]
++        },
++        "imagePullPolicy": {
++          "type": "string",
++          "default": "",
++          "title": "Image pullPolicy Schema",
++          "examples": [
++            "IfNotPresent"
++          ]
++        },
+         "acmesolver": {
+           "$ref": "#/$defs/helm-values.acmesolver"
+         },
+-- 
+2.44.0
+

--- a/projects/cert-manager/cert-manager/helm/schema.json
+++ b/projects/cert-manager/cert-manager/helm/schema.json
@@ -5,20 +5,44 @@
   "title": "Root Schema",
   "additionalProperties": false,
   "properties": {
+    "imagePullSecrets": {
+      "type": "array",
+      "default": [],
+      "title": "The imagePullSecrets Schema",
+      "items": {},
+      "examples": [
+        []
+      ]
+    },
+    "defaultNamespace": {
+      "type": "string",
+      "default": "",
+      "title": "Override default namespace of the helm chart and managed resources",
+      "examples": [
+        ""
+      ]
+    },
+    "sourceRegistry": {
+      "type": "string",
+      "default": "",
+      "title": "Override source registry of the helm chart",
+      "examples": [
+        "public.ecr.aws/eks-anywhere"
+      ]
+    },
+    "imagePullPolicy": {
+      "type": "string",
+      "default": "",
+      "title": "Image pullPolicy Schema",
+      "examples": [
+        "IfNotPresent"
+      ]
+    },
     "global": {
       "type": "object",
       "default": {},
       "title": "The global Schema",
       "properties": {
-        "imagePullSecrets": {
-          "type": "array",
-          "default": [],
-          "title": "The imagePullSecrets Schema",
-          "items": {},
-          "examples": [
-            []
-          ]
-        },
         "commonLabels": {
           "type": "object",
           "default": {},


### PR DESCRIPTION
*Description of changes:*
PR adds the helm patch to update the values.schema.json for schema validation.

In recent release of [cert-manager](https://github.com/cert-manager/cert-manager/tree/v1.16.1/deploy/charts/cert-manager), `values.schema.json` was added for schema validation, which caused package installation to fail as the properties needed by EKSA curated package(sourceRegistry, defaultNamespace, imagePullSecrets, imagePullPolicy) were missing, added the required properties in  `values.schema.json`.

Testing:
```
helm install cert-manager oci://public.ecr.aws/<personal-registry-alias>/cert-manager/cert-manager --version 1.16.1-67dc5c81b9313417ea3c285b3f4828b872df9b3c --set sourceRegistry=public.ecr.aws/<personal-registry-alias>
 ```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
