### PR TITLE
Add patch to fix RHEL 9 OVA builds

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0001-OVA-improvements.patch
@@ -1,7 +1,7 @@
 From 77033626dbc24f940add15328d2fd8e696221ff1 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 21:05:13 -0800
-Subject: [PATCH 01/12] OVA improvements
+Subject: [PATCH 01/13] OVA improvements
 
 - Create /etc/pki/tls/certs dir as part of image-builds
 - Tweak Product info in OVF
@@ -74,5 +74,5 @@ index 96f389d61..34e1f80b8 100644
      "existing_ansible_ssh_args": "{{env `ANSIBLE_SSH_ARGS`}}",
      "export_manifest": "none",
 -- 
-2.44.0
+2.48.1
 

--- a/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
@@ -1,7 +1,7 @@
 From 4de69d11f6a2d1028714663637ea417308be3e76 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 11 Jan 2022 18:36:56 -0800
-Subject: [PATCH 02/12] EKS-D support and changes
+Subject: [PATCH 02/13] EKS-D support and changes
 
 - Add goss validations for EKS-D artifacts
 - Add etcdadm and etcd.tar.gz to image for unstacked etcd support
@@ -316,5 +316,5 @@ index 082169753..f65d1f961 100644
        "version": "{{user `goss_version`}}"
      }
 -- 
-2.44.0
+2.48.1
 

--- a/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0003-Snow-AMI-support.patch
@@ -1,7 +1,7 @@
 From a7c96599ff163027cd0f7dede1a2f1dc5a069928 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 2 Feb 2023 01:39:15 -0800
-Subject: [PATCH 03/12] Snow AMI support
+Subject: [PATCH 03/13] Snow AMI support
 
 ---
  images/capi/packer/ami/packer.json | 12 ++++++++++--
@@ -50,5 +50,5 @@ index 0bfbf32cd..33fcfd43a 100644
 +}
 \ No newline at end of file
 -- 
-2.44.0
+2.48.1
 

--- a/projects/kubernetes-sigs/image-builder/patches/0004-RHEL-support-and-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0004-RHEL-support-and-improvements.patch
@@ -1,7 +1,7 @@
 From c22798591e204fb309df56bcf7d29453e3f483b8 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 6 Dec 2022 15:42:02 -0600
-Subject: [PATCH 04/12] RHEL support and improvements
+Subject: [PATCH 04/13] RHEL support and improvements
 
 - Fix redhat 9 cloud-init feature flags bug
 - Fix ensure iptables present for rhel
@@ -183,5 +183,5 @@ index 05ab075f7..6d62872ea 100644
    "ansible_scp_extra_args": "{{env `ANSIBLE_SCP_EXTRA_ARGS`}}"
  }
 -- 
-2.44.0
+2.48.1
 

--- a/projects/kubernetes-sigs/image-builder/patches/0005-Nutanix-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0005-Nutanix-improvements.patch
@@ -1,7 +1,7 @@
 From c234a55f2609fc840a2e23ff82c6284f1f2949da Mon Sep 17 00:00:00 2001
 From: Ilya Alekseyev <ilya.alekseyev@nutanix.com>
 Date: Wed, 11 Oct 2023 22:07:22 -0400
-Subject: [PATCH 05/12] Nutanix improvements
+Subject: [PATCH 05/13] Nutanix improvements
 
 - Fetch Nutanix RHEL source image URL from environment
 - Force-delete Nutanix builder VMs on failure
@@ -61,5 +61,5 @@ index b7dddb4f2..921a9729f 100644
    "shutdown_command": "shutdown -P now",
    "user_data": "I2Nsb3VkLWNvbmZpZwp1c2VyczoKICAtIG5hbWU6IGJ1aWxkZXIKICAgIHN1ZG86IFsnQUxMPShBTEwpIE5PUEFTU1dEOkFMTCddCmNocGFzc3dkOgogIGxpc3Q6IHwKICAgIGJ1aWxkZXI6YnVpbGRlcgogIGV4cGlyZTogRmFsc2UKc3NoX3B3YXV0aDogVHJ1ZQ=="
 -- 
-2.44.0
+2.48.1
 

--- a/projects/kubernetes-sigs/image-builder/patches/0006-adds-retries-and-timeout-to-packer-image-builder.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0006-adds-retries-and-timeout-to-packer-image-builder.patch
@@ -1,7 +1,7 @@
 From 84a0aca9df4854da625256b899968610f3611827 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Mon, 21 Aug 2023 18:40:07 -0500
-Subject: [PATCH 06/12] adds retries and timeout to packer image-builder
+Subject: [PATCH 06/13] adds retries and timeout to packer image-builder
 
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---
@@ -162,5 +162,5 @@ index f65d1f961..90ffc8b5b 100644
        "type": "qemu",
        "vm_name": "{{user `vm_name`}}"
 -- 
