### PR TITLE
Update the BMClib fork to include the vm fallback logic

### DIFF
--- a/projects/tinkerbell/rufio/CHECKSUMS
+++ b/projects/tinkerbell/rufio/CHECKSUMS
@@ -1,2 +1,2 @@
-4872cf19447e942b335ba41d47da2c444c888c374f236f7013e3b3c2c7984aba  _output/bin/rufio/linux-amd64/manager
-e4e4947f2dea6d6aa825bfed5e23a1f2f08920a94fac9db4aa55ac5c5cdbced9  _output/bin/rufio/linux-arm64/manager
+c84d39d0c76f63474188210846cda962ab60e9d8817f3647445ac2c963b41dfd  _output/bin/rufio/linux-amd64/manager
+d32a0357d2014c5c96f868d26f88781940ff48c79fc48ad106442e1a169b038b  _output/bin/rufio/linux-arm64/manager

--- a/projects/tinkerbell/rufio/patches/0001-fix-Replace-bmclib-with-fork-for-iDRAC10-gofish-comp.patch
+++ b/projects/tinkerbell/rufio/patches/0001-fix-Replace-bmclib-with-fork-for-iDRAC10-gofish-comp.patch
@@ -5,8 +5,11 @@ Subject: [PATCH 1/1] fix: Replace bmclib with fork for iDRAC10 gofish
  compatibility
 
 Point bmclib to a fork (github.com/rahulbabu95/bmclib) that includes
-gofish v0.20.1+ with iDRAC10 compatibility fixes from gofish PRs #510 and #511 The fork adapts bmclib to the new gofish
-API (schemas package restructure), mirroring bmc-toolbox/bmclib#432.
+gofish v0.20.1+ with iDRAC10 compatibility fixes from gofish PRs #510
+and #511. The fork adapts bmclib to the new gofish API (schemas package
+restructure), mirroring bmc-toolbox/bmclib#432, and adds a
+SetVirtualMedia fix that tries all matching slots instead of failing on
+the first error (needed for iDRAC10 multi-slot VirtualMedia).
 
 This is a temporary patch until upstream bmclib merges PR #432 and
 rufio bumps to a version that includes it.
@@ -35,7 +38,7 @@ index fe4bd66..3847997 100644
  	sigs.k8s.io/yaml v1.4.0 // indirect
  )
 +
-+replace github.com/bmc-toolbox/bmclib/v2 => github.com/rahulbabu95/bmclib/v2 v2.0.0-20260305223154-9e7e55bda2fe
++replace github.com/bmc-toolbox/bmclib/v2 => github.com/rahulbabu95/bmclib/v2 v2.0.0-20260310204344-f574c9d668ec
 diff --git a/go.sum b/go.sum
 index dcc50c0..f78f824 100644
 --- a/go.sum
@@ -53,8 +56,8 @@ index dcc50c0..f78f824 100644
  github.com/prometheus/common v0.55.0/go.mod h1:2SECS4xJG1kd8XF9IcM1gMX6510RAEL65zxzNImwdc8=
  github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
  github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-+github.com/rahulbabu95/bmclib/v2 v2.0.0-20260305223154-9e7e55bda2fe h1:BncNiKUfitjTVnxh9uJbm/PaCLJp9SVJIQGtf8BWJxk=
-+github.com/rahulbabu95/bmclib/v2 v2.0.0-20260305223154-9e7e55bda2fe/go.mod h1:3yBq8jDHT1OVa/iiJ1GKLttDlJB0dzF9Z5IH2hbaKHU=
++github.com/rahulbabu95/bmclib/v2 v2.0.0-20260310204344-f574c9d668ec h1:aCT6DcSvJrJ6POUV7tlmbPiMUyoYCpU+CaIJpp9/D80=
++github.com/rahulbabu95/bmclib/v2 v2.0.0-20260310204344-f574c9d668ec/go.mod h1:3yBq8jDHT1OVa/iiJ1GKLttDlJB0dzF9Z5IH2hbaKHU=
  github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
  github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
  github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=


### PR DESCRIPTION
*Issue #, if available:*
More Context here: https://github.com/rahulbabu95/bmclib/commit/f574c9d668ecb3e6f9ebce0982a995afb3a7642b

*Description of changes:*
Include the vm fall back logic in BMClib when multiple media devices are returned.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
