### PR TITLE
Update hook kernel with missing modules

### DIFF
--- a/projects/tinkerbell/hook/CHECKSUMS
+++ b/projects/tinkerbell/hook/CHECKSUMS
@@ -1,4 +1,4 @@
-c4e647d5a5c0d0b80537eaa761bc134b6a82514a0f692e97fe5f83822251d5a0  _output/bin/hook/linux-amd64/hook-bootkit
-aadf1483cf3973e18b810101f79346b3ce8375ed6c39c4cdac3b842313a921af  _output/bin/hook/linux-amd64/hook-docker
-dd5b057987ffa8fa31f26cd8a83f1f0fa0de3ab7bec999a82c8ad89026aa0226  _output/bin/hook/linux-arm64/hook-bootkit
-654ed06bcbbc4cba88361475cc0747ff3f285d40bb2d30dea345f731dcee465c  _output/bin/hook/linux-arm64/hook-docker
+c459fb0c306a599b5058a042a312113e3f6173e6022ae7753590c11a03551f0b  _output/bin/hook/linux-amd64/hook-bootkit
+a7059841b7ff1391e5c5f8e96bd45f68293ecf1eb3108e0027113625d6cefe46  _output/bin/hook/linux-amd64/hook-docker
+588649966b24e5590bea71f70d121a18978403a4ab6cacb1c91ea162ba9c5b03  _output/bin/hook/linux-arm64/hook-bootkit
+bf0dfc6a2fc3d6bf3cf0a2f878f50f6e5f743a28fc3be7925eb8dbf945189487  _output/bin/hook/linux-arm64/hook-docker

--- a/projects/tinkerbell/hook/patches/0002-builds-kernel-from-al2.patch
+++ b/projects/tinkerbell/hook/patches/0002-builds-kernel-from-al2.patch
@@ -1,14 +1,14 @@
-From bcbc69bfef4d8434fb3c08b55ec13b0db01cacbf Mon Sep 17 00:00:00 2001
+From 1ab3249a30d653aae005208a55d5a66d09f8c79c Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Mon, 15 Jul 2024 20:41:42 +0000
-Subject: [PATCH 2/4] builds kernel from al2
+Subject: [PATCH] builds kernel from al2
 
 ---
- kernel/Dockerfile | 34 +++++++++++++++++++++++++++-------
- 1 file changed, 27 insertions(+), 7 deletions(-)
+ kernel/Dockerfile | 35 ++++++++++++++++++++++++++++-------
+ 1 file changed, 28 insertions(+), 7 deletions(-)
 
 diff --git a/kernel/Dockerfile b/kernel/Dockerfile
-index 34903b6..d5146a6 100644
+index 34903b6..a776295 100644
 --- a/kernel/Dockerfile
 +++ b/kernel/Dockerfile
 @@ -1,11 +1,27 @@
@@ -40,7 +40,7 @@ index 34903b6..d5146a6 100644
 +
 +RUN set -x && yum -y update && \
 +        yum -y groupinstall "Development Tools" && \
-+        yum -y install --allowerasing bc ncurses-devel openssl-devel gnupg2-full && \
++        yum -y install --allowerasing bc ncurses-devel openssl-devel gnupg2-full kmod flex bison xz && \
 +        yum clean all && \
 +        rm -rf /var/cache/yum
  
@@ -57,6 +57,14 @@ index 34903b6..d5146a6 100644
  # Kernel config; copy the correct defconfig as .config, and run olddefconfig
  RUN set -x && make "ARCH=${KERNEL_ARCH}" olddefconfig
  
+@@ -65,6 +85,7 @@ ARG KERNEL_OUTPUT_IMAGE
+ RUN mkdir /out
+ 
+ RUN sed -i 's/#define COMMAND_LINE_SIZE 2048/#define COMMAND_LINE_SIZE 4096/' arch/x86/include/asm/setup.h
++RUN sed -i 's/#define COMMAND_LINE_SIZE 2048/#define COMMAND_LINE_SIZE 4096/' arch/arm64/include/uapi/asm/setup.h
+ 
+ # Kernel build. ENVs in previous stages are inherited; thus ARCH, CROSS_COMPILE, KCFLAGS, KBUILD_BUILD_USER, KBUILD_BUILD_HOST are available
+ RUN set -x && \
 -- 
-2.34.1
+2.40.1
 


### PR DESCRIPTION
*Description of changes:*
The recent Hook builds in CI have been creating HookOS kernels that are booting without loading drivers from `modules.dep.bin` properly. The `modules.dep.bin` do not show up on running systems at all. This causes most hardware to fail to load important things like Network Interface Card drivers. 

Troubleshooting pointed us to a potential issue with Yum repo package changes that have caused the HookOS kernel builds to be missing the linkage between the kernel and the `modules.dep.bin`. We don't know definitively what has changed to the packages or why this happened. What we do know through troubleshooting and testing is that adding a few packages resolves the issues. Comparing the logs between previous working kernels and the newer kernels, there is at least one warning related to all this.
```
#20 0.849 Warning: 'make modules_install' requires depmod. Please install it.
#20 0.849 This is probably in the kmod package.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
