### PR TITLE
[release-0.22] Fix rufio checksum

### DIFF
--- a/projects/tinkerbell/rufio/CHECKSUMS
+++ b/projects/tinkerbell/rufio/CHECKSUMS
@@ -1,1 +1,2 @@
 2eb115e623f2646900c3fb4459e02e9345fbe3122cd3981470763fa9c0a2c9dc  _output/bin/rufio/linux-amd64/manager
+036e663adbf7e082c793c14daffa67207e6461eb145e7e93f63cc8c137b5f434  _output/bin/rufio/linux-arm64/manager


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
rufio arm binary checksum was removed in previous version bump commit, adding it back

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
