### PR TITLE
Use EKS-D v1.34 dev release assets

### DIFF
--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -58,3 +58,4 @@ releases:
   endOfStandardSupport: "2026-12-31"
   kubeVersion: v1.34.0
   number: 3
+  dev: true


### PR DESCRIPTION
*Issue #, if available:*
[#3477](https://github.com/aws/eks-anywhere-internal/issues/3477)

*Description of changes:*
EKS-D has not yet completed their v1.34 production launch so we should use dev artifacts until they do.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
