### PR TITLE
Fix nutanix-rhel-8 presubmit

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0005-Nutanix-improvements.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0005-Nutanix-improvements.patch
@@ -1,4 +1,4 @@
-From 78f07866d07217514ecc0c56e8ad67846ccaab30 Mon Sep 17 00:00:00 2001
+From 916c57dd3fca5c1d53ebcf14db486555f16d9d89 Mon Sep 17 00:00:00 2001
 From: Ilya Alekseyev <ilya.alekseyev@nutanix.com>
 Date: Wed, 11 Oct 2023 22:07:22 -0400
 Subject: [PATCH 05/13] Nutanix improvements
@@ -9,9 +9,9 @@ Subject: [PATCH 05/13] Nutanix improvements
 Signed-off-by: Vignesh Goutham Ganesh <vgg@amazon.com>
 ---
  images/capi/packer/nutanix/packer.json.tmpl | 5 +++--
- images/capi/packer/nutanix/rhel-8.json      | 1 -
- images/capi/packer/nutanix/rhel-9.json      | 1 -
- 3 files changed, 3 insertions(+), 4 deletions(-)
+ images/capi/packer/nutanix/rhel-8.json      | 2 +-
+ images/capi/packer/nutanix/rhel-9.json      | 2 +-
+ 3 files changed, 5 insertions(+), 4 deletions(-)
 
 diff --git a/images/capi/packer/nutanix/packer.json.tmpl b/images/capi/packer/nutanix/packer.json.tmpl
 index f53c51514..3d4e875b0 100644
@@ -37,29 +37,33 @@ index f53c51514..3d4e875b0 100644
      "ssh_username": "builder",
      "vm_force_delete": "true"
 diff --git a/images/capi/packer/nutanix/rhel-8.json b/images/capi/packer/nutanix/rhel-8.json
-index 9aba21d66..b2bef7674 100644
+index 9aba21d66..718984aef 100644
 --- a/images/capi/packer/nutanix/rhel-8.json
 +++ b/images/capi/packer/nutanix/rhel-8.json
-@@ -5,7 +5,6 @@
+@@ -5,8 +5,8 @@
    "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8",
    "extra_rpms": "",
    "guest_os_type": "Linux",
 -  "image_url": "https://REPLACE_YOUR_SERVER/redhat/8/rhel-8.8-x86_64-kvm.qcow2",
++  "image_url": "{{user `image_url`}}",
    "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm",
    "shutdown_command": "shutdown -P now",
    "user_data": "I2Nsb3VkLWNvbmZpZwp1c2VyczoKICAtIG5hbWU6IGJ1aWxkZXIKICAgIHN1ZG86IFsnQUxMPShBTEwpIE5PUEFTU1dEOkFMTCddCmNocGFzc3dkOgogIGxpc3Q6IHwKICAgIGJ1aWxkZXI6YnVpbGRlcgogIGV4cGlyZTogRmFsc2UKc3NoX3B3YXV0aDogVHJ1ZQ=="
+ }
 diff --git a/images/capi/packer/nutanix/rhel-9.json b/images/capi/packer/nutanix/rhel-9.json
-index b7dddb4f2..921a9729f 100644
+index b7dddb4f2..c49a1a656 100644
 --- a/images/capi/packer/nutanix/rhel-9.json
 +++ b/images/capi/packer/nutanix/rhel-9.json
-@@ -5,7 +5,6 @@
+@@ -5,8 +5,8 @@
    "epel_rpm_gpg_key": "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-9",
    "extra_rpms": "",
    "guest_os_type": "Linux",
 -  "image_url": "https://REPLACE_YOUR_SERVER/redhat/9/rhel-9.2-x86_64-kvm.qcow2",
++  "image_url": "{{user `image_url`}}",
    "redhat_epel_rpm": "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm",
    "shutdown_command": "shutdown -P now",
    "user_data": "I2Nsb3VkLWNvbmZpZwp1c2VyczoKICAtIG5hbWU6IGJ1aWxkZXIKICAgIHN1ZG86IFsnQUxMPShBTEwpIE5PUEFTU1dEOkFMTCddCmNocGFzc3dkOgogIGxpc3Q6IHwKICAgIGJ1aWxkZXI6YnVpbGRlcgogIGV4cGlyZTogRmFsc2UKc3NoX3B3YXV0aDogVHJ1ZQ=="
+ }
 -- 
 2.49.0
 


### PR DESCRIPTION
*Description of changes:*

Image-builder presubmit is failing with
```1 error(s) occurred:

* disk 0: source_image_delete can be used only with source_image_path or
source_image_uri
```
Adding image_url back to rhel-8.json and rhel-9.json fixed the issue



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
