### PR TITLE
[release-0.21] Revert EKS-D 1.28 back to 1.28-43

### DIFF
--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -32,7 +32,7 @@ releases:
   number: 40
 - branch: 1-28
   kubeVersion: v1.28.15
-  number: 48
+  number: 43
 - branch: 1-29
   kubeVersion: v1.29.15
   number: 37


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
Since eksd 1.28-44, the coredns version was changed from v1.11.1 to v1.10.1, this will cause trouble when user try to upgrade from 1.27 to 1.28 because 1.27 eksd is using coredns version v1.11.1 and component version cannot be downgraded during an upgrade.

Revert eksd version back to 1.28-43 until 1.28 has a new eksd release with coredns v1.11

https://distro.eks.amazonaws.com/releases/1-28/44/
https://distro.eks.amazonaws.com/releases/1-28/43/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
