### PR TITLE
Add env binary to the image

### DIFF
--- a/projects/tinkerbell/tink/docker/linux/tink-relay-init/Dockerfile
+++ b/projects/tinkerbell/tink/docker/linux/tink-relay-init/Dockerfile
@@ -6,7 +6,7 @@ FROM $BUILDER_IMAGE as builder
 WORKDIR /newroot
 
 RUN set -x && \
-    install_binary /usr/sbin/awk /usr/bin/nmap /usr/bin/head /usr/sbin/ip /usr/bin/echo && \
+    install_binary /usr/sbin/awk /usr/bin/nmap /usr/bin/head /usr/sbin/ip /usr/bin/echo /usr/bin/env && \
     install_rpm bash && \
     cleanup "deps"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In the Tinkerbell Stack, `host_interface.sh` script is used to let smee serve dhcp traffic on host network. The script needs the [env](https://github.com/tinkerbell/charts/blob/44ca35d1249294af1224f4b2c4fe66b41b92f965/tinkerbell/stack/templates/init_configmap.yaml#L8) binary to run. Since the existing image doesn't contain the env binary, the chart installation fails. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
