### PR TITLE
fix: Updated autoscaler schema and patch for metrics-server

### DIFF
--- a/projects/kubernetes-sigs/metrics-server/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
+++ b/projects/kubernetes-sigs/metrics-server/helm/patches/0001-Conform-helm-chart-to-packages-standards.patch
@@ -90,7 +90,7 @@ index be843db4..55e4423d 100644
 -  repository: registry.k8s.io/metrics-server/metrics-server
 -  # Overrides the image tag whose default is v{{ .Chart.AppVersion }}
 -  tag: ""
-+  repository: metrics-server/eks-distro/kubernetes-sigs/metrics-server
++  repository: metrics-server/eks/metrics-server
 +  digest: {{eks/metrics-server}}
 +
    pullPolicy: IfNotPresent

--- a/projects/kubernetes/autoscaler/1-30/helm/schema.json
+++ b/projects/kubernetes/autoscaler/1-30/helm/schema.json
@@ -31,14 +31,14 @@
             "additionalProperties": false,
             "properties": {
                 "clusterName": {
-                    "type": "null",
-                    "default": null,
+                    "type": "string",
+                    "default": "",
                     "title": "The clusterName Schema",
                     "examples": []
                 },
                 "namespace": {
-                    "type": "null",
-                    "default": null,
+                    "type": "string",
+                    "default": "",
                     "title": "The namespace Schema",
                     "examples": []
                 },
@@ -78,8 +78,8 @@
             },
             "examples": [
                 {
-                    "clusterName": null,
-                    "namespace": null,
+                    "clusterName": "",
+                    "namespace": "",
                     "tags": [
                         "k8s.io/cluster-autoscaler/enabled",
                         "k8s.io/cluster-autoscaler/{{ .Values.autoDiscovery.clusterName }}"
@@ -663,10 +663,12 @@
                     ]
                 },
                 "interval": {
-                    "type": "null",
-                    "default": null,
+                    "type": "string",
+                    "default": "10s",
                     "title": "The interval Schema",
-                    "examples": []
+                    "examples": [
+                        "10s"
+                    ]
                 },
                 "rules": {
                     "type": "array",
@@ -680,7 +682,7 @@
                     "enabled": false,
                     "additionalLabels": {},
                     "namespace": "monitoring",
-                    "interval": null,
+                    "interval": "10s",
                     "rules": []
                 }
             ]
