### PR TITLE
Add BR release version for 1.32

### DIFF
--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
@@ -15,3 +15,6 @@
 1-31:
   ami-release-version: v1.30.0
   ova-release-version: v1.30.0
+1-32:
+  ami-release-version: v1.30.0
+  ova-release-version: 1.31.0


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/2764
*Description of changes:*
Add BR release v1.31.0 version for 1.32

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