-2.44.0
+2.48.1
 

--- a/projects/kubernetes-sigs/image-builder/patches/0007-Networking-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0007-Networking-improvements.patch
@@ -1,7 +1,7 @@
 From 10296f1cab9ac0e29ad2a831b8cfb923d490b765 Mon Sep 17 00:00:00 2001
 From: Taylor Neyland <tneyla@amazon.com>
 Date: Wed, 19 Jul 2023 12:51:30 -0500
-Subject: [PATCH 07/12] Networking improvements
+Subject: [PATCH 07/13] Networking improvements
 
 - Disable UDP offload service for Redhat and Ubuntu
 - Default Flatcar version to avoid pulling from internet on every make
@@ -125,5 +125,5 @@ index 46e524ee0..4e3f800b1 100644
 +    state: stopped
 +  when: ansible_distribution_version is version('22.04', '>=')
 -- 
-2.44.0
+2.48.1
 

--- a/projects/kubernetes-sigs/image-builder/patches/0008-Support-and-improvements-for-RHEL-9-EFI.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0008-Support-and-improvements-for-RHEL-9-EFI.patch
@@ -1,7 +1,7 @@
 From 4ad2f38de0002c1b1c74c6105cad2b7d4ff5beaf Mon Sep 17 00:00:00 2001
 From: Shizhao Liu <lshizhao@amazon.com>
 Date: Mon, 19 Aug 2024 10:14:26 -0700
-Subject: [PATCH 08/12] Support and improvements for RHEL 9 EFI
+Subject: [PATCH 08/13] Support and improvements for RHEL 9 EFI
 
 1. Remove 2 unwanted partitions (the swap partition and /boot
 partition).
@@ -50,5 +50,5 @@ index 23cd4ed34..586c063a8 100644
 +parted -s /dev/sda set 2 esp on
 +%end
 -- 
-2.44.0
+2.48.1
 

--- a/projects/kubernetes-sigs/image-builder/patches/0009-Pin-Packer-Goss-plugin-version-to-3.1.4.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0009-Pin-Packer-Goss-plugin-version-to-3.1.4.patch
@@ -1,7 +1,7 @@
 From da62450d53a10648acab070ad6afddd175d35897 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 19 Sep 2024 15:36:00 -0700
-Subject: [PATCH 09/12] Pin Packer Goss plugin version to 3.1.4
+Subject: [PATCH 09/13] Pin Packer Goss plugin version to 3.1.4
 
 Upstream image-builder moved from installing packer-provisioner-goss through a script to installing it
 via Packer config (https://github.com/kubernetes-sigs/image-builder/commit/c0b70ae37c4aac14c156fc7b907a9b35147757df).
@@ -27,5 +27,5 @@ index 2c5e1f293..28e76f2a7 100644
      }
    }
 -- 
-2.44.0
+2.48.1
 

--- a/projects/kubernetes-sigs/image-builder/patches/0010-Remove-containerd-configuration-for-hosts.toml-paths.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0010-Remove-containerd-configuration-for-hosts.toml-paths.patch
@@ -1,7 +1,7 @@
 From 9997a10614797c9716a6f04ea508ddf5ca6dc846 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 19 Sep 2024 16:04:19 -0700
-Subject: [PATCH 10/12] Remove containerd configuration for hosts.toml paths
+Subject: [PATCH 10/13] Remove containerd configuration for hosts.toml paths
 
 In EKS Anywhere, we're still using the older containerd config template (v2), so setting the
 config_path in the containerd config file causes errors like "invalid plugin config: `mirrors`
