### PR TITLE
Update checksums for fluxcd/source-controller

### DIFF
--- a/projects/fluxcd/source-controller/CHECKSUMS
+++ b/projects/fluxcd/source-controller/CHECKSUMS
@@ -1,2 +1,2 @@
-7e6a84ca0b926e4c72a92bce9ed502e04b7253b04c70494c8a6c3300022e80ab  _output/bin/source-controller/linux-amd64/source-controller
-7481e5e41d010ea26a2d6cd45d7f590b1e9a64b3409f15a3ccbd2d56964a0f49  _output/bin/source-controller/linux-arm64/source-controller
+dfad5af112713f5d083e085bdc1c69f5142bdb8cbdd66b0a7c071fb3bbea47b3  _output/bin/source-controller/linux-amd64/source-controller
+7d1ffa30045619f2591794360067b86918cb75c173c0f061d4a7a06436cb6f58  _output/bin/source-controller/linux-arm64/source-controller


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
fluxcd/source-controller build job is failing due to checksums mismatch issue. Updating correct checksums in this PR

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

