### PR TITLE
skip packages on attribution generation for release branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,8 +153,10 @@ add-generated-help-block: $(addprefix add-generated-help-block-project-, $(ALL_P
 .PHONY: attribution-files-project-%
 attribution-files-project-%:
 	$(eval PROJECT_PATH=$(call PROJECT_PATH_MAP,$*))
-	$(MAKE) -C $(PROJECT_PATH) all-attributions
-
+	if $(MAKE) -C $(PROJECT_PATH) check-for-release-branch-skip; then \
+		$(MAKE) -C $(PROJECT_PATH) all-attributions; \
+	fi
+	
 .PHONY: attribution-files
 attribution-files: $(addprefix attribution-files-project-, $(ALL_PROJECTS))
 	cat _output/total_summary.txt


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We do not need to generate the attribution files for packages on the nightly attribution job.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
