### PR TITLE
Update checksums from build of distrbution upgrade

### DIFF
--- a/projects/distribution/distribution/CHECKSUMS
+++ b/projects/distribution/distribution/CHECKSUMS
@@ -1,2 +1,2 @@
-9675e2c0a73ca01da6d12d93d57cd07e1434b047e31ab09790ad76ec66a487bc  _output/bin/distribution/linux-amd64/registry
-6b6d49389f22dc586083b535aecce0c94d83d60dd77a395a98cdf8697fb09266  _output/bin/distribution/linux-arm64/registry
+e82ba08b52406a04561c5d9170edd71a1598417627fb952c876c50f70417d99c  _output/bin/distribution/linux-amd64/registry
+24c20b75fc83487116bfaa584a9079d80fdc42df6e023bbb2000a0ad65f44b82  _output/bin/distribution/linux-arm64/registry

--- a/projects/distribution/distribution/Makefile
+++ b/projects/distribution/distribution/Makefile
@@ -12,7 +12,6 @@ REVISION=$(shell git -C $(REPO) rev-parse HEAD)$(shell if ! git -C $(REPO) diff 
 PKG=github.com/docker/distribution
 
 EXTRA_GO_LDFLAGS=-X $(PKG)/version.Version=$(VERSION) -X $(PKG)/version.Revision=$(REVISION) -X $(PKG)/version.Package=$(PKG)
-EXTRA_GOBUILD_FLAGS=-tags include_oss,include_gcs
 
 HAS_S3_ARTIFACTS=true
 EXCLUDE_FROM_STAGING_BUILDSPEC=true
@@ -22,20 +21,6 @@ IMAGE_NAMES=
 FIX_LICENSES_REDIS_TARGET=$(REPO)/vendor/github.com/garyburd/redigo/LICENSE.txt
 
 include $(BASE_DIRECTORY)/Common.mk
-
-$(GATHER_LICENSES_TARGETS): | $(FIX_LICENSES_REDIS_TARGET)
-
-$(FIX_LICENSES_REDIS_TARGET): | $(GO_MOD_DOWNLOAD_TARGETS)
-# The garyburd/redigo dependency github repo has a license however redis and internal are subfolders 
-# without their own licenses. Hence we need to manually download parent license from Github for each of them 
-# and place them in the respective folders under vendor directory so that they is available for 
-# go-licenses to pick up	
-	for package in redis internal ; do \
-		dest=$(REPO)/vendor/github.com/garyburd/redigo/$$package/LICENSE.txt; \
-		mkdir -p $$(dirname $$dest); \
-		wget -q --retry-connrefused https://raw.githubusercontent.com/garyburd/redigo/master/LICENSE -O \
-				$$dest; \
-	done;
 
 
 ########### DO NOT EDIT #############################


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Got a build failure in codepipelines, so using the checksums generated from there specifically for the arm build. We also don't need the "include_oss" and "include_gcs" build tags as they are for specific cloud providers that we don't support. The redigo patch also seems outdated as the repo doesn't exist anymore.

```

_output/bin/distribution/linux-amd64/registry: OK
_output/bin/distribution/linux-arm64/registry: FAILED
sha256sum: WARNING: 1 computed checksum did NOT match
Checksums do not match!

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
