### PR TITLE
Add image_url for Nutanix Ubuntu 24.04

### DIFF
--- a/projects/kubernetes-sigs/image-builder/build/build_image.sh
+++ b/projects/kubernetes-sigs/image-builder/build/build_image.sh
@@ -178,6 +178,8 @@ elif [[ $image_format == "nutanix" ]]; then
       image_url=https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
     elif [[ $image_os_version == "2204" ]]; then
       image_url=https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
+    elif [[ $image_os_version == "2404" ]]; then
+      image_url=https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
     fi
     source_image_name=source-$image_name.img
   fi


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add url of Ubuntu 24.04 image for Nutanix Ubuntu 24.04 build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
