### PR TITLE
Fix kubelet file check inside image

### DIFF
--- a/projects/kubernetes-sigs/image-builder/build/validate_ova_kubelet.sh
+++ b/projects/kubernetes-sigs/image-builder/build/validate_ova_kubelet.sh
@@ -43,7 +43,7 @@ fi
 VMDK="$($TAR --wildcards -tf $OVA_PATH '*.vmdk')"
 build::common::echo_and_run $TAR -C $TMP_FOLDER -xf $OVA_PATH $VMDK
 
-if $ZIP l $TMP_FOLDER/$VMDK | grep -q "usr/bin/kubelet"; then
+if $ZIP l $TMP_FOLDER/$VMDK | grep "usr/bin/kubelet"; then
     build::common::echo_and_run $ZIP -y -o$TMP_FOLDER e $TMP_FOLDER/$VMDK usr/bin/kubelet > /dev/null
     ACTUAL_VERSION="$($TMP_FOLDER/kubelet --version)"
 else


### PR DESCRIPTION
Fix kubelet file check inside image during OVA validation. This was not properly working due to the pipefail option

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
