### PR TITLE
Remove dev flag from EKSD 1-34

### DIFF
--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -58,4 +58,3 @@ releases:
   endOfStandardSupport: "2026-12-31"
   kubeVersion: v1.34.0
   number: 3
-  dev: true


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
EKSD now has the official release of 1-34 distro, so we can remove the dev flag from 1-34 EKS-D release

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
