### PR TITLE
fix image builder brittle goos check to support all registry urls

### DIFF
--- a/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0002-EKS-D-support-and-changes.patch
@@ -182,7 +182,7 @@ index ca6761d16..b89075504 100644
  {{if and (eq .Vars.kubernetes_source_type "http") (eq .Vars.kubernetes_cni_source_type "http") (not .Vars.kubernetes_load_additional_imgs)}}
  # The second last pipe of awk is to take out arch from kube-apiserver-amd64 (i.e. amd64 or any other arch)
 -  crictl images | grep -v 'IMAGE ID' | awk '{print $1}' | awk -F'/' '{print $NF}' | sed 's/-{{ .Vars.arch }}//g' | sort:
-+  crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $4}' | sed 's/-{{ .Vars.arch }}//g' | sort:
++  crictl images -o json | jq -r '.images[] | (.repoTags // [] + .repoDigests // [])[]' | awk -F'[:/]' '{print $(NF-1)}' | sed 's/-{{ .Vars.arch }}//g' | sort -u:
      exit-status: 0
      stderr: []
      timeout: 0
@@ -197,7 +197,7 @@ index ca6761d16..b89075504 100644
  {{if and (eq .Vars.kubernetes_source_type "http") (eq .Vars.kubernetes_cni_source_type "http") (.Vars.kubernetes_load_additional_imgs)}}
  # The second last pipe of awk is to take out arch from kube-apiserver-amd64 (i.e. amd64 or any other arch)
 -  crictl images | grep -v 'IMAGE ID' | awk '{print $1}' | awk -F'/' '{print $NF}' | sed 's/-{{ .Vars.arch }}//g' | sort:
-+  crictl images | grep -v 'IMAGE ID' | awk -F'[ /]' '{print $4}' | sed 's/-{{ .Vars.arch }}//g' | sort:
++  crictl images -o json | jq -r '.images[] | (.repoTags // [] + .repoDigests // [])[]' | awk -F'[:/]' '{print $(NF-1)}' | sed 's/-{{ .Vars.arch }}//g' | sort -u:
      exit-status: 0
      stderr: []
      timeout: 0


### PR DESCRIPTION
*Description of changes:*
Brittle command to list imported images is causing an issue with newer repoTag format of eks-d kube-apiserver, kube-proxy etc. images. 
```
subbusrv@7cf34dd53a0c eksd % jq -r '.[].RepoTags[]' kube-apiserver-57/manifest.json
public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.28.15-eks-1-28-57

subbusrv@7cf34dd53a0c eksd % jq -r '.[].RepoTags[]' kube-apiserver-58/manifest.json
registry.k8s.io/kube-apiserver-amd64:v1.28.15-eks-e386d34
719983614556.dkr.ecr.us-west-2.amazonaws.com/kube-apiserver-amd64:v1.28.15
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
