### PR TITLE
Bump bmclib in Rufio

### DIFF
--- a/projects/tinkerbell/rufio/CHECKSUMS
+++ b/projects/tinkerbell/rufio/CHECKSUMS
@@ -1,2 +1,2 @@
-4872cf19447e942b335ba41d47da2c444c888c374f236f7013e3b3c2c7984aba  _output/bin/rufio/linux-amd64/manager
-e4e4947f2dea6d6aa825bfed5e23a1f2f08920a94fac9db4aa55ac5c5cdbced9  _output/bin/rufio/linux-arm64/manager
+54f731a002b5bf5c1784e1d64c1257079b22050954256b39ce0ff9e28b427ec7  _output/bin/rufio/linux-amd64/manager
+dc71916ecb43cc08e7ddf423cf51add1cbc763c84eb1bf45762aa81f6dfc8faa  _output/bin/rufio/linux-arm64/manager

--- a/projects/tinkerbell/rufio/patches/0001-Bump-bmclib-to-3269f94-gofish-v0.21.6.patch
+++ b/projects/tinkerbell/rufio/patches/0001-Bump-bmclib-to-3269f94-gofish-v0.21.6.patch
@@ -1,71 +1,70 @@
-From f195ef9a40738a58bbdc1a9c6b621b008f556738 Mon Sep 17 00:00:00 2001
+From d64f5eafad4ee7d2cbd5470bb30132442170648a Mon Sep 17 00:00:00 2001
 From: Rahul Ganesh <rahulgab@amazon.com>
-Date: Thu, 5 Mar 2026 14:54:24 -0800
-Subject: [PATCH 1/1] fix: Replace bmclib with fork for iDRAC10 gofish
- compatibility
+Date: Thu, 16 Apr 2026 17:33:22 -0700
+Subject: [PATCH] Bump bmclib to 3269f94 (gofish v0.21.6)
 
-Point bmclib to a fork (github.com/rahulbabu95/bmclib) that includes
-gofish v0.20.1+ with iDRAC10 compatibility fixes from gofish PRs #510 and #511 The fork adapts bmclib to the new gofish
-API (schemas package restructure), mirroring bmc-toolbox/bmclib#432.
+Update bmclib from fork pin to upstream bmc-toolbox/bmclib@3269f94
+which merges all prior fork patches and bumps gofish to v0.21.6.
 
