### PR TITLE
Update metrics server to latest EKS Addon Image version

### DIFF
--- a/projects/kubernetes-sigs/metrics-server/EKS_ADDON_IMAGE_TAG
+++ b/projects/kubernetes-sigs/metrics-server/EKS_ADDON_IMAGE_TAG
@@ -1,1 +1,1 @@
-v0.7.2-eksbuild.2
+v0.7.2-eksbuild.3


### PR DESCRIPTION
*Description of changes:*
* Update metrics server to latest EKS Add-on Image version which resolves CVE issues in the current version

*Testing:*
- Tested using package install using helm on `VSphere Cluster`
  -  Replicate image to personal repo
  ```
  skopeo copy docker://602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/metrics-server:v0.7.2-eksbuild.3 docker://public.ecr.aws/g0y6o3v0/metrics-server/eks-distro/kubernetes-sigs/metrics-server:v0.7.2-eksbuild.3 -f oci --all
  ```
 - Install package using helm
    ```
    helm install metrics-server oci://public.ecr.aws/g0y6o3v0/metrics-server/charts/metrics-server --version 0.7.2-eksbuild.3-8b4f46cc05160e83cbce6eec328f4553cbc33243 --set sourceRegistry=public.ecr.aws/g0y6o3v0
    ```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
