### PR TITLE
Allow vmx_version to be configurable in image-builder cli

### DIFF
--- a/projects/aws/image-builder/CHECKSUMS
+++ b/projects/aws/image-builder/CHECKSUMS
@@ -1,2 +1,2 @@
-ee11f8af866e61a27761c1dffccd235c4f3006e264caa4e5233af60800d21674  _output/bin/image-builder/linux-amd64/image-builder
-ee3995b899ccd6db0c83088bb5300ec976c52e5a9648454289d4a8d33df2e7ac  _output/bin/image-builder/linux-arm64/image-builder
+a9adec17ddb30ac0283d0909493c26e090ebae14bfc5090a25a633ecacdb0977  _output/bin/image-builder/linux-amd64/image-builder
+5486c96f5c38caa05c0f17d24a9c4d54c04d61118832f354831d934ca8989f95  _output/bin/image-builder/linux-arm64/image-builder

--- a/projects/aws/image-builder/README.md
+++ b/projects/aws/image-builder/README.md
@@ -18,6 +18,7 @@ Supported OSes
 * Red Hat Enterprise Linux
 
 Supported Release Channels
+* 1-32
 * 1-31
 * 1-30
 * 1-29
@@ -108,6 +109,7 @@ sudo snap install yq
   "resource_pool":"<resource pool used for image building vm>",
   "username":"<vcenter username>",
   "vcenter_server":"<vcenter fqdn>",
+  "vmx_version":"<hardware version of virtual machine>"
 }
 ```
 4. Run the image builder tool for appropriate release channel

--- a/projects/aws/image-builder/builder/builder.go
+++ b/projects/aws/image-builder/builder/builder.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -118,6 +119,15 @@ func (b *BuildOptions) BuildImage() {
 	}
 	var outputImageGlobPattern string
 	if b.Hypervisor == VSphere {
+		if b.VsphereConfig.VmxVersion != "" {
+			vmxVersion, err := strconv.Atoi(b.VsphereConfig.VmxVersion)
+			if err != nil {
+				log.Fatalf("Error parsing vmx_version in vsphere config: %v", err)
+			}
+			if vmxVersion < minVmVersion {
+				log.Fatalf("vmx_version cannot be less than %d, have %d in vsphere config", minVmVersion, vmxVersion)
+			}
+		}
 		if b.AirGapped {
 			airGapEnvVars, err := getAirGapCmdEnvVars(b.VsphereConfig.ImageBuilderRepoUrl, detectedEksaVersion, b.ReleaseChannel)
 			if err != nil {

--- a/projects/aws/image-builder/builder/constants.go
+++ b/projects/aws/image-builder/builder/constants.go
@@ -63,9 +63,10 @@ const (
 	eksaAnsibleVerbosityEnvVar            string = "EKSA_ANSIBLE_VERBOSITY"
 
 	// Miscellaneous
-	mainBranch string = "main"
-	amd64      string = "amd64"
-	arm64      string = "arm64"
+	mainBranch   string = "main"
+	amd64        string = "amd64"
+	arm64        string = "arm64"
+	minVmVersion int    = 15
 )
 
 var DefaultAMIAdditionalFiles = []File{

--- a/projects/aws/image-builder/builder/types.go
+++ b/projects/aws/image-builder/builder/types.go
@@ -74,6 +74,7 @@ type VsphereConfig struct {
 	VcenterServer      string `json:"vcenter_server"`
 	Username           string `json:"username"`
 	Password           string `json:"password"`
+	VmxVersion         string `json:"vmx_version,omitempty"`
 	IsoConfig
 	RhelConfig
 	ProxyConfig


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3096

*Description of changes:*
Allow `vmx_version` to be configurable in image-builder cli instead of always using the default value 15 from upstream image-builder. Also add a validation to prevent using vmx_version of less than 15.

*Testing:
1. Do not specify vmx_version in vsphere.json, the output ova has 15 as vm version
2. Specify 14 as vmx_version value, image-build failed during validation because the min version should be 15.
3. Specify 18 as vmx_version and build the ova, in the output .ovf file we can see the VirtualSystemType is override.
```
    <VirtualHardwareSection>
      <Info>Virtual hardware requirements</Info>
      <System>
        <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>
        <vssd:InstanceID>0</vssd:InstanceID>
        <vssd:VirtualSystemIdentifier>ubuntu-2004-kube-v1.32.2</vssd:VirtualSystemIdentifier>
        <vssd:VirtualSystemType>vmx-18</vssd:VirtualSystemType>
      </System>
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
