### PR TITLE
Allow specifying maximum semvers for projects

### DIFF
--- a/tools/version-tracker/SKIPPED_PROJECTS
+++ b/tools/version-tracker/SKIPPED_PROJECTS
@@ -1,3 +1,0 @@
-containerd/containerd
-nutanix-cloud-native/cluster-api-provider-nutanix
-opencontainers/runc

--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -420,4 +420,11 @@ var (
 		},
 		CuratedPackagesProjects...,
 	)
+
+	ProjectMaximumSemvers = map[string]string{
+		"containerd/containerd":                             "v1",
+		"nutanix-cloud-native/cluster-api-provider-nutanix": "v1.4",
+		"opencontainers/runc":                               "v1.1",
+		"prometheus/prometheus":                             "v2",
+	}
 )


### PR DESCRIPTION
Allow specifying maximum semvers for projects which have upgrade restrictions due to breaking changes, incompatibilities with other projects, etc.

### Example
#### Before
```console
$ version-tracker display --project containerd/containerd
ORGANIZATION  REPOSITORY  CURRENT VERSION  LATEST VERSION  
containerd    containerd  v1.7.23          v2.0.1
```

#### After
```console
$ version-tracker display --project containerd/containerd
ORGANIZATION  REPOSITORY  CURRENT VERSION  LATEST VERSION  
containerd    containerd  v1.7.23          v1.7.24
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
