### PR TITLE
Add end of standard support dates for all kubernetes versions above 1.28

### DIFF
--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -33,16 +33,16 @@ releases:
 - branch: 1-28
   kubeVersion: v1.28.15
   number: 38
-  endOfStandardSupport: 12/31/2024
+  endOfStandardSupport: "2024-12-31"
 - branch: 1-29
   kubeVersion: v1.29.11
   number: 27
-  endOfStandardSupport: 04/30/2025
+  endOfStandardSupport: "2025-04-30"
 - branch: 1-30
   kubeVersion: v1.30.7
   number: 20
-  endOfStandardSupport: 08/31/2025
+  endOfStandardSupport: "2025-08-31"
 - branch: 1-31
   kubeVersion: v1.31.3
   number: 9
-  endOfStandardSupport: 12/31/2025
+  endOfStandardSupport: "2025-12-31"

--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -33,12 +33,16 @@ releases:
 - branch: 1-28
   kubeVersion: v1.28.15
   number: 38
+  endOfStandardSupport: 12/31/2024
 - branch: 1-29
   kubeVersion: v1.29.11
   number: 27
+  endOfStandardSupport: 04/30/2025
 - branch: 1-30
   kubeVersion: v1.30.7
   number: 20
+  endOfStandardSupport: 08/31/2025
 - branch: 1-31
   kubeVersion: v1.31.3
   number: 9
+  endOfStandardSupport: 12/31/2025

--- a/tools/version-tracker/pkg/commands/upgrade/upgrade.go
+++ b/tools/version-tracker/pkg/commands/upgrade/upgrade.go
@@ -652,10 +652,13 @@ func updateUpstreamProjectsTrackerFile(projectsList *types.ProjectsList, buildTo
 	}
 	b.Write([]byte("\n"))
 
-	// Create a new YAML encoder with an appropriate indentation value and encode the project list into a byte buufer
+	// Create a new YAML encoder with an appropriate indentation value and encode the project list into a byte buffer
 	yamlEncoder := goyamlv3.NewEncoder(&b)
 	yamlEncoder.SetIndent(2)
-	yamlEncoder.Encode(&projectsList)
+	err = yamlEncoder.Encode(&projectsList)
+	if err != nil {
+		return fmt.Errorf("encoding the project list into a byte buffer: %v", err)
+	}
 
 	err = os.WriteFile(upstreamProjectsTrackerFilePath, b.Bytes(), 0o644)
 	if err != nil {

--- a/tools/version-tracker/pkg/types/types.go
+++ b/tools/version-tracker/pkg/types/types.go
@@ -67,10 +67,11 @@ type ImageMetadata struct {
 }
 
 type EKSDistroRelease struct {
-	Branch      string `json:"branch"`
-	KubeVersion string `json:"kubeVersion"`
-	Number      int    `json:"number"`
-	Dev         *bool  `json:"dev,omitempty"`
+	Branch               string `json:"branch"`
+	KubeVersion          string `json:"kubeVersion"`
+	Number               int    `json:"number"`
+	Dev                  *bool  `json:"dev,omitempty"`
+	EndOfStandardSupport string `json:"endOfStandardSupport,omitempty"`
 }
 
 type EKSDistroLatestReleases struct {


### PR DESCRIPTION
*Issue #, if available:*
[#2855](https://github.com/aws/eks-anywhere-internal/issues/2855)

*Description of changes:*
This PR adds the end of standard support dates for all Kubernetes versions starting from v1.28 onwards to indicate the start of extended support period for that version. This file will act as a source of truth for the start of extended support period for each supported kubernetes version.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
