### PR TITLE
stops cilium operator from blocking draining of nodes

### DIFF
--- a/projects/cilium/cilium/manifests/cilium-eksa.yaml
+++ b/projects/cilium/cilium/manifests/cilium-eksa.yaml
@@ -9,5 +9,12 @@ rollOutCiliumPods: true
 routing-mode: "tunnel"
 tunnel-protocol: "geneve"
 operator:
+  tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Exists"
+    - key: "node.kubernetes.io/not-ready"
+      operator: "Exists"
+    - key: "node.cilium.io/agent-not-ready"
+      operator: "Exists"
   prometheus:
     enabled: true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Replaces cilium-operator tolerations from  tolerations: [{operator: Exists}] to 
tolerations: [{key: "[node-role.kubernetes.io/control-plane](http://node-role.kubernetes.io/control-plane)", operator: "Exists"}, {key: "[node.kubernetes.io/not-ready](http://node.kubernetes.io/not-ready)", operator: "Exists"}, {key: "[node.cilium.io/agent-not-ready](http://node.cilium.io/agent-not-ready)", operator: "Exists"},]

Worker node upgrade workflow sometimes fail due to cilium operator getting scheduled onto the nodes marked for deletion as they have wildcard tolerations by default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
