### PR TITLE
Fix kind build

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -138,7 +138,6 @@ else ifneq ($(IS_RELEASE_BRANCH_BUILD),)
 	# avoid warnings when trying to read GIT_TAG file which wont exist when no release_branch is given
 	GIT_TAG=non-existent
 	OUTPUT_DIR=non-existent
-	BINARY_TARGET_FILES=non-existent
 else
 	PROJECT_ROOT?=$(MAKE_ROOT)
 	ARTIFACTS_UPLOAD_PATH?=$(PROJECT_PATH)

--- a/projects/containerd/containerd/Makefile
+++ b/projects/containerd/containerd/Makefile
@@ -4,7 +4,7 @@ GOLANG_VERSION=$(shell cat ./$(RELEASE_BRANCH)/GOLANG_VERSION)
 REPO=containerd
 REPO_OWNER=containerd
 
-BINARY_TARGET_FILES=$(shell cat ./$(RELEASE_BRANCH)/BINARY_TARGET_FILES)
+BINARY_TARGET_FILES=$(if $(RELEASE_BRANCH),$(shell cat ./$(RELEASE_BRANCH)/BINARY_TARGET_FILES),)
 SOURCE_PATTERNS=$(foreach target,$(BINARY_TARGET_FILES),./cmd/$(target))
 
 GITVERSION=$(shell git -C $(REPO) describe --dirty --long --always)


### PR DESCRIPTION
*Description of changes:*

Reverting Common.mk change made for containerd as it caused the word function to evaluate against a non-matching entry, producing below error in the kind build,
```
first argument to 'word' function must be greater than 0
```

This PR should fix this issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
