### PR TITLE
Pin CAPI project to version v1.9.4

### DIFF
--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -446,6 +446,7 @@ var (
 
 	ProjectMaximumSemvers = map[string]string{
 		"containerd/containerd": "v1",
+		"kubernetes-sigs/cluster-api": "v1.9.4",
 		"opencontainers/runc":   "v1.1",
 		"prometheus/prometheus": "v2",
 	}


### PR DESCRIPTION
Pin CAPI project to version v1.9.4 until we identify why 1.9.5 is causing Tinkerbell tests to fail. This will prevent the bot from opening upgrade PRs for v1.9.5.
Ref: https://github.com/aws/eks-anywhere-build-tooling/pull/4442

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