-This is a temporary patch until upstream bmclib merges PR #432 and
-rufio bumps to a version that includes it.
+Key fixes included via gofish v0.21.5/v0.21.6:
+- SetBoot tries main System resource before Settings URI,
+  fixing one-time boot override on iDRAC 7.x-9.x
+- Fix multi-type JSON Schema properties resolving to wrong type
+
+Also removes the rahulbabu95/bmclib fork replace directive since
+all fork commits (PRs #433, #434, #435) are now merged upstream.
 
 Signed-off-by: Rahul Ganesh <rahulgab@amazon.com>
 ---
- go.mod | 4 +++-
+ go.mod | 4 ++--
  go.sum | 8 ++++----
- 2 files changed, 7 insertions(+), 5 deletions(-)
+ 2 files changed, 6 insertions(+), 6 deletions(-)
 
 diff --git a/go.mod b/go.mod
-index fe4bd66..3847997 100644
+index fe4bd66..bc7179d 100644
 --- a/go.mod
 +++ b/go.mod
+@@ -6,7 +6,7 @@ toolchain go1.22.2
+ 
+ require (
+ 	dario.cat/mergo v1.0.1
+-	github.com/bmc-toolbox/bmclib/v2 v2.3.5-0.20251010091507-63cb571e5597
++	github.com/bmc-toolbox/bmclib/v2 v2.3.5-0.20260416064330-3269f94932e9
+ 	github.com/ccoveille/go-safecast v1.5.0
+ 	github.com/go-logr/logr v1.4.2
+ 	github.com/go-logr/zerologr v1.2.3
 @@ -63,7 +63,7 @@ require (
  	github.com/prometheus/procfs v0.15.1 // indirect
  	github.com/satori/go.uuid v1.2.0 // indirect
  	github.com/spf13/pflag v1.0.5 // indirect
 -	github.com/stmcginnis/gofish v0.20.0 // indirect
-+	github.com/stmcginnis/gofish v0.20.1-0.20260304143028-a1180d37929a // indirect
++	github.com/stmcginnis/gofish v0.21.6 // indirect
  	github.com/x448/float16 v0.8.4 // indirect
  	go.opentelemetry.io/otel v1.29.0 // indirect
  	go.opentelemetry.io/otel/trace v1.29.0 // indirect
-@@ -90,3 +90,5 @@ require (
- 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
- 	sigs.k8s.io/yaml v1.4.0 // indirect
- )
-+
-+replace github.com/bmc-toolbox/bmclib/v2 => github.com/rahulbabu95/bmclib/v2 v2.0.0-20260305223154-9e7e55bda2fe
 diff --git a/go.sum b/go.sum
-index dcc50c0..f78f824 100644
+index dcc50c0..a36dc2f 100644
 --- a/go.sum
 +++ b/go.sum
-@@ -8,8 +8,6 @@ github.com/VictorLowther/soap v0.0.0-20150314151524-8e36fca84b22 h1:a0MBqYm44o0N
+@@ -8,8 +8,8 @@ github.com/VictorLowther/soap v0.0.0-20150314151524-8e36fca84b22 h1:a0MBqYm44o0N
  github.com/VictorLowther/soap v0.0.0-20150314151524-8e36fca84b22/go.mod h1:/B7V22rcz4860iDqstGvia/2+IYWXf3/JdQCVd/1D2A=
  github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
  github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 -github.com/bmc-toolbox/bmclib/v2 v2.3.5-0.20251010091507-63cb571e5597 h1:V8lDpeWcQXhlarTtD5op6++v5Dh6wO4WTBXq8ugNuj4=
 -github.com/bmc-toolbox/bmclib/v2 v2.3.5-0.20251010091507-63cb571e5597/go.mod h1:2tYJD9JtY1tJxLHhslICrFOZhxE9O4gYMb1nJ5BKI5w=
++github.com/bmc-toolbox/bmclib/v2 v2.3.5-0.20260416064330-3269f94932e9 h1:q4Sc06ok4ZDPuu6yYIkXDTJw8DEh5xA4Px9OQD087cg=
++github.com/bmc-toolbox/bmclib/v2 v2.3.5-0.20260416064330-3269f94932e9/go.mod h1:NicaxDvwo1RbClp+6XPefZt28svygBT5wofYk/A1Sk0=
  github.com/bmc-toolbox/common v0.0.0-20250112191656-b6de52e8303d h1:5c0jhS9jNLm1t3GVEESsWv+p6recFRLGW90zp8HDIDs=
  github.com/bmc-toolbox/common v0.0.0-20250112191656-b6de52e8303d/go.mod h1:Cdnkm+edb6C0pVkyCrwh3JTXAe0iUF9diDG/DztPI9I=
  github.com/bombsimon/logrusr/v2 v2.0.1 h1:1VgxVNQMCvjirZIYaT9JYn6sAVGVEcNtRE0y4mvaOAM=
-@@ -128,6 +126,8 @@ github.com/prometheus/common v0.55.0 h1:KEi6DK7lXW/m7Ig5i47x0vRzuBsHuvJdi5ee6Y3G
- github.com/prometheus/common v0.55.0/go.mod h1:2SECS4xJG1kd8XF9IcM1gMX6510RAEL65zxzNImwdc8=
- github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
- github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-+github.com/rahulbabu95/bmclib/v2 v2.0.0-20260305223154-9e7e55bda2fe h1:BncNiKUfitjTVnxh9uJbm/PaCLJp9SVJIQGtf8BWJxk=
-+github.com/rahulbabu95/bmclib/v2 v2.0.0-20260305223154-9e7e55bda2fe/go.mod h1:3yBq8jDHT1OVa/iiJ1GKLttDlJB0dzF9Z5IH2hbaKHU=
- github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
- github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
- github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 @@ -139,8 +139,8 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
  github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
  github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
  github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 -github.com/stmcginnis/gofish v0.20.0 h1:hH2V2Qe898F2wWT1loApnkDUrXXiLKqbSlMaH3Y1n08=
 -github.com/stmcginnis/gofish v0.20.0/go.mod h1:PzF5i8ecRG9A2ol8XT64npKUunyraJ+7t0kYMpQAtqU=
-+github.com/stmcginnis/gofish v0.20.1-0.20260304143028-a1180d37929a h1:sgqQv6GMpYzDXI5O938qVzf22U2NT9n+ZwfGqFwj0fM=
-+github.com/stmcginnis/gofish v0.20.1-0.20260304143028-a1180d37929a/go.mod h1:PzF5i8ecRG9A2ol8XT64npKUunyraJ+7t0kYMpQAtqU=
++github.com/stmcginnis/gofish v0.21.6 h1:jK3TGD6VANaAHKHypVNfD6io2nPrU+6eF8X4qARsTlY=
++github.com/stmcginnis/gofish v0.21.6/go.mod h1:PzF5i8ecRG9A2ol8XT64npKUunyraJ+7t0kYMpQAtqU=
  github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
  github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
  github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove temporary BMC lib fork as the patches are all upstream and bump BMC lib to a commit that uses Gofish release v0.21.6 which has critical IDRAC fixes. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