@@ -44,5 +44,5 @@ index 0bae3b0d7..2066c4971 100644
    [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
      runtime_type = "io.containerd.runc.v2"
 -- 
-2.44.0
+2.48.1
 

--- a/projects/kubernetes-sigs/image-builder/patches/0011-Revert-updating-preseed-and-cloud-init-to-use-CD-for.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0011-Revert-updating-preseed-and-cloud-init-to-use-CD-for.patch
@@ -1,7 +1,7 @@
 From 4ec60a21c91eab7b28a2c34307d1d4889f104e27 Mon Sep 17 00:00:00 2001
 From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
 Date: Thu, 19 Sep 2024 18:52:00 -0700
-Subject: [PATCH 11/12] Revert updating preseed and cloud-init to use CD for
+Subject: [PATCH 11/13] Revert updating preseed and cloud-init to use CD for
  boot files
 
 We are reverting the upstream change that updated preseed and cloud-init scripts
@@ -173,5 +173,5 @@ index 683670a35..5794d876c 100755
  docker run --rm -d --name vpn -v "${HOME}/.openvpn/:${HOME}/.openvpn/" \
    -w "${HOME}/.openvpn/" --cap-add=NET_ADMIN --net=host --device=/dev/net/tun \
 -- 
-2.44.0
+2.48.1
 

--- a/projects/kubernetes-sigs/image-builder/patches/0012-Make-configurable-Nutanix-image-size.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0012-Make-configurable-Nutanix-image-size.patch
@@ -1,7 +1,7 @@
-From b808b549f221a514fe9c8849c0eb436d3c704b3a Mon Sep 17 00:00:00 2001
+From c3bd4efeb64c35c330056baceba8f2626c07b00b Mon Sep 17 00:00:00 2001
 From: Ilya Alekseyev <ilya.alekseyev@nutanix.com>
 Date: Tue, 11 Feb 2025 14:19:12 +0000
-Subject: [PATCH 12/12] Make configurable Nutanix image size
+Subject: [PATCH 12/13] Make configurable Nutanix image size
 
 ---
  images/capi/packer/nutanix/packer-windows.json | 2 +-
@@ -35,5 +35,5 @@ index 3d4e875b0..413dd97ac 100644
      "force_deregister": "true",
      "image_delete": "false",
 -- 
-2.44.0
+2.48.1
 

--- a/projects/kubernetes-sigs/image-builder/patches/0013-Update-Packer-VM-hardware-version-to-support-RHEL-9.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0013-Update-Packer-VM-hardware-version-to-support-RHEL-9.patch
@@ -1,0 +1,43 @@
+From c8c8e968877bdacf2ae5f1c3f30e4df7bc3d8d86 Mon Sep 17 00:00:00 2001
+From: Abhay Krishna Arunachalam <arnchlm@amazon.com>
+Date: Mon, 10 Mar 2025 23:56:00 -0700
+Subject: [PATCH 13/13] Update Packer VM hardware version to support RHEL 9
+
+The RHEL 9 Guest OS type was introduced in vSphere API release 7.0.1.0 (Source - https://dp-downloads.broadcom.com/api-content/apis/API_VWSA_001/8.0U3/html/ReferenceGuides/vim.vm.GuestOsDescriptor.GuestOsIdentifier.html),
+which is compatible with virtual machine hardware version 18 (Source - https://knowledge.broadcom.com/external/article/315655/virtual-machine-hardware-versions.html).
+But image-builder hardcodes the VM hardware version to 15, so we need to override it to 18 for RHEL 9 OVA.
+
+Also the OVA build Python script was missing RHEL 9 in the OS ID mapping, so added it there.
+
+Signed-off-by: Abhay Krishna Arunachalam <arnchlm@amazon.com>
+---
+ images/capi/hack/image-build-ova.py | 1 +
+ images/capi/packer/ova/rhel-9.json  | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/images/capi/hack/image-build-ova.py b/images/capi/hack/image-build-ova.py
+index a1b9eee72..d557bbd09 100755
+--- a/images/capi/hack/image-build-ova.py
++++ b/images/capi/hack/image-build-ova.py
+@@ -112,6 +112,7 @@ def main():
+                  "centos8-64": {"id": "107", "version": "8", "type": "centos8_64Guest"},
+                  "rhel7-64": {"id": "80", "version": "7", "type": "rhel7_64Guest"},
+                  "rhel8-64": {"id": "80", "version": "8", "type": "rhel8_64Guest"},
++                 "rhel9-64": {"id": "80", "version": "9", "type": "rhel9_64Guest"},
+                  "rockylinux-64": {"id": "80", "version": "", "type": "rockylinux_64Guest"},
+                  "ubuntu-64": {"id": "94", "version": "", "type": "ubuntu64Guest"},
+                  "flatcar-64": {"id": "100", "version": "", "type": "other4xLinux64Guest"},
+diff --git a/images/capi/packer/ova/rhel-9.json b/images/capi/packer/ova/rhel-9.json
+index a3f7becff..0b806d1a8 100644
+--- a/images/capi/packer/ova/rhel-9.json
++++ b/images/capi/packer/ova/rhel-9.json
+@@ -16,5 +16,6 @@
+   "os_display_name": "RHEL 9",
+   "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
+   "shutdown_command": "shutdown -P now",
++  "vmx_version": "18",
+   "vsphere_guest_os_type": "rhel9_64Guest"
+ }
+-- 
+2.48.1
+


### PR DESCRIPTION
Add patch to fix RHEL 9 OVA builds

Fixes the following error
```
==> Some builds didn't complete successfully and had errors:
--> vsphere-iso.vsphere: No host is compatible with the virtual machine.
```
/hold


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
