### PR TITLE
Add patch for adding endpointsslices to kube-vip role in tink charts

### DIFF
--- a/projects/tinkerbell/charts/helm/patches/0001-Load-stream-model-for-nginx-and-update-http2-command.patch
+++ b/projects/tinkerbell/charts/helm/patches/0001-Load-stream-model-for-nginx-and-update-http2-command.patch
@@ -1,7 +1,7 @@
-From bb2527578cca77908f80981c3f871a1faec3b193 Mon Sep 17 00:00:00 2001
+From 8a6a7109050ce6c4ff55e389372f7583354d2523 Mon Sep 17 00:00:00 2001
 From: Ahree Hong <ahreeh@amazon.com>
 Date: Thu, 13 Jun 2024 11:20:37 -0700
-Subject: [PATCH 1/2] Load stream model for nginx and update http2 command
+Subject: [PATCH 1/3] Load stream model for nginx and update http2 command
 
 Signed-off-by: Ahree Hong <ahreeh@amazon.com>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Ahree Hong <ahreeh@amazon.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/tinkerbell/stack/templates/nginx-configmap.yaml b/tinkerbell/stack/templates/nginx-configmap.yaml
-index 37f5be0..4b65e86 100644
+index b056ddb..17b1359 100644
 --- a/tinkerbell/stack/templates/nginx-configmap.yaml
 +++ b/tinkerbell/stack/templates/nginx-configmap.yaml
 @@ -8,6 +8,7 @@ metadata:
@@ -31,5 +31,5 @@ index 37f5be0..4b65e86 100644
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 -- 
-2.45.0
+2.49.0
 

--- a/projects/tinkerbell/charts/helm/patches/0002-Fix-smee-deployment-tolerations-rendering.patch
+++ b/projects/tinkerbell/charts/helm/patches/0002-Fix-smee-deployment-tolerations-rendering.patch
@@ -1,7 +1,7 @@
-From 1ac5855e0fb23daa7b1699636eca91bdb8c48ac6 Mon Sep 17 00:00:00 2001
+From 4c413c4c0854876bcc2d6b6b65d196c0e27ac52a Mon Sep 17 00:00:00 2001
 From: Rahul Ganesh <rahulgab@amazon.com>
 Date: Thu, 31 Jul 2025 22:52:48 +0000
-Subject: [PATCH 2/2] Fix smee deployment tolerations rendering
+Subject: [PATCH 2/3] Fix smee deployment tolerations rendering
 
 This patch fixes an issue with the smee chart's deployment.yaml file
 where the tolerations section is rendered incorrectly when both
@@ -32,5 +32,5 @@ index 9f099c3..b3e8724 100644
        {{- include "singleNodeClusterConfig" . | indent 6 }}
        {{- end }}
 -- 
-2.47.1
+2.49.0
 

--- a/projects/tinkerbell/charts/helm/patches/0003-Add-endpointslices-to-kube-vip-clusterrole.patch
+++ b/projects/tinkerbell/charts/helm/patches/0003-Add-endpointslices-to-kube-vip-clusterrole.patch
@@ -1,0 +1,32 @@
+From 0baa4ea23ea3f57d351bdc27fc8c9c581a8c0c72 Mon Sep 17 00:00:00 2001
+From: rajeshvenkata <rajesh.venkat.p@gmail.com>
+Date: Sun, 5 Oct 2025 23:01:00 -0700
+Subject: [PATCH 3/3] Add endpointslices to kube-vip clusterrole
+
+---
+ tinkerbell/stack/templates/kubevip.yaml | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/tinkerbell/stack/templates/kubevip.yaml b/tinkerbell/stack/templates/kubevip.yaml
+index f794fa1..f6486bb 100644
+--- a/tinkerbell/stack/templates/kubevip.yaml
++++ b/tinkerbell/stack/templates/kubevip.yaml
+@@ -84,6 +84,15 @@ rules:
+       - "watch"
+       - "update"
+       - "create"
++  - apiGroups:
++      - "discovery.k8s.io"
++    resources:
++      - "endpointslices"
++    verbs:
++      - "list"
++      - "get"
++      - "watch"
++      - "update"
+ ---
+ apiVersion: rbac.authorization.k8s.io/v1
+ kind: ClusterRoleBinding
+-- 
+2.49.0
+


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3628

*Description of changes:*
CI for baremetal tests are failing due to helm upgrade failure when installing the tinkerbell stack in the management cluster. This has been happening after kube-vip is upgraded to the latest version which uses endpointslices (see [here](https://github.com/kube-vip/kube-vip/pull/1215)). 
The current ClusterRole for kube-vip lacks the necessary permissions to watch EndpointSlices, which causes the tink service stack installation to hang indefinitely while waiting for an IP address from kube-vip in the management cluster.

```
ERROR watch error provider=endpointslices err="endpointslices.discovery.k8s.io is forbidden: User \"system:serviceaccount:eksa-system:kube-vip\" cannot watch resource \"endpointslices\" in API group \"discovery.k8s.io\" in the namespace \"eksa-system\""
```

In this PR, I am adding a patch for tinkerbell/charts to add the missing permissions for endpointslices.


<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
