### PR TITLE
Add patch for cloudstack to remove kube rbac proxy

### DIFF
--- a/projects/kubernetes-sigs/cluster-api-provider-cloudstack/CHECKSUMS
+++ b/projects/kubernetes-sigs/cluster-api-provider-cloudstack/CHECKSUMS
@@ -1,2 +1,2 @@
-48d2989a13f91dbe58d0d9c8c5465dc350d3b8278ed0a74734c12d549aea8f8f  _output/bin/cluster-api-provider-cloudstack/linux-amd64/manager
-89492d90478de825ba1907ba195f5965119175e791cc01106ad996d4be304369  _output/bin/cluster-api-provider-cloudstack/linux-arm64/manager
+1918bf5aeebf9bf8c0ad94a9feeab5f3ecc35f3a4c39a60a4d699d47721c6e75  _output/bin/cluster-api-provider-cloudstack/linux-amd64/manager
+65942617ca5160b26f704665ea15c2ed505eacf0ce12b018a82444ef91c429e5  _output/bin/cluster-api-provider-cloudstack/linux-arm64/manager

--- a/projects/kubernetes-sigs/cluster-api-provider-cloudstack/build/create_manifests.sh
+++ b/projects/kubernetes-sigs/cluster-api-provider-cloudstack/build/create_manifests.sh
@@ -33,10 +33,7 @@ build::common::use_go_version ${GOLANG_VERSION}
 
 cd $REPO
 
-KUBE_RBAC_PROXY_IMAGE_OVERRIDE=${IMAGE_REPO}/brancz/kube-rbac-proxy:latest
-sed -i 's,image: .*,image: '"${KUBE_RBAC_PROXY_IMAGE_OVERRIDE}"',' ./config/default-with-metrics-port/manager_auth_proxy_patch.yaml
-
-make release-manifests-metrics-port \
+make release-manifests \
   RELEASE_DIR="out" \
   IMG="${IMAGE_REPO}/kubernetes-sigs/cluster-api-provider-cloudstack/release/manager:$IMAGE_TAG"
 

--- a/projects/kubernetes-sigs/cluster-api-provider-cloudstack/patches/0001-Support-re-assignment-of-another-failure-domain-when.patch
+++ b/projects/kubernetes-sigs/cluster-api-provider-cloudstack/patches/0001-Support-re-assignment-of-another-failure-domain-when.patch
@@ -1,7 +1,7 @@
-From 4d8718335eb653e78deda8cfcc8dfbbf0521e484 Mon Sep 17 00:00:00 2001
+From c622e1051f7f1a08afb06cdfb00789f0dec6e5d8 Mon Sep 17 00:00:00 2001
 From: Jhaanvi Golani <jhaanvi@amazon.com>
 Date: Mon, 11 Mar 2024 17:32:24 -0700
-Subject: [PATCH] Support re-assignment of another failure domain when the
+Subject: [PATCH 1/2] Support re-assignment of another failure domain when the
  machine failed to provision
 
 Signed-off-by: Jhaanvi Golani <jhaanvi@amazon.com>

