### PR TITLE
Patch smee deployment.yaml on upstream chart

### DIFF
--- a/projects/tinkerbell/charts/helm/patches/0001-Load-stream-model-for-nginx-and-update-http2-command.patch
+++ b/projects/tinkerbell/charts/helm/patches/0001-Load-stream-model-for-nginx-and-update-http2-command.patch
@@ -1,7 +1,7 @@
 From bb2527578cca77908f80981c3f871a1faec3b193 Mon Sep 17 00:00:00 2001
 From: Ahree Hong <ahreeh@amazon.com>
 Date: Thu, 13 Jun 2024 11:20:37 -0700
-Subject: [PATCH] Load stream model for nginx and update http2 command
+Subject: [PATCH 1/2] Load stream model for nginx and update http2 command
 
 Signed-off-by: Ahree Hong <ahreeh@amazon.com>
 ---

--- a/projects/tinkerbell/charts/helm/patches/0002-Fix-smee-deployment-tolerations-rendering.patch
+++ b/projects/tinkerbell/charts/helm/patches/0002-Fix-smee-deployment-tolerations-rendering.patch
@@ -1,0 +1,36 @@
+From 1ac5855e0fb23daa7b1699636eca91bdb8c48ac6 Mon Sep 17 00:00:00 2001
+From: Rahul Ganesh <rahulgab@amazon.com>
+Date: Thu, 31 Jul 2025 22:52:48 +0000
+Subject: [PATCH 2/2] Fix smee deployment tolerations rendering
+
+This patch fixes an issue with the smee chart's deployment.yaml file
+where the tolerations section is rendered incorrectly when both
+.Values.deployment.tolerations (which is an empty array by default) and
+.Values.singleNodeClusterConfig.controlPlaneTolerationsEnabled are true.
+This results in invalid YAML that causes the chart to fail to render.
+
+This change renders .Values.deployment.tolerations only if
+.Values.singleNodeClusterConfig.controlPlaneTolerationsEnabled is false.
+
+Signed-off-by: Rahul Ganesh <rahulgab@amazon.com>
+---
+ tinkerbell/smee/templates/deployment.yaml | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/tinkerbell/smee/templates/deployment.yaml b/tinkerbell/smee/templates/deployment.yaml
+index 9f099c3..b3e8724 100644
+--- a/tinkerbell/smee/templates/deployment.yaml
++++ b/tinkerbell/smee/templates/deployment.yaml
+@@ -165,7 +165,9 @@ spec:
+       {{- end }}
+       {{- if or .Values.deployment.tolerations .Values.singleNodeClusterConfig.controlPlaneTolerationsEnabled }}
+       tolerations:
++      {{- if and .Values.deployment.tolerations (not .Values.singleNodeClusterConfig.controlPlaneTolerationsEnabled) }}
+       {{- .Values.deployment.tolerations | toYaml | nindent 8 }}
++      {{- end }}
+       {{- if .Values.singleNodeClusterConfig.controlPlaneTolerationsEnabled }}
+       {{- include "singleNodeClusterConfig" . | indent 6 }}
+       {{- end }}
+-- 
+2.47.1
+


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Upstream chart values.yaml for smee had an issue rendering tolerations when Values.singleNodeClusterConfig.controlPlaneTolerationsEnabled is set to True. Patch the chart to conditionally apply tolerations when singleNodeClusterConfig settings are not set. With singleNodeClusterconfig set on the values-override yaml below is the error message we see:

`
{"stderr": "Pulled: public.ecr.aws/l0g8r8j6/tinkerbell/stack:0.6.2-eks-a-v0.24.0-dev-build.58\nDigest: sha256:26d12a718d65781f728fd3ca2f7022986f128ac51a8ba6a879396ab3bfe3606c\nError: YAML parse error on stack/charts/smee/templates/deployment.yaml: error converting YAML to JSON: yaml: line 128: did not find expected key\n"}
` 

Testing: 
Built a patched version of chart and was able to deploy successfully with single node cluster config enabled on values-override.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
