### PR TITLE
Avoid force-pushes for projects with architecture-specific builds

### DIFF
--- a/tools/version-tracker/pkg/commands/upgrade/upgrade.go
+++ b/tools/version-tracker/pkg/commands/upgrade/upgrade.go
@@ -470,9 +470,10 @@ func Run(upgradeOptions *types.UpgradeOptions) error {
 			return fmt.Errorf("committing updated project version files for [%s] project: %v", projectName, err)
 		}
 
+		force := !slices.Contains(constants.ProjectsWithSeparateArchitectures, projectName)
 		if !upgradeOptions.DryRun {
 			// Push the changes to the target branch in the head repository.
-			err = git.Push(repo, headRepoOwner, headBranchName, githubToken)
+			err = git.Push(repo, headRepoOwner, headBranchName, githubToken, force)
 			if err != nil {
 				return fmt.Errorf("pushing updated project version files for [%s] project: %v", projectName, err)
 			}

--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -449,4 +449,9 @@ var (
 		"opencontainers/runc":                               "v1.1",
 		"prometheus/prometheus":                             "v2",
 	}
+
+	ProjectsWithSeparateArchitectures = []string{
+		"containerd/containerd",
+		"tinkerbell/tink",
+	}
 )

--- a/tools/version-tracker/pkg/git/git.go
+++ b/tools/version-tracker/pkg/git/git.go
@@ -131,7 +131,7 @@ func Commit(worktree *git.Worktree, commitMessage string) error {
 }
 
 // Push pushes changes to the given remote branch on GitHub.
-func Push(repo *git.Repository, headRepoOwner, branch, githubToken string) error {
+func Push(repo *git.Repository, headRepoOwner, branch, githubToken string, force bool) error {
 	logger.V(6).Info(fmt.Sprintf("Pushing changes to remote [%s]", headRepoOwner))
 	progress := io.Discard
 	if logger.Verbosity >= 6 {
@@ -145,7 +145,7 @@ func Push(repo *git.Repository, headRepoOwner, branch, githubToken string) error
 			Password: githubToken,
 		},
 		Progress: progress,
-		Force:    true,
+		Force:    force,
 	})
 	if err != nil {
 		if err == git.NoErrAlreadyUpToDate {


### PR DESCRIPTION
Avoid force-pushes for projects with architecture-specific builds, to avoid overwriting checksums.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
