### PR TITLE
Update gitignore file to point to new repo

### DIFF
--- a/projects/tinkerbell/actions/.gitignore
+++ b/projects/tinkerbell/actions/.gitignore
@@ -1,1 +1,1 @@
-hub
+actions


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The CI builds failed because the gitIgnore file was still pointing to the old repo name. Update gitignore to point to the new repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
