### PR TITLE
Improve display command for version tracker

### DIFF
--- a/tools/version-tracker/cmd/display.go
+++ b/tools/version-tracker/cmd/display.go
@@ -27,5 +27,4 @@ var displayCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(displayCmd)
 	displayCmd.Flags().StringVar(&displayOptions.ProjectName, "project", "", "Specify the project name to track versions for")
-	displayCmd.Flags().BoolVar(&displayOptions.PrintLatestVersion, "print-latest-version", false, "Flag to print only the latest version of the project")
 }

--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -46,7 +46,7 @@ const (
 	PatchesDirectory                        = "patches"
 	FailedPatchApplyMarker                  = "patch does not apply"
 	DoesNotExistInIndexMarker               = "does not exist in index"
-	SemverRegex                             = `v?(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?`
+	SemverRegex                             = `v?(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)(\.(?P<patch>0|[1-9]\d*))?(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?`
 	FailedPatchApplyRegex                   = "Patch failed at .*"
 	FailedPatchFilesRegex                   = "error: (.*): patch does not apply"
 	DoesNotExistInIndexFilesRegex           = "error: (.*): does not exist in index"

--- a/tools/version-tracker/pkg/github/github.go
+++ b/tools/version-tracker/pkg/github/github.go
@@ -136,12 +136,12 @@ func GetLatestRevision(client *github.Client, org, repo, currentRevision, branch
 		needsUpgrade = true
 	} else {
 		semverRegex := regexp.MustCompile(constants.SemverRegex)
-		currentRevisionForSemver := semverRegex.FindString(currentRevision)
+		currentRevisionForSemver := version.EnsurePatchVersion(semverRegex.FindString(currentRevision))
 
 		// Get SemVer construct corresponding to the current revision tag.
 		currentRevisionSemver, err := semver.New(currentRevisionForSemver)
 		if err != nil {
-			return "", false, fmt.Errorf("getting semver for current version: %v", err)
+			return "", false, fmt.Errorf("getting semver for current version %s: %v", currentRevisionForSemver, err)
 		}
 
 		for _, tag := range allTags {
@@ -154,7 +154,7 @@ func GetLatestRevision(client *github.Client, org, repo, currentRevision, branch
 					continue
 				}
 			}
-			tagNameForSemver := semverRegex.FindString(tagName)
+			tagNameForSemver := version.EnsurePatchVersion(semverRegex.FindString(tagName))
 			if tagNameForSemver == "" {
 				continue
 			}
@@ -232,7 +232,7 @@ func isUpgradeRequired(client *github.Client, org, repo, latestRevision string, 
 	}
 
 	semverRegex := regexp.MustCompile(constants.SemverRegex)
-	latestRevisionForSemver := semverRegex.FindString(latestRevision)
+	latestRevisionForSemver := version.EnsurePatchVersion(semverRegex.FindString(latestRevision))
 
 	// Get SemVer construct corresponding to the latest revision tag.
 	latestRevisionSemver, err := semver.New(latestRevisionForSemver)

--- a/tools/version-tracker/pkg/types/types.go
+++ b/tools/version-tracker/pkg/types/types.go
@@ -2,8 +2,7 @@ package types
 
 // DisplayOptions represents the options that can be passed to the `display` command.
 type DisplayOptions struct {
-	ProjectName        string
-	PrintLatestVersion bool
+	ProjectName string
 }
 
 // UpgradeOptions represents the options that can be passed to the `upgrade` command.
@@ -42,6 +41,7 @@ type ProjectVersionInfo struct {
 	Repo           string
 	CurrentVersion string
 	LatestVersion  string
+	UpToDate       string
 }
 
 // ReleaseTarball represents the GitHub release asset name, binary name and related settings to get the

--- a/tools/version-tracker/pkg/util/version/version.go
+++ b/tools/version-tracker/pkg/util/version/version.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os/exec"
 	"regexp"
+	"strings"
 
 	"github.com/aws/eks-anywhere-build-tooling/tools/version-tracker/pkg/util/command"
 )
@@ -21,4 +22,30 @@ func GetGoVersion(goBinaryLocation string) (string, error) {
 	matches := pattern.FindStringSubmatch(commandOutput)
 
 	return matches[1], nil
+}
+
+func EnsurePatchVersion(version string) string {
+	// Remove 'v' prefix if present
+	version = strings.TrimPrefix(version, "v")
+
+	// Regular expression to match version components
+	re := regexp.MustCompile(`^(\d+\.\d+)(?:\.(\d+))?(.*)$`)
+	matches := re.FindStringSubmatch(version)
+
+	if len(matches) < 2 {
+		// If the version string doesn't match the expected format, return it unchanged
+		return version
+	}
+
+	majorMinor := matches[1]
+	patch := matches[2]
+	metadata := matches[3]
+
+	if patch == "" {
+		// If patch version is missing, add ".0"
+		return fmt.Sprintf("%s.0%s", majorMinor, metadata)
+	}
+
+	// If patch version is present, return the original version
+	return version
 }


### PR DESCRIPTION
Improve display command for version tracker:
1. Versions table shows project versions for all currently-supported EKS-D release branches
2. Versions table includes up-to-date column to denote if project's current version matches latest upstream version
3. Github version retrieval supports projects which don't have a patch version in their semver
4. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
