### PR TITLE
Add EKS Distro base tag files to version-tracker automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,7 @@ generate-staging-buildspec: | ensure-locale
 	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "emissary-ingress_emissary" "$(BASE_DIRECTORY)/projects/emissary-ingress/emissary/buildspecs/batch-build.yml" "$(BASE_DIRECTORY)/buildspec.yml" true "DO_NOT_EXCLUDE_FROM_BUILDSPEC"
 	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "goharbor_harbor" "$(BASE_DIRECTORY)/projects/goharbor/harbor/buildspecs/batch-build.yml" "$(BASE_DIRECTORY)/buildspec.yml" true "DO_NOT_EXCLUDE_FROM_BUILDSPEC"
 	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "aws_upgrader" "$(BASE_DIRECTORY)/projects/aws/upgrader/buildspecs/batch-build.yml" "$(BASE_DIRECTORY)/buildspec.yml" true "DO_NOT_EXCLUDE_FROM_BUILDSPEC"
-	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "$(ALL_PROJECTS)" "$(BASE_DIRECTORY)/tools/version-tracker/buildspecs/upgrade.yml" "$(BASE_DIRECTORY)/buildspecs/upgrade-buildspec.yml" true EXCLUDE_FROM_UPGRADE_BUILDSPEC UPGRADE_BUILDSPECS false buildspecs/upgrade-eks-distro-buildspec.yml true
+	build/lib/generate_staging_buildspec.sh $(BASE_DIRECTORY) "$(ALL_PROJECTS)" "$(BASE_DIRECTORY)/tools/version-tracker/buildspecs/upgrade.yml" "$(BASE_DIRECTORY)/buildspecs/upgrade-buildspec.yml" true EXCLUDE_FROM_UPGRADE_BUILDSPEC UPGRADE_BUILDSPECS false "buildspecs/upgrade-eks-distro-buildspec.yml,buildspecs/upgrade-eks-distro-build-tooling-buildspec.yml" true
 
 .PHONY: generate
 generate: generate-project-list generate-staging-buildspec

--- a/buildspecs/upgrade-eks-distro-build-tooling-buildspec.yml
+++ b/buildspecs/upgrade-eks-distro-build-tooling-buildspec.yml
@@ -1,0 +1,14 @@
+version: 0.2
+
+env:
+  secrets-manager:
+    GITHUB_TOKEN: "github-eks-distro-pr-bot:github-token"
+
+phases:
+  pre_build:
+    commands:
+    - ./build/lib/setup.sh
+
+  build:
+    commands:
+    - make upgrade -C tools/version-tracker PROJECT=aws/eks-distro-build-tooling VERBOSITY=6

--- a/tools/version-tracker/buildspecs/upgrade.yml
+++ b/tools/version-tracker/buildspecs/upgrade.yml
@@ -497,6 +497,11 @@ batch:
       env:
         type: ARM_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
+    - identifier: final_stage_2
+      buildspec: buildspecs/upgrade-eks-distro-build-tooling-buildspec.yml
+      env:
+        type: ARM_CONTAINER
+        compute-type: BUILD_GENERAL1_SMALL
 version: 0.2
 env:
   secrets-manager:

