### PR TITLE
Fix containerd path for aws upgrader and tinkerbell hook projects

### DIFF
--- a/projects/aws/upgrader/docker/linux/Dockerfile
+++ b/projects/aws/upgrader/docker/linux/Dockerfile
@@ -14,7 +14,7 @@ ARG TARGETOS
 
 COPY --from=builder /newroot /
 
-COPY _output/$RELEASE_BRANCH/dependencies/$TARGETOS-$TARGETARCH/eksa/containerd/containerd/$RELEASE_BRANCH /eksa-upgrades/binaries/containerd
+COPY _output/$RELEASE_BRANCH/dependencies/$TARGETOS-$TARGETARCH/eksa/containerd/containerd /eksa-upgrades/binaries/containerd
 COPY _output/$RELEASE_BRANCH/dependencies/$TARGETOS-$TARGETARCH/eksa/kubernetes-sigs/cri-tools /eksa-upgrades/binaries/containerd/usr/local/bin
 COPY _output/$RELEASE_BRANCH/dependencies/$TARGETOS-$TARGETARCH/eksd/cni-plugins /eksa-upgrades/binaries/cni-plugins/opt/cni/bin
 COPY _output/$RELEASE_BRANCH/dependencies/$TARGETOS-$TARGETARCH/eksd/kubernetes/client/bin /eksa-upgrades/binaries/kubernetes/usr/bin
@@ -23,8 +23,8 @@ COPY _output/$RELEASE_BRANCH/dependencies/$TARGETOS-$TARGETARCH/eksd/kubernetes/
     /eksa-upgrades/binaries/kubernetes/usr/bin/
 COPY _output/bin/upgrader/$TARGETOS-$TARGETARCH/upgrader /eksa-upgrades/tools/
 
-COPY _output/$RELEASE_BRANCH/dependencies/$TARGETOS-$TARGETARCH/eksa/containerd/containerd/$RELEASE_BRANCH/usr/local/bin/CONTAINERD_ATTRIBUTION.txt /THIRD_PARTY_LICENSES/CONTAINERD_ATTRIBUTION.txt
-COPY _output/$RELEASE_BRANCH/dependencies/$TARGETOS-$TARGETARCH/eksa/containerd/containerd/$RELEASE_BRANCH/usr/local/sbin/RUNC_ATTRIBUTION.txt /THIRD_PARTY_LICENSES/RUNC_ATTRIBUTION.txt
+COPY _output/$RELEASE_BRANCH/dependencies/$TARGETOS-$TARGETARCH/eksa/containerd/containerd/usr/local/bin/CONTAINERD_ATTRIBUTION.txt /THIRD_PARTY_LICENSES/CONTAINERD_ATTRIBUTION.txt
+COPY _output/$RELEASE_BRANCH/dependencies/$TARGETOS-$TARGETARCH/eksa/containerd/containerd/usr/local/sbin/RUNC_ATTRIBUTION.txt /THIRD_PARTY_LICENSES/RUNC_ATTRIBUTION.txt
 COPY _output/$RELEASE_BRANCH/dependencies/$TARGETOS-$TARGETARCH/eksa/kubernetes-sigs/cri-tools/ATTRIBUTION.txt /THIRD_PARTY_LICENSES/CRI-TOOLS_ATTRIBUTION.txt
 COPY _output/$RELEASE_BRANCH/dependencies/$TARGETOS-$TARGETARCH/eksa/kubernetes-sigs/cri-tools/LICENSES /THIRD_PARTY_LICENSES/CRI-TOOLS_LICENSES
 COPY _output/$RELEASE_BRANCH/dependencies/$TARGETOS-$TARGETARCH/eksd/cni-plugins/ATTRIBUTION.txt /THIRD_PARTY_LICENSES/CNI-PLUGINS_ATTRIBUTION.txt

--- a/projects/tinkerbell/hook/docker/linux/hook-containerd/Dockerfile
+++ b/projects/tinkerbell/hook/docker/linux/hook-containerd/Dockerfile
@@ -14,9 +14,10 @@ WORKDIR /
 
 ARG TARGETOS
 ARG TARGETARCH
+ARG RELEASE_BRANCH
 
 COPY --from=builder /etc/init.d/ /etc/init.d/
 COPY --from=builder /opt/containerd/ /opt/containerd/
 
-COPY _output/$RELEASE_BRANCH/dependencies/$TARGETOS-$TARGETARCH/eksa/containerd/containerd/$RELEASE_BRANCH/usr/local/bin /usr/bin
+COPY _output/$RELEASE_BRANCH/dependencies/$TARGETOS-$TARGETARCH/eksa/containerd/containerd/usr/local/bin /usr/bin
 COPY hook/images/hook-containerd/etc /etc/

--- a/projects/tinkerbell/hook/docker/linux/hook-runc/Dockerfile
+++ b/projects/tinkerbell/hook/docker/linux/hook-runc/Dockerfile
@@ -15,8 +15,9 @@ WORKDIR /
 
 ARG TARGETOS
 ARG TARGETARCH
+ARG RELEASE_BRANCH
 
 COPY --from=builder /etc/init.d/ /etc/init.d/
 COPY --from=builder /etc/shutdown.d/ /etc/shutdown.d/
 
-COPY _output/$RELEASE_BRANCH/dependencies/$TARGETOS-$TARGETARCH/eksa/containerd/containerd/1-33/usr/local/sbin /usr/bin
+COPY _output/$RELEASE_BRANCH/dependencies/$TARGETOS-$TARGETARCH/eksa/containerd/containerd/usr/local/sbin /usr/bin


### PR DESCRIPTION
*Description of changes:*
aws-upgrader and tinkerbell-hook builds failed because incorrect path fomation for containerd project.

For aws-upgrader the error is,
```
#23 ERROR: failed to calculate checksum of ref krvwejcputolyisq6di6cv0sq::khip1xkuulzwx0merczlo50nc: "/_output/1-28/dependencies/linux-amd64/eksa/containerd/containerd/1-28/usr/local/sbin/RUNC_ATTRIBUTION.txt": not found
```

For tinkerbell-hook, the error is,
```
#13 ERROR: failed to calculate checksum of ref 0s1l7f6v3hrcy5lraz1gyg9vv::mu52lh6uotb2gbxpdgwvp35ov: "/_output/dependencies/linux-arm64/eksa/containerd/containerd/1-33/usr/local/sbin": not found
```

The PR will fix these issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