@@ -1086,8 +1088,8 @@
             "affinity": {},
             "additionalLabels": {},
             "autoDiscovery": {
-                "clusterName": null,
-                "namespace": null,
+                "clusterName": "",
+                "namespace": "",
                 "tags": [
                     "k8s.io/cluster-autoscaler/enabled",
                     "k8s.io/cluster-autoscaler/{{ .Values.autoDiscovery.clusterName }}"
@@ -1171,7 +1173,7 @@
                 "enabled": false,
                 "additionalLabels": {},
                 "namespace": "monitoring",
-                "interval": null,
+                "interval": "10s",
                 "rules": []
             },
             "rbac": {

--- a/projects/kubernetes/autoscaler/1-31/helm/schema.json
+++ b/projects/kubernetes/autoscaler/1-31/helm/schema.json
@@ -31,14 +31,14 @@
             "additionalProperties": false,
             "properties": {
                 "clusterName": {
-                    "type": "null",
-                    "default": null,
+                    "type": "string",
+                    "default": "",
                     "title": "The clusterName Schema",
                     "examples": []
                 },
                 "namespace": {
-                    "type": "null",
-                    "default": null,
+                    "type": "string",
+                    "default": "",
                     "title": "The namespace Schema",
                     "examples": []
                 },
@@ -78,8 +78,8 @@
             },
             "examples": [
                 {
-                    "clusterName": null,
-                    "namespace": null,
+                    "clusterName": "",
+                    "namespace": "",
                     "tags": [
                         "k8s.io/cluster-autoscaler/enabled",
                         "k8s.io/cluster-autoscaler/{{ .Values.autoDiscovery.clusterName }}"
@@ -660,10 +660,12 @@
                     ]
                 },
                 "interval": {
-                    "type": "null",
-                    "default": null,
+                    "type": "string",
+                    "default": "10s",
                     "title": "The interval Schema",
-                    "examples": []
+                    "examples": [
+                        "10s"
+                    ]
                 },
                 "rules": {
                     "type": "array",
@@ -677,7 +679,7 @@
                     "enabled": false,
                     "additionalLabels": {},
                     "namespace": "monitoring",
-                    "interval": null,
+                    "interval": "10s",
                     "rules": []
                 }
             ]
@@ -1083,8 +1085,8 @@
             "affinity": {},
             "additionalLabels": {},
             "autoDiscovery": {
-                "clusterName": null,
-                "namespace": null,
+                "clusterName": "",
+                "namespace": "",
                 "tags": [
                     "k8s.io/cluster-autoscaler/enabled",
                     "k8s.io/cluster-autoscaler/{{ .Values.autoDiscovery.clusterName }}"
@@ -1168,7 +1170,7 @@
                 "enabled": false,
                 "additionalLabels": {},
                 "namespace": "monitoring",
-                "interval": null,
+                "interval": "10s",
                 "rules": []
             },
             "rbac": {

--- a/projects/kubernetes/autoscaler/1-32/helm/schema.json
+++ b/projects/kubernetes/autoscaler/1-32/helm/schema.json
@@ -31,14 +31,14 @@
             "additionalProperties": false,
             "properties": {
                 "clusterName": {
-                    "type": "null",
-                    "default": null,
+                    "type": "string",
+                    "default": "",
                     "title": "The clusterName Schema",
                     "examples": []
                 },
                 "namespace": {
-                    "type": "null",
-                    "default": null,
+                    "type": "string",
+                    "default": "",
                     "title": "The namespace Schema",
                     "examples": []
                 },
@@ -78,8 +78,8 @@
             },
             "examples": [
                 {
-                    "clusterName": null,
-                    "namespace": null,
+                    "clusterName": "",
+                    "namespace": "",
                     "tags": [
                         "k8s.io/cluster-autoscaler/enabled",
                         "k8s.io/cluster-autoscaler/{{ .Values.autoDiscovery.clusterName }}"
@@ -660,10 +660,12 @@
                     ]
                 },
                 "interval": {
-                    "type": "null",
-                    "default": null,
+                    "type": "string",
+                    "default": "10s",
                     "title": "The interval Schema",
-                    "examples": []
+                    "examples": [
+                        "10s"
+                    ]
                 },
                 "rules": {
                     "type": "array",
@@ -677,7 +679,7 @@
                     "enabled": false,
                     "additionalLabels": {},
                     "namespace": "monitoring",
-                    "interval": null,
+                    "interval": "10s",
                     "rules": []
                 }
             ]
@@ -1083,8 +1085,8 @@
             "affinity": {},
             "additionalLabels": {},
             "autoDiscovery": {
-                "clusterName": null,
-                "namespace": null,
+                "clusterName": "",
+                "namespace": "",
                 "tags": [
                     "k8s.io/cluster-autoscaler/enabled",
                     "k8s.io/cluster-autoscaler/{{ .Values.autoDiscovery.clusterName }}"
@@ -1168,7 +1170,7 @@
                 "enabled": false,
                 "additionalLabels": {},
                 "namespace": "monitoring",
-                "interval": null,
+                "interval": "10s",
                 "rules": []
             },
             "rbac": {

--- a/projects/kubernetes/autoscaler/1-33/helm/schema.json
+++ b/projects/kubernetes/autoscaler/1-33/helm/schema.json
@@ -31,14 +31,14 @@
             "additionalProperties": false,
             "properties": {
                 "clusterName": {
-                    "type": "null",
-                    "default": null,
+                    "type": "string",
+                    "default": "",
                     "title": "The clusterName Schema",
                     "examples": []
                 },
                 "namespace": {
-                    "type": "null",
-                    "default": null,
+                    "type": "string",
+                    "default": "",
                     "title": "The namespace Schema",
                     "examples": []
                 },
@@ -78,8 +78,8 @@
             },
             "examples": [
                 {
-                    "clusterName": null,
-                    "namespace": null,
+                    "clusterName": "",
+                    "namespace": "",
                     "tags": [
                         "k8s.io/cluster-autoscaler/enabled",
                         "k8s.io/cluster-autoscaler/{{ .Values.autoDiscovery.clusterName }}"
@@ -660,10 +660,12 @@
                     ]
                 },
                 "interval": {
-                    "type": "null",
-                    "default": null,
+                    "type": "string",
+                    "default": "10s",
                     "title": "The interval Schema",
-                    "examples": []
+                    "examples": [
+                        "10s"
+                    ]
                 },
                 "rules": {
                     "type": "array",
@@ -677,7 +679,7 @@
                     "enabled": false,
                     "additionalLabels": {},
                     "namespace": "monitoring",
-                    "interval": null,
+                    "interval": "10s",
                     "rules": []
                 }
             ]
@@ -1083,8 +1085,8 @@
             "affinity": {},
             "additionalLabels": {},
             "autoDiscovery": {
-                "clusterName": null,
-                "namespace": null,
+                "clusterName": "",
+                "namespace": "",
                 "tags": [
                     "k8s.io/cluster-autoscaler/enabled",
                     "k8s.io/cluster-autoscaler/{{ .Values.autoDiscovery.clusterName }}"
@@ -1168,7 +1170,7 @@
                 "enabled": false,
                 "additionalLabels": {},
                 "namespace": "monitoring",
-                "interval": null,
+                "interval": "10s",
                 "rules": []
             },
             "rbac": {


### PR DESCRIPTION
*Description of changes:*
* Updated schema for autoscaler package.
* Updated patch for metrics-server to have correct repo name for metrics-server image.

*Testing*

* Verfied the package install on cluster with locally built package.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
