### PR TITLE
Trim trailing newlines in file before string comparison

### DIFF
--- a/tools/version-tracker/pkg/commands/upgrade/upgrade.go
+++ b/tools/version-tracker/pkg/commands/upgrade/upgrade.go
@@ -584,7 +584,7 @@ func updateEKSDistroBaseImageTagFiles(client *gogithub.Client, buildToolingRepoP
 	}
 
 	for _, tagFile := range tagFileGlob {
-		tagFileContents, err := os.ReadFile(tagFile)
+		tagFileContents, err := file.ReadContentsTrimmed(tagFile)
 		if err != nil {
 			return "", false, fmt.Errorf("reading tag file: %v", err)
 		}

--- a/tools/version-tracker/pkg/util/file/file.go
+++ b/tools/version-tracker/pkg/util/file/file.go
@@ -4,7 +4,16 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 )
+
+func ReadContentsTrimmed(filePath string) (string, error) {
+	contents, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(contents)), nil
+}
 
 // Download downloads a file from the given URL to the destination filepath.
 func Download(url, filepath string) error {


### PR DESCRIPTION
Trim trailing newlines in file before string comparison to avoid false positive diffs, for example, `v1.2.3\n` vs `v1.2.3`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
