### PR TITLE
Support envoyproxy/envoy, isc-projects/dhcp projects in display command

### DIFF
--- a/tools/version-tracker/go.mod
+++ b/tools/version-tracker/go.mod
@@ -3,7 +3,6 @@ module github.com/aws/eks-anywhere-build-tooling/tools/version-tracker
 go 1.22
 
 require (
-	github.com/aws/eks-anywhere v0.18.3
 	github.com/aws/eks-distro-build-tooling/release v0.0.0-20240513204929-c69ded04ed10
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-git/go-git/v5 v5.11.0
@@ -68,6 +67,7 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	k8s.io/api v0.26.2 // indirect
 	k8s.io/apimachinery v0.26.2 // indirect
 	k8s.io/klog/v2 v2.90.1 // indirect
 	k8s.io/utils v0.0.0-20230220204549-a5ecb0141aa5 // indirect

--- a/tools/version-tracker/go.sum
+++ b/tools/version-tracker/go.sum
@@ -49,8 +49,6 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/aws/eks-anywhere v0.18.3 h1:qMSO0Jddh+sMae1fyPkaW/HdwayQ3qY9JYnF6cvKHts=
-github.com/aws/eks-anywhere v0.18.3/go.mod h1:/UJSNvCylwvRGQQqKs3pTkw93qfV43Diq9TmuuiVAM4=
 github.com/aws/eks-distro-build-tooling/release v0.0.0-20240513204929-c69ded04ed10 h1:tHMJTH65peauXPtaF/NRhgxhQU8gIOcbEpmLlv3l5EI=
 github.com/aws/eks-distro-build-tooling/release v0.0.0-20240513204929-c69ded04ed10/go.mod h1:NzE2uGUGDDkCIcZh+xxbq1SBHsEu1AR9QT3lpKPZXRc=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=

--- a/tools/version-tracker/pkg/commands/display/display.go
+++ b/tools/version-tracker/pkg/commands/display/display.go
@@ -102,9 +102,7 @@ func Run(displayOptions *types.DisplayOptions) error {
 			if displayOptions.ProjectName != "" && displayOptions.ProjectName != fullRepoName {
 				continue
 			}
-			if fullRepoName == "envoyproxy/envoy" || fullRepoName == "isc-projects/dhcp" {
-				continue
-			}
+
 			releaseBranched := false
 			var currentVersion types.Version
 			if len(repo.Versions) > 1 {
@@ -135,8 +133,8 @@ func Run(displayOptions *types.DisplayOptions) error {
 				currentVersionList = append(currentVersionList, currentRevision)
 
 				var latestRevision string
-				if fullRepoName == "cilium/cilium" {
-					latestRevision, _, err = ecrpublic.GetLatestRevision(constants.CiliumImageRepository, currentRevision, branchName)
+				if fullRepoName == "cilium/cilium" || fullRepoName == "envoyproxy/envoy" {
+					latestRevision, _, err = ecrpublic.GetLatestRevision(constants.ECRImageRepositories[fullRepoName], currentRevision, branchName)
 					if err != nil {
 						return fmt.Errorf("getting latest revision from ECR Public: %v", err)
 					}

--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -46,7 +46,7 @@ const (
 	PatchesDirectory                        = "patches"
 	FailedPatchApplyMarker                  = "patch does not apply"
 	DoesNotExistInIndexMarker               = "does not exist in index"
-	SemverRegex                             = `v?(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)(\.(?P<patch>0|[1-9]\d*))?(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?`
+	SemverRegex                             = `v?(?P<major>0|[1-9]\d*)(\.|_)(?P<minor>0|[1-9]\d*)((\.|_)(?P<patch>0|[1-9]\d*))?(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?`
 	FailedPatchApplyRegex                   = "Patch failed at .*"
 	FailedPatchFilesRegex                   = "error: (.*): patch does not apply"
 	DoesNotExistInIndexFilesRegex           = "error: (.*): does not exist in index"
@@ -56,6 +56,7 @@ const (
 	BottlerocketHostContainersTOMLFile      = "sources/shared-defaults/public-host-containers.toml"
 	CertManagerManifestYAMLFile             = "cert-manager.yaml"
 	CiliumImageRepository                   = "public.ecr.aws/isovalent/cilium"
+	EnvoyImageRepository                    = "public.ecr.aws/appmesh/aws-appmesh-envoy"
 	EKSDistroBaseTagsYAMLFile               = "EKS_DISTRO_TAG_FILE.yaml"
 	AL2023Suffix                            = "-al2023"
 	TagFileSuffix                           = "_TAG_FILE"
@@ -447,5 +448,10 @@ var (
 		"containerd/containerd": "v1",
 		"opencontainers/runc":   "v1.1",
 		"prometheus/prometheus": "v2",
+	}
+
+	ECRImageRepositories = map[string]string{
+		"cilium/cilium":    CiliumImageRepository,
+		"envoyproxy/envoy": EnvoyImageRepository,
 	}
 )

--- a/tools/version-tracker/pkg/ecrpublic/ecrpublic.go
+++ b/tools/version-tracker/pkg/ecrpublic/ecrpublic.go
@@ -7,10 +7,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/aws/eks-anywhere/pkg/semver"
-
 	"github.com/aws/eks-anywhere-build-tooling/tools/version-tracker/pkg/constants"
 	"github.com/aws/eks-anywhere-build-tooling/tools/version-tracker/pkg/util/command"
+	"github.com/aws/eks-anywhere-build-tooling/tools/version-tracker/pkg/util/semver"
 )
 
 func GetLatestRevision(imageRepository, currentRevision, branchName string) (string, bool, error) {
@@ -35,6 +34,7 @@ func GetLatestRevision(imageRepository, currentRevision, branchName string) (str
 	ciliumTags := tagsList.(map[string]interface{})["Tags"].([]interface{})
 
 	latestRevisionSemver := currentRevisionSemver
+	latestRevision = currentRevision
 	for _, tag := range ciliumTags {
 		tag := tag.(string)
 		if !strings.HasPrefix(tag, "v") {

--- a/tools/version-tracker/pkg/github/github.go
+++ b/tools/version-tracker/pkg/github/github.go
@@ -13,12 +13,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aws/eks-anywhere/pkg/semver"
 	"github.com/google/go-github/v53/github"
 
 	"github.com/aws/eks-anywhere-build-tooling/tools/version-tracker/pkg/constants"
 	"github.com/aws/eks-anywhere-build-tooling/tools/version-tracker/pkg/util/file"
 	"github.com/aws/eks-anywhere-build-tooling/tools/version-tracker/pkg/util/logger"
+	"github.com/aws/eks-anywhere-build-tooling/tools/version-tracker/pkg/util/semver"
 	"github.com/aws/eks-anywhere-build-tooling/tools/version-tracker/pkg/util/tar"
 	"github.com/aws/eks-anywhere-build-tooling/tools/version-tracker/pkg/util/version"
 )

--- a/tools/version-tracker/pkg/util/semver/semver.go
+++ b/tools/version-tracker/pkg/util/semver/semver.go
@@ -1,0 +1,94 @@
+package semver
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/aws/eks-anywhere-build-tooling/tools/version-tracker/pkg/constants"
+)
+
+type Version struct {
+	Major, Minor, Patch       int64
+	Prerelease, Buildmetadata string
+}
+
+func New(version string) (*Version, error) {
+	semverRegexp := regexp.MustCompile(constants.SemverRegex)
+	matches := semverRegexp.FindStringSubmatch(version)
+	namedGroups := make(map[string]string, len(matches))
+	groupNames := semverRegexp.SubexpNames()
+	for i, value := range matches {
+		name := groupNames[i]
+		if name != "" {
+			namedGroups[name] = value
+		}
+	}
+
+	v := &Version{}
+	var err error
+
+	v.Major, err = strconv.ParseInt(namedGroups["major"], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid major version in semver %s: %v", version, err)
+	}
+	v.Minor, err = strconv.ParseInt(namedGroups["minor"], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid minor version in semver %s: %v", version, err)
+	}
+	v.Patch, err = strconv.ParseInt(namedGroups["patch"], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid patch version in semver %s: %v", version, err)
+	}
+
+	v.Prerelease = namedGroups["prerelease"]
+	v.Buildmetadata = namedGroups["buildmetadata"]
+
+	return v, nil
+}
+
+func (v *Version) SameMajor(v2 *Version) bool {
+	return v.Major == v2.Major
+}
+
+func (v *Version) SameMinor(v2 *Version) bool {
+	return v.SameMajor(v2) && v.Minor == v2.Minor
+}
+
+func (v *Version) SamePatch(v2 *Version) bool {
+	return v.SameMinor(v2) && v.Patch == v2.Patch
+}
+
+func (v *Version) SamePrerelease(v2 *Version) bool {
+	return v.SamePatch(v2) && v.Prerelease == v2.Prerelease
+}
+
+func (v *Version) Equal(v2 *Version) bool {
+	return v.SamePrerelease(v2) && v.Buildmetadata == v2.Buildmetadata
+}
+
+func (v *Version) GreaterThan(v2 *Version) bool {
+	return v.Compare(v2) == 1
+}
+
+func (v *Version) Compare(v2 *Version) int {
+	if c := compare(v.Major, v2.Major); c != 0 {
+		return c
+	}
+	if c := compare(v.Minor, v2.Minor); c != 0 {
+		return c
+	}
+	if c := compare(v.Patch, v2.Patch); c != 0 {
+		return c
+	}
+	return 0
+}
+
+func compare(i, i2 int64) int {
+	if i > i2 {
+		return 1
+	} else if i < i2 {
+		return -1
+	}
+	return 0
+}


### PR DESCRIPTION
Support tagging schemes of `envoyproxy/envoy` and `isc-projects/dhcp` projects in display command. Earlier these were being skipped. Now they all show up in the display command output.
#### Before

```console
➜ bin/version-tracker display --project envoyproxy/envoy 
2025/02/20 11:31:38 Error displaying version information: getting latest revision from GitHub for project envoyproxy/envoy: getting epoch time corresponding to current revision commit: getting date for commit  in [envoyproxy/envoy] repository: GET https://api.github.com/repos/envoyproxy/envoy/commits/: 422 No commit found for SHA:  []

➜ bin/version-tracker display --project isc-projects/dhcp
2025/02/20 11:31:33 Error displaying version information: getting latest revision from GitHub for project isc-projects/dhcp: getting semver for current version : invalid major version in semver : strconv.ParseInt: parsing "": invalid syntax
```

#### After

```console
➜ bin/version-tracker display --project envoyproxy/envoy
ORGANIZATION  REPOSITORY  CURRENT VERSION  LATEST VERSION   UP-TO-DATE  
envoyproxy    envoy       v1.22.2.0-prod   v1.29.12.0-prod  false

➜ bin/version-tracker display --project isc-projects/dhcp
ORGANIZATION  REPOSITORY  CURRENT VERSION  LATEST VERSION  UP-TO-DATE  
isc-projects  dhcp        v4_4_3           v4_4_3          true
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
