### PR TITLE
fix: remove additionalProperties from schema.json

### DIFF
--- a/projects/kubernetes/autoscaler/1-30/helm/schema.json
+++ b/projects/kubernetes/autoscaler/1-30/helm/schema.json
@@ -5,14 +5,12 @@
     "default": {},
     "title": "Root Schema",
     "required": [],
-    "additionalProperties": false,
     "properties": {
         "affinity": {
             "type": "object",
             "default": {},
             "title": "The affinity Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "additionalLabels": {
@@ -20,7 +18,6 @@
             "default": {},
             "title": "The additionalLabels Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "autoDiscovery": {
@@ -28,7 +25,6 @@
             "default": {},
             "title": "The autoDiscovery Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "clusterName": {
                     "type": "string",
@@ -300,7 +296,6 @@
             "default": {},
             "title": "The containerSecurityContext Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "deployment": {
@@ -308,14 +303,12 @@
             "default": {},
             "title": "The deployment Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "annotations": {
                     "type": "object",
                     "default": {},
                     "title": "The annotations Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 }
             },
@@ -354,7 +347,6 @@
             "default": {},
             "title": "The expanderPriorities Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "extraArgs": {
@@ -362,7 +354,6 @@
             "default": {},
             "title": "The extraArgs Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "logtostderr": {
                     "type": "boolean",
@@ -408,7 +399,6 @@
             "default": {},
             "title": "The extraEnv Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "extraEnvConfigMaps": {
@@ -416,7 +406,6 @@
             "default": {},
             "title": "The extraEnvConfigMaps Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "extraEnvSecrets": {
@@ -424,7 +413,6 @@
             "default": {},
             "title": "The extraEnvSecrets Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "extraObjects": {
@@ -450,7 +438,6 @@
             "default": {},
             "title": "The extraVolumeSecrets Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "initContainers": {
@@ -488,7 +475,6 @@
             "default": {},
             "title": "The image Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "repository": {
                     "type": "string",
@@ -574,7 +560,6 @@
             "default": {},
             "title": "The nodeSelector Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "podAnnotations": {
@@ -582,7 +567,6 @@
             "default": {},
             "title": "The podAnnotations Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "podDisruptionBudget": {
@@ -590,7 +574,6 @@
             "default": {},
             "title": "The podDisruptionBudget Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "maxUnavailable": {
                     "type": "integer",
@@ -612,7 +595,6 @@
             "default": {},
             "title": "The podLabels Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "priorityClassName": {
@@ -628,7 +610,6 @@
             "default": {},
             "title": "The priorityConfigMapAnnotations Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "prometheusRule": {
@@ -636,7 +617,6 @@
             "default": {},
             "title": "The prometheusRule Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "enabled": {
                     "type": "boolean",
@@ -651,7 +631,6 @@
                     "default": {},
                     "title": "The additionalLabels Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 },
                 "namespace": {
@@ -692,7 +671,6 @@
             "default": {},
             "title": "The rbac Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "create": {
                     "type": "boolean",
@@ -723,14 +701,12 @@
                     "default": {},
                     "title": "The serviceAccount Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {
                         "annotations": {
                             "type": "object",
                             "default": {},
                             "title": "The annotations Schema",
                             "required": [],
-                            "additionalProperties": false,
                             "properties": {}
                         },
                         "create": {
@@ -795,7 +771,6 @@
             "default": {},
             "title": "The resources Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "revisionHistoryLimit": {
@@ -811,7 +786,6 @@
             "default": {},
             "title": "The securityContext Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "service": {
@@ -819,7 +793,6 @@
             "default": {},
             "title": "The service Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "create": {
                     "type": "boolean",
@@ -834,7 +807,6 @@
                     "default": {},
                     "title": "The annotations Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 },
                 "labels": {
@@ -842,7 +814,6 @@
                     "default": {},
                     "title": "The labels Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 },
                 "externalIPs": {
@@ -918,7 +889,6 @@
             "default": {},
             "title": "The serviceMonitor Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "enabled": {
                     "type": "boolean",
@@ -949,7 +919,6 @@
                     "default": {},
                     "title": "The selector Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {
                         "release": {
                             "type": "string",
@@ -979,7 +948,6 @@
                     "default": {},
                     "title": "The annotations Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 },
                 "relabelings": {
@@ -987,7 +955,6 @@
                     "default": {},
                     "title": "The relabelings Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 },
                 "metricRelabelings": {
@@ -995,7 +962,6 @@
                     "default": {},
                     "title": "The metricRelabelings Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 }
             },
@@ -1031,7 +997,6 @@
             "default": {},
             "title": "The updateStrategy Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "vpa": {
@@ -1039,7 +1004,6 @@
             "default": {},
             "title": "The vpa Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "enabled": {
                     "type": "boolean",
@@ -1062,7 +1026,6 @@
                     "default": {},
                     "title": "The containerPolicy Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 }
             },

--- a/projects/kubernetes/autoscaler/1-31/helm/schema.json
+++ b/projects/kubernetes/autoscaler/1-31/helm/schema.json
@@ -5,14 +5,12 @@
     "default": {},
     "title": "Root Schema",
     "required": [],
-    "additionalProperties": false,
     "properties": {
         "affinity": {
             "type": "object",
             "default": {},
             "title": "The affinity Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "additionalLabels": {
@@ -20,7 +18,6 @@
             "default": {},
             "title": "The additionalLabels Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "autoDiscovery": {
@@ -28,7 +25,6 @@
             "default": {},
             "title": "The autoDiscovery Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "clusterName": {
                     "type": "string",
@@ -300,7 +296,6 @@
             "default": {},
             "title": "The containerSecurityContext Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "deployment": {
@@ -308,14 +303,12 @@
             "default": {},
             "title": "The deployment Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "annotations": {
                     "type": "object",
                     "default": {},
                     "title": "The annotations Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 }
             },
@@ -354,7 +347,6 @@
             "default": {},
             "title": "The expanderPriorities Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "extraArgs": {
@@ -362,7 +354,6 @@
             "default": {},
             "title": "The extraArgs Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "logtostderr": {
                     "type": "boolean",
@@ -408,7 +399,6 @@
             "default": {},
             "title": "The extraEnv Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "extraEnvConfigMaps": {
@@ -416,7 +406,6 @@
             "default": {},
             "title": "The extraEnvConfigMaps Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "extraEnvSecrets": {
@@ -424,7 +413,6 @@
             "default": {},
             "title": "The extraEnvSecrets Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "extraObjects": {
@@ -450,7 +438,6 @@
             "default": {},
             "title": "The extraVolumeSecrets Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "initContainers": {
@@ -571,7 +558,6 @@
             "default": {},
             "title": "The nodeSelector Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "podAnnotations": {
@@ -579,7 +565,6 @@
             "default": {},
             "title": "The podAnnotations Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "podDisruptionBudget": {
@@ -587,7 +572,6 @@
             "default": {},
             "title": "The podDisruptionBudget Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "maxUnavailable": {
                     "type": "integer",
@@ -609,7 +593,6 @@
             "default": {},
             "title": "The podLabels Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "priorityClassName": {
@@ -625,7 +608,6 @@
             "default": {},
             "title": "The priorityConfigMapAnnotations Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "prometheusRule": {
@@ -633,7 +615,6 @@
             "default": {},
             "title": "The prometheusRule Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "enabled": {
                     "type": "boolean",
@@ -648,7 +629,6 @@
                     "default": {},
                     "title": "The additionalLabels Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 },
                 "namespace": {
@@ -689,7 +669,6 @@
             "default": {},
             "title": "The rbac Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "create": {
                     "type": "boolean",
@@ -720,14 +699,12 @@
                     "default": {},
                     "title": "The serviceAccount Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {
                         "annotations": {
                             "type": "object",
                             "default": {},
                             "title": "The annotations Schema",
                             "required": [],
-                            "additionalProperties": false,
                             "properties": {}
                         },
                         "create": {
@@ -792,7 +769,6 @@
             "default": {},
             "title": "The resources Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "revisionHistoryLimit": {
@@ -808,7 +784,6 @@
             "default": {},
             "title": "The securityContext Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "service": {
@@ -816,7 +791,6 @@
             "default": {},
             "title": "The service Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "create": {
                     "type": "boolean",
@@ -831,7 +805,6 @@
                     "default": {},
                     "title": "The annotations Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 },
                 "labels": {
@@ -839,7 +812,6 @@
                     "default": {},
                     "title": "The labels Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 },
                 "externalIPs": {
@@ -915,7 +887,6 @@
             "default": {},
             "title": "The serviceMonitor Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "enabled": {
                     "type": "boolean",
@@ -946,7 +917,6 @@
                     "default": {},
                     "title": "The selector Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {
                         "release": {
                             "type": "string",
@@ -976,7 +946,6 @@
                     "default": {},
                     "title": "The annotations Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 },
                 "relabelings": {
@@ -984,7 +953,6 @@
                     "default": {},
                     "title": "The relabelings Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 },
                 "metricRelabelings": {
@@ -992,7 +960,6 @@
                     "default": {},
                     "title": "The metricRelabelings Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 }
             },
@@ -1028,7 +995,6 @@
             "default": {},
             "title": "The updateStrategy Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "vpa": {
@@ -1036,7 +1002,6 @@
             "default": {},
             "title": "The vpa Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "enabled": {
                     "type": "boolean",
@@ -1059,7 +1024,6 @@
                     "default": {},
                     "title": "The containerPolicy Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 }
             },

--- a/projects/kubernetes/autoscaler/1-32/helm/schema.json
+++ b/projects/kubernetes/autoscaler/1-32/helm/schema.json
@@ -5,14 +5,12 @@
     "default": {},
     "title": "Root Schema",
     "required": [],
-    "additionalProperties": false,
     "properties": {
         "affinity": {
             "type": "object",
             "default": {},
             "title": "The affinity Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "additionalLabels": {
@@ -20,7 +18,6 @@
             "default": {},
             "title": "The additionalLabels Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "autoDiscovery": {
@@ -28,7 +25,6 @@
             "default": {},
             "title": "The autoDiscovery Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "clusterName": {
                     "type": "string",
@@ -300,7 +296,6 @@
             "default": {},
             "title": "The containerSecurityContext Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "deployment": {
@@ -308,14 +303,12 @@
             "default": {},
             "title": "The deployment Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "annotations": {
                     "type": "object",
                     "default": {},
                     "title": "The annotations Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 }
             },
@@ -354,7 +347,6 @@
             "default": {},
             "title": "The expanderPriorities Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "extraArgs": {
@@ -362,7 +354,6 @@
             "default": {},
             "title": "The extraArgs Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "logtostderr": {
                     "type": "boolean",
@@ -408,7 +399,6 @@
             "default": {},
             "title": "The extraEnv Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "extraEnvConfigMaps": {
@@ -416,7 +406,6 @@
             "default": {},
             "title": "The extraEnvConfigMaps Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "extraEnvSecrets": {
@@ -424,7 +413,6 @@
             "default": {},
             "title": "The extraEnvSecrets Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "extraObjects": {
@@ -450,7 +438,6 @@
             "default": {},
             "title": "The extraVolumeSecrets Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "initContainers": {
@@ -571,7 +558,6 @@
             "default": {},
             "title": "The nodeSelector Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "podAnnotations": {
@@ -579,7 +565,6 @@
             "default": {},
             "title": "The podAnnotations Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "podDisruptionBudget": {
@@ -587,7 +572,6 @@
             "default": {},
             "title": "The podDisruptionBudget Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "maxUnavailable": {
                     "type": "integer",
@@ -609,7 +593,6 @@
             "default": {},
             "title": "The podLabels Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "priorityClassName": {
@@ -625,7 +608,6 @@
             "default": {},
             "title": "The priorityConfigMapAnnotations Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "prometheusRule": {
@@ -633,7 +615,6 @@
             "default": {},
             "title": "The prometheusRule Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "enabled": {
                     "type": "boolean",
@@ -648,7 +629,6 @@
                     "default": {},
                     "title": "The additionalLabels Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 },
                 "namespace": {
@@ -689,7 +669,6 @@
             "default": {},
             "title": "The rbac Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "create": {
                     "type": "boolean",
@@ -720,14 +699,12 @@
                     "default": {},
                     "title": "The serviceAccount Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {
                         "annotations": {
                             "type": "object",
                             "default": {},
                             "title": "The annotations Schema",
                             "required": [],
-                            "additionalProperties": false,
                             "properties": {}
                         },
                         "create": {
@@ -792,7 +769,6 @@
             "default": {},
             "title": "The resources Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "revisionHistoryLimit": {
@@ -808,7 +784,6 @@
             "default": {},
             "title": "The securityContext Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "service": {
@@ -816,7 +791,6 @@
             "default": {},
             "title": "The service Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "create": {
                     "type": "boolean",
@@ -831,7 +805,6 @@
                     "default": {},
                     "title": "The annotations Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 },
                 "labels": {
@@ -839,7 +812,6 @@
                     "default": {},
                     "title": "The labels Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 },
                 "externalIPs": {
@@ -915,7 +887,6 @@
             "default": {},
             "title": "The serviceMonitor Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "enabled": {
                     "type": "boolean",
@@ -946,7 +917,6 @@
                     "default": {},
                     "title": "The selector Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {
                         "release": {
                             "type": "string",
@@ -976,7 +946,6 @@
                     "default": {},
                     "title": "The annotations Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 },
                 "relabelings": {
@@ -984,7 +953,6 @@
                     "default": {},
                     "title": "The relabelings Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 },
                 "metricRelabelings": {
@@ -992,7 +960,6 @@
                     "default": {},
                     "title": "The metricRelabelings Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 }
             },
@@ -1028,7 +995,6 @@
             "default": {},
             "title": "The updateStrategy Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "vpa": {
@@ -1036,7 +1002,6 @@
             "default": {},
             "title": "The vpa Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "enabled": {
                     "type": "boolean",
@@ -1059,7 +1024,6 @@
                     "default": {},
                     "title": "The containerPolicy Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 }
             },

--- a/projects/kubernetes/autoscaler/1-33/helm/schema.json
+++ b/projects/kubernetes/autoscaler/1-33/helm/schema.json
@@ -5,14 +5,12 @@
     "default": {},
     "title": "Root Schema",
     "required": [],
-    "additionalProperties": false,
     "properties": {
         "affinity": {
             "type": "object",
             "default": {},
             "title": "The affinity Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "additionalLabels": {
@@ -20,7 +18,6 @@
             "default": {},
             "title": "The additionalLabels Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "autoDiscovery": {
@@ -28,7 +25,6 @@
             "default": {},
             "title": "The autoDiscovery Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "clusterName": {
                     "type": "string",
@@ -300,7 +296,6 @@
             "default": {},
             "title": "The containerSecurityContext Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "deployment": {
@@ -308,14 +303,12 @@
             "default": {},
             "title": "The deployment Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "annotations": {
                     "type": "object",
                     "default": {},
                     "title": "The annotations Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 }
             },
@@ -354,7 +347,6 @@
             "default": {},
             "title": "The expanderPriorities Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "extraArgs": {
@@ -362,7 +354,6 @@
             "default": {},
             "title": "The extraArgs Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "logtostderr": {
                     "type": "boolean",
@@ -408,7 +399,6 @@
             "default": {},
             "title": "The extraEnv Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "extraEnvConfigMaps": {
@@ -416,7 +406,6 @@
             "default": {},
             "title": "The extraEnvConfigMaps Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "extraEnvSecrets": {
@@ -424,7 +413,6 @@
             "default": {},
             "title": "The extraEnvSecrets Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "extraObjects": {
@@ -450,7 +438,6 @@
             "default": {},
             "title": "The extraVolumeSecrets Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "initContainers": {
@@ -571,7 +558,6 @@
             "default": {},
             "title": "The nodeSelector Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "podAnnotations": {
@@ -579,7 +565,6 @@
             "default": {},
             "title": "The podAnnotations Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "podDisruptionBudget": {
@@ -587,7 +572,6 @@
             "default": {},
             "title": "The podDisruptionBudget Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "maxUnavailable": {
                     "type": "integer",
@@ -609,7 +593,6 @@
             "default": {},
             "title": "The podLabels Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "priorityClassName": {
@@ -625,7 +608,6 @@
             "default": {},
             "title": "The priorityConfigMapAnnotations Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "prometheusRule": {
@@ -633,7 +615,6 @@
             "default": {},
             "title": "The prometheusRule Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "enabled": {
                     "type": "boolean",
@@ -648,7 +629,6 @@
                     "default": {},
                     "title": "The additionalLabels Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 },
                 "namespace": {
@@ -689,7 +669,6 @@
             "default": {},
             "title": "The rbac Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "create": {
                     "type": "boolean",
@@ -720,14 +699,12 @@
                     "default": {},
                     "title": "The serviceAccount Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {
                         "annotations": {
                             "type": "object",
                             "default": {},
                             "title": "The annotations Schema",
                             "required": [],
-                            "additionalProperties": false,
                             "properties": {}
                         },
                         "create": {
@@ -792,7 +769,6 @@
             "default": {},
             "title": "The resources Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "revisionHistoryLimit": {
@@ -808,7 +784,6 @@
             "default": {},
             "title": "The securityContext Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "service": {
@@ -816,7 +791,6 @@
             "default": {},
             "title": "The service Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "create": {
                     "type": "boolean",
@@ -831,7 +805,6 @@
                     "default": {},
                     "title": "The annotations Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 },
                 "labels": {
@@ -839,7 +812,6 @@
                     "default": {},
                     "title": "The labels Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 },
                 "externalIPs": {
@@ -915,7 +887,6 @@
             "default": {},
             "title": "The serviceMonitor Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "enabled": {
                     "type": "boolean",
@@ -946,7 +917,6 @@
                     "default": {},
                     "title": "The selector Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {
                         "release": {
                             "type": "string",
@@ -976,7 +946,6 @@
                     "default": {},
                     "title": "The annotations Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 },
                 "relabelings": {
@@ -984,7 +953,6 @@
                     "default": {},
                     "title": "The relabelings Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 },
                 "metricRelabelings": {
@@ -992,7 +960,6 @@
                     "default": {},
                     "title": "The metricRelabelings Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 }
             },
@@ -1028,7 +995,6 @@
             "default": {},
             "title": "The updateStrategy Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {}
         },
         "vpa": {
@@ -1036,7 +1002,6 @@
             "default": {},
             "title": "The vpa Schema",
             "required": [],
-            "additionalProperties": false,
             "properties": {
                 "enabled": {
                     "type": "boolean",
@@ -1059,7 +1024,6 @@
                     "default": {},
                     "title": "The containerPolicy Schema",
                     "required": [],
-                    "additionalProperties": false,
                     "properties": {}
                 }
             },


### PR DESCRIPTION
*Description of changes:*
* Remove additionalProperties field from schema.json to allow for additional fields by removing property restrictions


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