--- a/projects/kubernetes-sigs/cluster-api-provider-cloudstack/patches/0002-Remove-kube-rbac-proxy.patch
+++ b/projects/kubernetes-sigs/cluster-api-provider-cloudstack/patches/0002-Remove-kube-rbac-proxy.patch
@@ -1,0 +1,172 @@
+From c7c26125f3bc6dc6e10f47b8f7cfdc89f122713f Mon Sep 17 00:00:00 2001
+From: rajeshvenkata <rajesh.venkat.p@gmail.com>
+Date: Wed, 11 Jun 2025 14:19:27 -0700
+Subject: [PATCH 2/2] Remove kube-rbac-proxy
+
+---
+ Makefile                                      |  7 +-----
+ .../auth_proxy_client_clusterrole.yaml        |  9 --------
+ .../auth_proxy_role.yaml                      | 17 --------------
+ .../auth_proxy_role_binding.yaml              | 12 ----------
+ .../auth_proxy_service.yaml                   | 15 -------------
+ .../kustomization.yaml                        | 14 ------------
+ .../manager_auth_proxy_patch.yaml             | 22 -------------------
+ 7 files changed, 1 insertion(+), 95 deletions(-)
+ delete mode 100644 config/default-with-metrics-port/auth_proxy_client_clusterrole.yaml
+ delete mode 100644 config/default-with-metrics-port/auth_proxy_role.yaml
+ delete mode 100644 config/default-with-metrics-port/auth_proxy_role_binding.yaml
+ delete mode 100644 config/default-with-metrics-port/auth_proxy_service.yaml
+ delete mode 100644 config/default-with-metrics-port/kustomization.yaml
+ delete mode 100644 config/default-with-metrics-port/manager_auth_proxy_patch.yaml
+
+diff --git a/Makefile b/Makefile
+index 8c8adb1..1cfa323 100644
+--- a/Makefile
++++ b/Makefile
+@@ -328,16 +328,11 @@ clean: ## Cleans up everything.
+ .PHONY: release-manifests
+ RELEASE_MANIFEST_TARGETS=$(RELEASE_DIR)/infrastructure-components.yaml $(RELEASE_DIR)/metadata.yaml
+ RELEASE_MANIFEST_INPUTS=$(KUSTOMIZE) config/.flag.mk $(shell find config)
+-RELEASE_MANIFEST_SOURCE_BASE ?= config/default
+ release-manifests: $(RELEASE_MANIFEST_TARGETS) ## Create kustomized release manifest in $RELEASE_DIR (defaults to out).
+ $(RELEASE_DIR)/%: $(RELEASE_MANIFEST_INPUTS)
+ 	@mkdir -p $(RELEASE_DIR)
+ 	cp metadata.yaml $(RELEASE_DIR)/metadata.yaml
+-	$(KUSTOMIZE) build $(RELEASE_MANIFEST_SOURCE_BASE) > $(RELEASE_DIR)/infrastructure-components.yaml
+-
+-.PHONY: release-manifests-metrics-port
+-release-manifests-metrics-port:
+-	make release-manifests RELEASE_MANIFEST_SOURCE_BASE=config/default-with-metrics-port
++	kustomize build config/default > $(RELEASE_DIR)/infrastructure-components.yaml
+ 
+ .PHONY: release-staging
+ release-staging: ## Builds and uploads manifests to the staging bucket and creates new tag
+diff --git a/config/default-with-metrics-port/auth_proxy_client_clusterrole.yaml b/config/default-with-metrics-port/auth_proxy_client_clusterrole.yaml
+deleted file mode 100644
+index 51a75db..0000000
+--- a/config/default-with-metrics-port/auth_proxy_client_clusterrole.yaml
++++ /dev/null
+@@ -1,9 +0,0 @@
+-apiVersion: rbac.authorization.k8s.io/v1
+-kind: ClusterRole
+-metadata:
+-  name: metrics-reader
+-rules:
+-- nonResourceURLs:
+-  - "/metrics"
+-  verbs:
+-  - get
+diff --git a/config/default-with-metrics-port/auth_proxy_role.yaml b/config/default-with-metrics-port/auth_proxy_role.yaml
+deleted file mode 100644
+index 80e1857..0000000
+--- a/config/default-with-metrics-port/auth_proxy_role.yaml
++++ /dev/null
+@@ -1,17 +0,0 @@
+-apiVersion: rbac.authorization.k8s.io/v1
+-kind: ClusterRole
+-metadata:
+-  name: proxy-role
+-rules:
+-- apiGroups:
+-  - authentication.k8s.io
+-  resources:
+-  - tokenreviews
+-  verbs:
+-  - create
+-- apiGroups:
+-  - authorization.k8s.io
+-  resources:
+-  - subjectaccessreviews
+-  verbs:
+-  - create
+diff --git a/config/default-with-metrics-port/auth_proxy_role_binding.yaml b/config/default-with-metrics-port/auth_proxy_role_binding.yaml
+deleted file mode 100644
+index ec7acc0..0000000
+--- a/config/default-with-metrics-port/auth_proxy_role_binding.yaml
++++ /dev/null
+@@ -1,12 +0,0 @@
+-apiVersion: rbac.authorization.k8s.io/v1
+-kind: ClusterRoleBinding
+-metadata:
+-  name: proxy-rolebinding
+-roleRef:
+-  apiGroup: rbac.authorization.k8s.io
+-  kind: ClusterRole
+-  name: proxy-role
+-subjects:
+-- kind: ServiceAccount
+-  name: controller-manager
+-  namespace: system
+diff --git a/config/default-with-metrics-port/auth_proxy_service.yaml b/config/default-with-metrics-port/auth_proxy_service.yaml
+deleted file mode 100644
+index dcb3b89..0000000
+--- a/config/default-with-metrics-port/auth_proxy_service.yaml
++++ /dev/null
+@@ -1,15 +0,0 @@
+-apiVersion: v1
+-kind: Service
+-metadata:
+-  labels:
+-    control-plane: controller-manager
+-  name: controller-manager-metrics-service
+-  namespace: system
+-spec:
+-  ports:
+-  - name: https
+-    port: 8443
+-    protocol: TCP
+-    targetPort: https
+-  selector:
+-    control-plane: capc-controller-manager
+diff --git a/config/default-with-metrics-port/kustomization.yaml b/config/default-with-metrics-port/kustomization.yaml
+deleted file mode 100644
+index 7811196..0000000
+--- a/config/default-with-metrics-port/kustomization.yaml
++++ /dev/null
+@@ -1,14 +0,0 @@
+-apiVersion: kustomize.config.k8s.io/v1beta1
+-kind: Kustomization
+-
+-bases:
+-- ../default
+-
+-resources:
+-- auth_proxy_client_clusterrole.yaml
+-- auth_proxy_role.yaml
+-- auth_proxy_role_binding.yaml
+-- auth_proxy_service.yaml
+-
+-patchesStrategicMerge:
+-  - manager_auth_proxy_patch.yaml
+\ No newline at end of file
+diff --git a/config/default-with-metrics-port/manager_auth_proxy_patch.yaml b/config/default-with-metrics-port/manager_auth_proxy_patch.yaml
+deleted file mode 100644
+index d4f6481..0000000
+--- a/config/default-with-metrics-port/manager_auth_proxy_patch.yaml
++++ /dev/null
+@@ -1,22 +0,0 @@
+-# This patch inject a sidecar container which is a HTTP proxy for the
+-# controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+-apiVersion: apps/v1
+-kind: Deployment
+-metadata:
+-  name: controller-manager
+-  namespace: system
+-spec:
+-  template:
+-    spec:
+-      containers:
+-      - name: kube-rbac-proxy
+-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+-        args:
+-        - "--secure-listen-address=0.0.0.0:8443"
+-        - "--upstream=http://127.0.0.1:8080/"
+-        - "--logtostderr=true"
+-        - "--v=10"
+-        ports:
+-        - containerPort: 8443
+-          protocol: TCP
+-          name: https
+-- 
+2.49.0
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In the CAPC upgrade from v0.5.0 to v0.6.0 cluster creation failed because CAPC controller pod kept crashing due to the 8443 port conflicts from [kube-rbac-proxy](https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack/blob/main/config/default-with-metrics-port/manager_auth_proxy_patch.yaml#L15) and CAPI diagnostic feature (enabled in [v0.6.0](https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack/blob/v0.6.0/config/manager/manager.yaml#L27))


Looks like int the past, rbac proxy was added as a workaround to serve metrics. With diagnostic feature enabled, I believe this rbac proxy is not needed because CAPI diagnostic feature now servers the same purpose - serving metrics endpoint via https (8443)and protected via authentication and authorization.


Given that is it not needed now and also the port conflicts issue, adding patch in CAPC to remove kube-rbac-proxy and modifying the build commands to use release-manifests

*Testing*
Ran local e2e test with new local CAPC built image
![Screenshot 2025-06-12 at 2 07 20 PM](https://github.com/user-attachments/assets/c4a4915e-ed2f-4eb9-96c4-123becfa8081)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

