### PR TITLE
Use LINUX_CONTAINER as build platform for fluxcd/source-controller

### DIFF
--- a/projects/fluxcd/source-controller/Makefile
+++ b/projects/fluxcd/source-controller/Makefile
@@ -5,6 +5,7 @@ REPO=source-controller
 REPO_OWNER=fluxcd
 
 BINARY_TARGET_FILES=source-controller
+BUILDSPEC_PLATFORM=LINUX_CONTAINER
 
 FIX_LICENSES_XEIPUUV_TARGET=$(REPO)/vendor/github.com/xeipuuv/gojsonpointer/LICENSE.txt
 FIX_LICENSES_ALIBABACLOUD_TARGET=$(REPO)/vendor/github.com/alibabacloud-go/cr-20160607/LICENSE

--- a/release/checksums-build.yml
+++ b/release/checksums-build.yml
@@ -171,7 +171,7 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/fluxcd.notification-controller
     - identifier: fluxcd_source_controller
       env:
-        type: ARM_CONTAINER
+        type: LINUX_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           PROJECT_PATH: projects/fluxcd/source-controller

--- a/release/staging-build.yml
+++ b/release/staging-build.yml
@@ -228,7 +228,7 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/fluxcd.notification-controller
     - identifier: fluxcd_source_controller
       env:
-        type: ARM_CONTAINER
+        type: LINUX_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           PROJECT_PATH: projects/fluxcd/source-controller

--- a/tools/version-tracker/buildspecs/upgrade.yml
+++ b/tools/version-tracker/buildspecs/upgrade.yml
@@ -148,7 +148,7 @@ batch:
           CLONE_URL: https://git-codecommit.us-west-2.amazonaws.com/v1/repos/fluxcd.notification-controller
     - identifier: fluxcd_source_controller
       env:
-        type: ARM_CONTAINER
+        type: LINUX_CONTAINER
         compute-type: BUILD_GENERAL1_SMALL
         variables:
           PROJECT_PATH: projects/fluxcd/source-controller


### PR DESCRIPTION
*Issue #, if available:*
The ARM checksum for fluxcd/source-controller in our codeBuild does not match what we have in eks-a-build-tooling projects, because CodeBuild uses ARM container to calculate the checksum.

*Description of changes:*
Use LINUX_CONTAINER as build environment type for fluxcd/source-controller

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