--- a/tools/version-tracker/pkg/commands/display/display.go
+++ b/tools/version-tracker/pkg/commands/display/display.go
@@ -44,7 +44,7 @@ func Run(displayOptions *types.DisplayOptions) error {
 	// Get base repository owner environment variable if set.
 	baseRepoOwner := os.Getenv(constants.BaseRepoOwnerEnvvar)
 	if baseRepoOwner == "" {
-		baseRepoOwner = constants.DefaultBaseRepoOwner
+		baseRepoOwner = constants.AWSOrgName
 	}
 
 	// Clone the eks-anywhere-build-tooling repository.

--- a/tools/version-tracker/pkg/commands/listprojects/listprojects.go
+++ b/tools/version-tracker/pkg/commands/listprojects/listprojects.go
@@ -30,7 +30,7 @@ func Run() error {
 	// Get base repository owner environment variable if set.
 	baseRepoOwner := os.Getenv(constants.BaseRepoOwnerEnvvar)
 	if baseRepoOwner == "" {
-		baseRepoOwner = constants.DefaultBaseRepoOwner
+		baseRepoOwner = constants.AWSOrgName
 	}
 
 	// Clone the eks-anywhere-build-tooling repository.

--- a/tools/version-tracker/pkg/commands/upgrade/upgrade.go
+++ b/tools/version-tracker/pkg/commands/upgrade/upgrade.go
@@ -146,6 +146,43 @@ func Run(upgradeOptions *types.UpgradeOptions) error {
 		if isUpdated {
 			updatedFiles = append(updatedFiles, constants.EKSDistroLatestReleasesFile)
 		}
+	} else if isEKSDistroBuildToolingUpgrade(projectName) {
+		headBranchName = fmt.Sprintf("update-eks-distro-base-image-tag-files-%s", branchName)
+		baseBranchName = branchName
+		commitMessage = "Bump EKS Distro base image tag files to latest"
+
+		// Checkout a new branch to keep track of version upgrade chaneges.
+		err = git.Checkout(worktree, headBranchName, true)
+		if err != nil {
+			return fmt.Errorf("checking out worktree at branch %s: %v", headBranchName, err)
+		}
+
+		// Reset current worktree to get a clean index.
+		err = git.ResetToHEAD(worktree, headCommit)
+		if err != nil {
+			return fmt.Errorf("resetting new branch to [origin/%s] HEAD: %v", branchName, err)
+		}
+
+		eksDistroBaseTagFilesGlobPattern := filepath.Join(buildToolingRepoPath, constants.EKSDistroBaseTagFilesPattern)
+		eksDistroBaseTagFilesGlob, err := filepath.Glob(eksDistroBaseTagFilesGlobPattern)
+		if err != nil {
+			return fmt.Errorf("finding filenames matching EKS Distro Base tag file pattern [%s]: %v", constants.EKSDistroBaseTagFilesPattern, err)
+		}
+
+		updatedPackages, isUpdated, err := updateEKSDistroBaseImageTagFiles(client, buildToolingRepoPath, eksDistroBaseTagFilesGlob)
+		if err != nil {
+			return fmt.Errorf("updating EKS Distro base tag files: %v", err)
+		}
+		if isUpdated {
+			pullRequestBody = fmt.Sprintf(constants.EKSDistroBuildToolingUpgradePullRequestBody, updatedPackages)
+			for _, tagFile := range eksDistroBaseTagFilesGlob {
+				tagFileRelativePath, err := filepath.Rel(buildToolingRepoPath, tagFile)
+				if err != nil {
+					return fmt.Errorf("getting relative path for tag file: %v", err)
+				}
+				updatedFiles = append(updatedFiles, tagFileRelativePath)
+			}
+		}
 	} else {
 		// Validate if the project name provided exists in the repository.
 		projectPath := filepath.Join("projects", projectName)
@@ -531,6 +568,56 @@ func updateEKSDistroReleasesFile(buildToolingRepoPath string) (bool, error) {
 	return isUpdated, nil
 }
 
+func updateEKSDistroBaseImageTagFiles(client *gogithub.Client, buildToolingRepoPath string, tagFileGlob []string) (string, bool, error) {
+	var updatedPackages string
+	var isUpdated bool
+
+	eksDistroBaseTagYAMLContents, err := github.GetFileContents(client, constants.AWSOrgName, constants.EKSDistroBuildToolingRepoName, constants.EKSDistroBaseTagsYAMLFile, "main")
+	if err != nil {
+		return "", false, fmt.Errorf("getting contents of EKS Distro Base tag file: %v", err)
+	}
+
+	var eksDistroBaseTagYAMLMap map[string]interface{}
+	err = yaml.Unmarshal(eksDistroBaseTagYAMLContents, &eksDistroBaseTagYAMLMap)
+	if err != nil {
+		return "", false, fmt.Errorf("unmarshalling EKS Distro Base tag file: %v", err)
+	}
+
+	for _, tagFile := range tagFileGlob {
+		tagFileContents, err := os.ReadFile(tagFile)
+		if err != nil {
+			return "", false, fmt.Errorf("reading tag file: %v", err)
+		}
+		tagFileName := filepath.Base(tagFile)
+		imageName := strings.TrimSuffix(tagFileName, constants.TagFileSuffix)
+
+		tagFileKey := strings.ReplaceAll(strings.ToLower(imageName), "_", "-")
+		osFolder := "2"
+		osKey := "al2"
+		if strings.HasSuffix(tagFileKey, "al2023") {
+			tagFileKey = strings.TrimSuffix(tagFileKey, constants.AL2023Suffix)
+			osFolder = "2023"
+			osKey = "al2023"
+		}
+		tagReleaseDate := eksDistroBaseTagYAMLMap[osKey].(map[string]interface{})[tagFileKey].(string)
+
+		if string(tagFileContents) != tagReleaseDate {
+			isUpdated = true
+			err = os.WriteFile(tagFile, []byte(fmt.Sprintf("%s\n", tagReleaseDate)), 0o644)
+			if err != nil {
+				return "", false, fmt.Errorf("writing tag file: %v", err)
+			}
+
+			updatedPackagesFilesContents, err := github.GetFileContents(client, constants.AWSOrgName, constants.EKSDistroBuildToolingRepoName, fmt.Sprintf(constants.EKSDistroBaseUpdatedPackagesFileFormat, osFolder, tagFileKey), "main")
+			if err != nil {
+				return "", false, fmt.Errorf("getting contents of EKS Distro Base image updated packages: %v", err)
+			}
+			updatedPackages = fmt.Sprintf("%s#### %s\nThe following yum packages were updated:\n```bash\n%s```\n\n", updatedPackages, imageName, string(updatedPackagesFilesContents))
+		}
+	}
+	return updatedPackages, isUpdated, nil
+}
+
 func getSupportedReleaseBranches(buildToolingRepoPath string) ([]string, error) {
 	supportedReleaseBranchesFilepath := filepath.Join(buildToolingRepoPath, constants.SupportedReleaseBranchesFile)
 
@@ -690,7 +777,7 @@ func applyPatchesToRepo(projectRootFilepath, projectRepo string, totalPatchCount
 		patchesApplied = totalPatchCount
 	} else {
 		failedFiles := []string{}
-		gitDescribeRegex := regexp.MustCompile(`v?\d+\.\d+\.\d+(-([0-9]+)-g.*)?`)
+		gitDescribeRegex := regexp.MustCompile(constants.GitDescribeRegex)
 		gitDescribeCmd := exec.Command("git", "-C", filepath.Join(projectRootFilepath, projectRepo), "describe", "--tag")
 		gitDescribeOutput, err := command.ExecCommand(gitDescribeCmd)
 		if err != nil {
@@ -890,16 +977,16 @@ func verifyBRImageExists(channel, format, bottlerocketVersion string) (bool, err
 	switch format {
 	case "ami":
 		variant = "aws"
-		imageTarget = fmt.Sprintf("bottlerocket-%s-k8s-%s-x86_64-%s.img.lz4", variant, kubeVersion, bottlerocketVersion)
+		imageTarget = fmt.Sprintf(constants.BottlerocketAMIImageTargetFormat, variant, kubeVersion, bottlerocketVersion)
 	case "ova":
 		variant = "vmware"
-		imageTarget = fmt.Sprintf("bottlerocket-%s-k8s-%s-x86_64-%s.ova", variant, kubeVersion, bottlerocketVersion)
+		imageTarget = fmt.Sprintf(constants.BottlerocketOVAImageTargetFormat, variant, kubeVersion, bottlerocketVersion)
 	case "raw":
 		variant = "metal"
-		imageTarget = fmt.Sprintf("bottlerocket-%s-k8s-%s-x86_64-%s.img.lz4", variant, kubeVersion, bottlerocketVersion)
+		imageTarget = fmt.Sprintf(constants.BottlerocketRawImageTargetFormat, variant, kubeVersion, bottlerocketVersion)
 	}
 
-	timestampURL := fmt.Sprintf("https://updates.bottlerocket.aws/2020-07-07/%s-k8s-%s/x86_64/timestamp.json", variant, kubeVersion)
+	timestampURL := fmt.Sprintf(constants.BottlerocketTimestampJSONURLFormat, variant, kubeVersion)
 	timestampManifest, err := file.ReadURL(timestampURL)
 	if err != nil {
 		return false, fmt.Errorf("reading Bottlerocket timestamp URL: %v", err)
@@ -914,7 +1001,7 @@ func verifyBRImageExists(channel, format, bottlerocketVersion string) (bool, err
 	version := timestampData.(map[string]interface{})["signed"].(map[string]interface{})["version"].(float64)
 	versionString := fmt.Sprintf("%.0f", version)
 
-	targetsURL := fmt.Sprintf("https://updates.bottlerocket.aws/2020-07-07/%s-k8s-%s/x86_64/%s.targets.json", variant, kubeVersion, versionString)
+	targetsURL := fmt.Sprintf(constants.BottlerocketTargetsJSONURLFormat, variant, kubeVersion, versionString)
 	targetsManifest, err := file.ReadURL(targetsURL)
 	if err != nil {
 		return false, fmt.Errorf("reading Bottlerocket targets URL: %v", err)
@@ -938,7 +1025,7 @@ func verifyBRImageExists(channel, format, bottlerocketVersion string) (bool, err
 
 func updateBottlerocketHostContainerMetadata(client *gogithub.Client, projectRootFilepath, projectPath, latestBottlerocketVersion string) ([]string, error) {
 	updatedHostContainerFiles := []string{}
-	hostContainersTOMLContents, err := github.GetFileContents(client, "bottlerocket-os", "bottlerocket", constants.BottlerocketHostContainersTOMLFile, latestBottlerocketVersion)
+	hostContainersTOMLContents, err := github.GetFileContents(client, constants.BottlerocketOrgName, constants.BottlerocketRepoName, constants.BottlerocketHostContainersTOMLFile, latestBottlerocketVersion)
 	if err != nil {
 		return nil, fmt.Errorf("getting contents of Bottlerocket host containers file: %v", err)
 	}
@@ -993,6 +1080,10 @@ func updateBottlerocketHostContainerMetadata(client *gogithub.Client, projectRoo
 
 func isEKSDistroUpgrade(projectName string) bool {
 	return projectName == "aws/eks-distro"
+}
+
+func isEKSDistroBuildToolingUpgrade(projectName string) bool {
+	return projectName == "aws/eks-distro-build-tooling"
 }
 
 func getDefaultReleaseBranch(buildToolingRepoPath string) (string, error) {

--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -16,11 +16,19 @@ const (
 	DefaultCommitAuthorName                 = "EKS Distro PR Bot"
 	DefaultCommitAuthorEmail                = "aws-model-rocket-bots+eksdistroprbot@amazon.com"
 	BuildToolingRepoName                    = "eks-anywhere-build-tooling"
-	DefaultBaseRepoOwner                    = "aws"
+	EKSDistroBuildToolingRepoName           = "eks-distro-build-tooling"
+	AWSOrgName                              = "aws"
+	BottlerocketOrgName                     = "bottlerocket-os"
+	BottlerocketRepoName                    = "bottlerocket"
 	BuildToolingRepoURL                     = "https://github.com/%s/eks-anywhere-build-tooling"
 	ReadmeFile                              = "README.md"
 	ReadmeUpdateScriptFile                  = "build/lib/readme_check.sh"
 	LicenseBoilerplateFile                  = "hack/boilerplate.yq.txt"
+	BottlerocketTargetsJSONURLFormat        = "https://updates.bottlerocket.aws/2020-07-07/%s-k8s-%s/x86_64/%s.targets.json"
+	BottlerocketTimestampJSONURLFormat      = "https://updates.bottlerocket.aws/2020-07-07/%s-k8s-%s/x86_64/timestamp.json"
+	BottlerocketAMIImageTargetFormat        = "bottlerocket-%s-k8s-%s-x86_64-%s.img.lz4"
+	BottlerocketOVAImageTargetFormat        = "bottlerocket-%s-k8s-%s-x86_64-%s.ova"
+	BottlerocketRawImageTargetFormat        = "bottlerocket-%s-k8s-%s-x86_64-%s.img.lz4"
 	EKSDistroLatestReleasesFile             = "EKSD_LATEST_RELEASES"
 	EKSDistroReleaseChannelsFileURLFormat   = "https://distro.eks.amazonaws.com/releasechannels/%s.yaml"
 	EKSDistroReleaseManifestURLFormat       = "https://distro.eks.amazonaws.com/kubernetes-%[1]s/kubernetes-%[1]s-eks-%d.yaml"
@@ -31,6 +39,8 @@ const (
 	GoVersionFile                           = "GOLANG_VERSION"
 	ChecksumsFile                           = "CHECKSUMS"
 	AttributionsFilePattern                 = "*ATTRIBUTION.txt"
+	EKSDistroBaseTagFilesPattern            = "EKS_DISTRO*TAG_FILE"
+	EKSDistroBaseUpdatedPackagesFileFormat  = "eks-distro-base-updates/%s/update_packages-%s"
 	BuildDirectory                          = "build"
 	ManifestsDirectory                      = "manifests"
 	PatchesDirectory                        = "patches"
@@ -40,17 +50,29 @@ const (
 	FailedPatchApplyRegex                   = "Patch failed at .*"
 	FailedPatchFilesRegex                   = "error: (.*): patch does not apply"
 	DoesNotExistInIndexFilesRegex           = "error: (.*): does not exist in index"
+	GitDescribeRegex                        = `v?\d+\.\d+\.\d+(-([0-9]+)-g.*)?`
 	BottlerocketReleasesFile                = "BOTTLEROCKET_RELEASES"
 	BottlerocketContainerMetadataFileFormat = "BOTTLEROCKET_%s_CONTAINER_METADATA"
 	BottlerocketHostContainersTOMLFile      = "sources/shared-defaults/public-host-containers.toml"
 	CertManagerManifestYAMLFile             = "cert-manager.yaml"
 	CiliumImageRepository                   = "public.ecr.aws/isovalent/cilium"
+	EKSDistroBaseTagsYAMLFile               = "EKS_DISTRO_TAG_FILE.yaml"
+	AL2023Suffix                            = "-al2023"
+	TagFileSuffix                           = "_TAG_FILE"
 	KindNodeImageBuildArgsScriptFile        = "node-image-build-args.sh"
 	GithubPerPage                           = 100
 	datetimeFormat                          = "%Y-%m-%dT%H:%M:%SZ"
 	MainBranchName                          = "main"
 	BaseRepoHeadRevisionPattern             = "refs/remotes/origin/%s"
 	EKSDistroUpgradePullRequestBody         = `This PR bumps EKS Distro releases to the latest available release versions.
+
+/hold
+/area dependencies
+
+By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.`
+	EKSDistroBuildToolingUpgradePullRequestBody = `This PR updates the base image tag in tag file(s) with the tag of the newly-built EKS Distro base image and/or its minimal variants.
+
+%s
 
 /hold
 /area dependencies


### PR DESCRIPTION
The EKS Distro base tag file updates were handled by a separate automation which was managed by scripts in the eks-distro-build-tooling repository, but by bringing it under the umbrella of the version tracker owned by us, we can control and fine-tune the automation as we see fit. Also we can now automate the bumps in all 3 branches whereas the previous automation just opened an update PR on main (for example, #4170) and we were required to manually backport to the release branches which has led to misses over the years.

Example PR with this change: https://github.com/abhay-krishna/eks-anywhere-build-tooling/pull/59

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
