### PR TITLE
Use archived apt repositories for buster as original ones are deprecated

### DIFF
--- a/projects/goharbor/harbor/docker/linux/harbor-portal/Dockerfile
+++ b/projects/goharbor/harbor/docker/linux/harbor-portal/Dockerfile
@@ -8,7 +8,10 @@ COPY _output/harbor-portal/ /
 
 ENV NPM_CONFIG_REGISTRY=https://registry.npmjs.org
 
-RUN apt-get update \
+RUN sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list \
+    && sed -i 's|http://deb.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list \
+    && sed -i '/buster-updates/d' /etc/apt/sources.list \
+    && apt-get update \
     && apt-get install -y --no-install-recommends python-yaml \
     && npm install --unsafe-perm \ 
     && npm run generate-build-timestamp \


### PR DESCRIPTION
*Description of changes:*
[harbor-tooling-presubmit](https://prow.eks.amazonaws.com/view/s3/prowpresubmitsdataclusterstack-prowbucket7c73355c-vfwwxd2eb4gp/pr-logs/pull/aws_eks-anywhere-build-tooling/4600/harbor-tooling-presubmit/1947207287193997312) job is failing as it's unable to fetch apt repositories of buster release. This is because buster has reached end of life. So, we will be using archived repositories going forward. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
