### PR TITLE
Remove hardcoded version pin for capi project in upgrader

### DIFF
--- a/tools/version-tracker/pkg/constants/constants.go
+++ b/tools/version-tracker/pkg/constants/constants.go
@@ -446,10 +446,9 @@ var (
 
 	ProjectMaximumSemvers = map[string]string{
 		"containerd/containerd": "v1",
-		"kubernetes-sigs/cluster-api": "v1.9.4",
 		"opencontainers/runc":   "v1.1",
 		"prometheus/prometheus": "v2",
-		"helm/helm": "v3.16.4",
+		"helm/helm":             "v3.16.4",
 	}
 
 	ECRImageRepositories = map[string]string{


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3112

*Description of changes:*    
CAPI project was pinned to 1.9.4 as subsequent versions were breaking metal tests. CAPT has a [fix](https://github.com/tinkerbell/cluster-api-provider-tinkerbell/pull/460) upstream in latest release that should be compatible with the latest versions of CAPI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
