### PR TITLE
Add getopt binary to tink-relay-init image

### DIFF
--- a/projects/tinkerbell/tink/docker/linux/tink-relay-init/Dockerfile
+++ b/projects/tinkerbell/tink/docker/linux/tink-relay-init/Dockerfile
@@ -6,7 +6,7 @@ FROM $BUILDER_IMAGE as builder
 WORKDIR /newroot
 
 RUN set -x && \
-    install_binary /usr/sbin/awk /usr/bin/nmap /usr/bin/head /usr/sbin/ip /usr/bin/echo /usr/bin/env && \
+    install_binary /usr/sbin/awk /usr/bin/nmap /usr/bin/head /usr/sbin/ip /usr/bin/echo /usr/bin/env /usr/bin/getopt && \
     install_rpm bash && \
     cleanup "deps"
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`host-interface.sh` [script](https://github.com/tinkerbell/charts/blob/main/tinkerbell/stack/templates/init_configmap.yaml#L70) that's responsible to auto-discover the interface to serve dhcp traffic on host network, uses `getopt` binary, which is not present in the base image. Install the binary so that the script doesn't error out.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
