### PR TITLE
Increase default disk size for raw image-builder builds

### DIFF
--- a/projects/aws/image-builder/builder/builder.go
+++ b/projects/aws/image-builder/builder/builder.go
@@ -201,15 +201,22 @@ func (b *BuildOptions) BuildImage() {
 		}
 
 		baremetalConfigFile := filepath.Join(imageBuilderProjectPath, packerBaremetalConfigFile)
-		if b.BaremetalConfig != nil {
-			baremetalConfigData, err := json.Marshal(b.BaremetalConfig)
-			if err != nil {
-				log.Fatalf("Error marshalling baremetal config data: %v", err)
-			}
-			err = ioutil.WriteFile(baremetalConfigFile, baremetalConfigData, 0o644)
-			if err != nil {
-				log.Fatalf("Error writing baremetal config file to packer: %v", err)
-			}
+		if b.BaremetalConfig == nil {
+			b.BaremetalConfig = &BaremetalConfig{}
+		}
+		if b.BaremetalConfig.DiskSizeMb == "" {
+			b.BaremetalConfig.DiskSizeMb = DefaultBaremetalDiskSizeMb
+			log.Printf("Using default disk size: %s MB", b.BaremetalConfig.DiskSizeMb)
+		} else {
+			log.Printf("Using configured disk size: %s MB", b.BaremetalConfig.DiskSizeMb)
+		}
+		baremetalConfigData, err := json.Marshal(b.BaremetalConfig)
+		if err != nil {
+			log.Fatalf("Error marshalling baremetal config data: %v", err)
+		}
+		err = ioutil.WriteFile(baremetalConfigFile, baremetalConfigData, 0o644)
+		if err != nil {
+			log.Fatalf("Error writing baremetal config file to packer: %v", err)
 		}
 
 		var buildCommand string
@@ -229,7 +236,7 @@ func (b *BuildOptions) BuildImage() {
 			commandEnvVars = append(commandEnvVars, fmt.Sprintf("%s=%s", packerTypeVarFilesEnvVar, baremetalConfigFile))
 		}
 
-		err := executeMakeBuildCommand(buildCommand, commandEnvVars...)
+		err = executeMakeBuildCommand(buildCommand, commandEnvVars...)
 		if err != nil {
 			log.Fatalf("Error executing image-builder for raw hypervisor: %v", err)
 		}

--- a/projects/aws/image-builder/builder/constants.go
+++ b/projects/aws/image-builder/builder/constants.go
@@ -10,6 +10,7 @@ const (
 	DefaultAMIVolumeSize           string = "25"
 	DefaultAMIVolumeType           string = "gp3"
 	DefaultAMIManifestOutput       string = "manifest.json"
+	DefaultBaremetalDiskSizeMb     string = "6656"
 
 	// Paths and URLs
 	buildToolingRepoUrl              string = "https://github.com/aws/eks-anywhere-build-tooling.git"

--- a/projects/aws/image-builder/builder/types.go
+++ b/projects/aws/image-builder/builder/types.go
@@ -84,6 +84,7 @@ type VsphereConfig struct {
 }
 
 type BaremetalConfig struct {
+	DiskSizeMb string `json:"disk_size,omitempty"`
 	IsoConfig
 	RhelConfig
 	ProxyConfig

--- a/projects/aws/image-builder/cmd/build.go
+++ b/projects/aws/image-builder/cmd/build.go
@@ -206,6 +206,11 @@ func ValidateInputs(bo *builder.BuildOptions) error {
 					return err
 				}
 			}
+			if bo.BaremetalConfig != nil && bo.BaremetalConfig.DiskSizeMb != "" {
+				if _, err := strconv.Atoi(bo.BaremetalConfig.DiskSizeMb); err != nil {
+					return fmt.Errorf("parsing disk_size in baremetal config: %w", err)
+				}
+			}
 			if err = validateRHSM(bo.Os, &bo.BaremetalConfig.RhsmConfig); err != nil {
 				return err
 			}


### PR DESCRIPTION
*Description of changes:*

1-33-redhat-8-raw, 1-30-redhat-8-raw, 1-29-redhat-8-raw, 1-28-redhat-8-raw builds are failing due to packer builder vm running out of default configured 6gb disk size, with the latest eks-d release. 

This PR configures the default disk size for raw image building to 6.5gb overriding the [upstream default](https://github.com/kubernetes-sigs/image-builder/blob/main/images/capi/packer/raw/packer.json.tmpl#L173) of 6gb using [user defined packer config parameter](https://github.com/kubernetes-sigs/image-builder/blob/main/images/capi/packer/raw/packer.json.tmpl#L16)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
