### PR TITLE
increase disk size of Snow admin machine from 60G to 70G

### DIFF
--- a/projects/aws/eks-a-admin-image/eks-a-admin-snow.pkr.hcl
+++ b/projects/aws/eks-a-admin-image/eks-a-admin-snow.pkr.hcl
@@ -31,7 +31,7 @@ source "amazon-ebs" "amazonlinux2" {
   launch_block_device_mappings {
     device_name           = "/dev/xvda"
     delete_on_termination = true
-    volume_size           = 60
+    volume_size           = 70
     volume_type           = "gp3"
     iops                  = 3000
     throughput            = 125


### PR DESCRIPTION
*Issue #, if available:*
Snow cluster provision failed as the admin instance does not have enough space to extract and import container images
```
Error: loading docker image mover source: loading images from file: write /usr/bin/dockerd: no space left on device
```

*Description of changes:*
Increase the disk size from 60G to 70G

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
