### PR TITLE
Fix ecr-credential-provider checksums for new builder-base

### DIFF
--- a/projects/kubernetes/cloud-provider-aws/1-32/CHECKSUMS
+++ b/projects/kubernetes/cloud-provider-aws/1-32/CHECKSUMS
@@ -1,2 +1,2 @@
-cf2707e73b0ff0a2c2451ddb2496f097c3f72a80733cedfa2018b8f811647853  _output/1-32/bin/cloud-provider-aws/linux-amd64/ecr-credential-provider
-30e408db8e9e04cf03cb207b6b07c542d1cc3a62eb5dc5ca03f369d805e86e9d  _output/1-32/bin/cloud-provider-aws/linux-arm64/ecr-credential-provider
+dc70cd74694410aa8ab46b86f79172577795720a3835addd265c4f07c17e0505  _output/1-32/bin/cloud-provider-aws/linux-amd64/ecr-credential-provider
+f924d34039afa74b18c3ea801b96d49d101fe9d18e1463d951e3b9583de75a47  _output/1-32/bin/cloud-provider-aws/linux-arm64/ecr-credential-provider

--- a/projects/kubernetes/cloud-provider-aws/1-33/CHECKSUMS
+++ b/projects/kubernetes/cloud-provider-aws/1-33/CHECKSUMS
@@ -1,2 +1,2 @@
-142ad13e6655cae05553686923222cf908a402380c1cd73175492e5d9aa85cb6  _output/1-33/bin/cloud-provider-aws/linux-amd64/ecr-credential-provider
-a9201708aac6785eb1f2f1c80629933d8fa46125c4cff79e654ff33ae08f0c89  _output/1-33/bin/cloud-provider-aws/linux-arm64/ecr-credential-provider
+741334760a899a14e20268258dd94c12d7ff74b4a0b40e8531dc110b009c2276  _output/1-33/bin/cloud-provider-aws/linux-amd64/ecr-credential-provider
+83f97c6d5af699a82903c496383a49373a6bc2929fcbe224539a09f9622a902c  _output/1-33/bin/cloud-provider-aws/linux-arm64/ecr-credential-provider


### PR DESCRIPTION
*Description of changes:*
aws-eks-anywhere-build-tooling-checksums-update [codebuild job](https://tiny.amazon.com/y79lh06p/IsenLink) missed updating checksums in [PR](https://github.com/aws/eks-anywhere-build-tooling/pull/4812)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
