### PR TITLE
Bump Go version to 1.24 for version-tracker tool

### DIFF
--- a/tools/version-tracker/Makefile
+++ b/tools/version-tracker/Makefile
@@ -4,7 +4,7 @@ BASE_DIRECTORY:=$(shell git rev-parse --show-toplevel)
 
 BINARY_NAME?=version-tracker
 BINARY_PATH?=bin/$(BINARY_NAME)
-GOLANG_VERSION=1.22
+GOLANG_VERSION=1.24
 GO ?= $(shell source $(BASE_DIRECTORY)/build/lib/common.sh && build::common::get_go_path $(GOLANG_VERSION))/go
 DRY_RUN?=false
 VERBOSITY?=0

--- a/tools/version-tracker/go.mod
+++ b/tools/version-tracker/go.mod
@@ -1,7 +1,8 @@
 module github.com/aws/eks-anywhere-build-tooling/tools/version-tracker
 
-go 1.22
-toolchain go1.23.7
+go 1.24
+
+toolchain go1.24.0
 
 require (
 	github.com/aws/eks-distro-build-tooling/release v0.0.0-20240513204929-c69ded04ed10


### PR DESCRIPTION
Bump Go version to 1.24 for version-tracker tool.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
