### PR TITLE
Attribution files update release 0.25 994403ff0d22004128c003dc7961899f6c706beb

### DIFF
--- a/projects/aquasecurity/trivy/ATTRIBUTION.txt
+++ b/projects/aquasecurity/trivy/ATTRIBUTION.txt
@@ -2691,7 +2691,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/go; version go1.25.8 --
+** golang.org/go; version go1.25.9 --
 https://github.com/golang/go
 
 ** golang.org/x/crypto; version v0.45.0 --

--- a/projects/brancz/kube-rbac-proxy/ATTRIBUTION.txt
+++ b/projects/brancz/kube-rbac-proxy/ATTRIBUTION.txt
@@ -863,7 +863,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/go; version go1.25.8 --
+** golang.org/go; version go1.25.9 --
 https://github.com/golang/go
 
 ** golang.org/x/crypto; version v0.46.0 --

--- a/projects/cert-manager/cert-manager/CERT_MANAGER_ACMESOLVER_ATTRIBUTION.txt
+++ b/projects/cert-manager/cert-manager/CERT_MANAGER_ACMESOLVER_ATTRIBUTION.txt
@@ -547,7 +547,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/go; version go1.25.8 --
+** golang.org/go; version go1.25.9 --
 https://github.com/golang/go
 
 ** golang.org/x/net; version v0.47.0 --

--- a/projects/cert-manager/cert-manager/CERT_MANAGER_CAINJECTOR_ATTRIBUTION.txt
+++ b/projects/cert-manager/cert-manager/CERT_MANAGER_CAINJECTOR_ATTRIBUTION.txt
@@ -681,7 +681,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/go; version go1.25.8 --
+** golang.org/go; version go1.25.9 --
 https://github.com/golang/go
 
 ** golang.org/x/crypto; version v0.45.0 --

--- a/projects/cert-manager/cert-manager/CERT_MANAGER_CONTROLLER_ATTRIBUTION.txt
+++ b/projects/cert-manager/cert-manager/CERT_MANAGER_CONTROLLER_ATTRIBUTION.txt
@@ -667,7 +667,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ** github.com/cert-manager/cert-manager/third_party/forked/acme; version v0.0.0-00010101000000-000000000000 --
 https://github.com/cert-manager/cert-manager
 
-** golang.org/go; version go1.25.8 --
+** golang.org/go; version go1.25.9 --
 https://github.com/golang/go
 
 ** golang.org/x/crypto; version v0.45.0 --

--- a/projects/cert-manager/cert-manager/CERT_MANAGER_STARTUPAPICHECK_ATTRIBUTION.txt
+++ b/projects/cert-manager/cert-manager/CERT_MANAGER_STARTUPAPICHECK_ATTRIBUTION.txt
@@ -729,7 +729,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/go; version go1.25.8 --
+** golang.org/go; version go1.25.9 --
 https://github.com/golang/go
 
 ** golang.org/x/crypto; version v0.45.0 --

--- a/projects/cert-manager/cert-manager/CERT_MANAGER_WEBHOOK_ATTRIBUTION.txt
+++ b/projects/cert-manager/cert-manager/CERT_MANAGER_WEBHOOK_ATTRIBUTION.txt
@@ -796,7 +796,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/go; version go1.25.8 --
+** golang.org/go; version go1.25.9 --
 https://github.com/golang/go
 
 ** golang.org/x/crypto; version v0.45.0 --

--- a/projects/fluxcd/flux2/ATTRIBUTION.txt
+++ b/projects/fluxcd/flux2/ATTRIBUTION.txt
@@ -1765,7 +1765,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/go; version go1.25.8 --
+** golang.org/go; version go1.25.9 --
 https://github.com/golang/go
 
 ** golang.org/x/crypto; version v0.44.0 --

--- a/projects/fluxcd/helm-controller/ATTRIBUTION.txt
+++ b/projects/fluxcd/helm-controller/ATTRIBUTION.txt
@@ -1379,7 +1379,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/go; version go1.25.8 --
+** golang.org/go; version go1.25.9 --
 https://github.com/golang/go
 
 ** golang.org/x/crypto; version v0.44.0 --

--- a/projects/fluxcd/kustomize-controller/ATTRIBUTION.txt
+++ b/projects/fluxcd/kustomize-controller/ATTRIBUTION.txt
@@ -1540,7 +1540,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/go; version go1.25.8 --
+** golang.org/go; version go1.25.9 --
 https://github.com/golang/go
 
 ** golang.org/x/crypto; version v0.44.0 --

--- a/projects/fluxcd/notification-controller/ATTRIBUTION.txt
+++ b/projects/fluxcd/notification-controller/ATTRIBUTION.txt
@@ -1464,7 +1464,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/go; version go1.25.8 --
+** golang.org/go; version go1.25.9 --
 https://github.com/golang/go
 
 ** golang.org/x/crypto; version v0.44.0 --

--- a/projects/fluxcd/source-controller/ATTRIBUTION.txt
+++ b/projects/fluxcd/source-controller/ATTRIBUTION.txt
@@ -2170,7 +2170,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/go; version go1.25.8 --
+** golang.org/go; version go1.25.9 --
 https://github.com/golang/go
 
 ** golang.org/x/crypto; version v0.44.0 --

--- a/projects/helm/helm/ATTRIBUTION.txt
+++ b/projects/helm/helm/ATTRIBUTION.txt
@@ -854,7 +854,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/go; version go1.25.8 --
+** golang.org/go; version go1.25.9 --
 https://github.com/golang/go
 
 ** golang.org/x/crypto; version v0.47.0 --

--- a/projects/kube-vip/kube-vip/ATTRIBUTION.txt
+++ b/projects/kube-vip/kube-vip/ATTRIBUTION.txt
@@ -1039,7 +1039,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/go; version go1.25.8 --
+** golang.org/go; version go1.25.9 --
 https://github.com/golang/go
 
 ** golang.org/x/crypto/curve25519; version v0.45.0 --

--- a/projects/kubernetes-sigs/cri-tools/ATTRIBUTION.txt
+++ b/projects/kubernetes-sigs/cri-tools/ATTRIBUTION.txt
@@ -836,7 +836,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/go; version go1.25.8 --
+** golang.org/go; version go1.25.9 --
 https://github.com/golang/go
 
 ** golang.org/x/mod/semver; version v0.29.0 --

--- a/projects/kubernetes-sigs/kind/ATTRIBUTION.txt
+++ b/projects/kubernetes-sigs/kind/ATTRIBUTION.txt
@@ -329,7 +329,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/go; version go1.25.8 --
+** golang.org/go; version go1.25.9 --
 https://github.com/golang/go
 
 Copyright 2009 The Go Authors.

--- a/projects/kubernetes-sigs/kind/KINDNETD_ATTRIBUTION.txt
+++ b/projects/kubernetes-sigs/kind/KINDNETD_ATTRIBUTION.txt
@@ -594,7 +594,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/go; version go1.25.8 --
+** golang.org/go; version go1.25.9 --
 https://github.com/golang/go
 
 ** golang.org/x/net; version v0.40.0 --

--- a/projects/kubernetes/autoscaler/1-29/ATTRIBUTION.txt
+++ b/projects/kubernetes/autoscaler/1-29/ATTRIBUTION.txt
@@ -816,7 +816,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ------
 
 ** github.com/imdario/mergo; version v0.3.15 --
-https://github.com/imdario/mergo
+https://github.com/darccio/mergo
 
 Copyright (c) 2013 Dario Castañé. All rights reserved.
 Copyright (c) 2012 The Go Authors. All rights reserved.
@@ -992,51 +992,33 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ** golang.org/go; version go1.24.13 --
 https://github.com/golang/go
 
+Copyright 2009 The Go Authors.
 
-<html>
-  <head>
-    <meta content="origin" name="referrer">
-    <title>Rate limit &middot; GitHub</title>
-    <meta name="viewport" content="width=device-width">
-    <style type="text/css" media="screen">
-      body {
-        background-color: #f6f8fa;
-        color: rgba(0, 0, 0, 0.5);
-        font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
-        font-size: 14px;
-        line-height: 1.5;
-      }
-      .c { margin: 50px auto; max-width: 600px; text-align: center; padding: 0 24px; }
-      a { text-decoration: none; }
-      a:hover { text-decoration: underline; }
-      h1 { color: #24292e; line-height: 60px; font-size: 48px; font-weight: 300; margin: 0px; }
-      p { margin: 20px 0 40px; }
-      #s { margin-top: 35px; }
-      #s a {
-        color: #666666;
-        font-weight: 200;
-        font-size: 14px;
-        margin: 0 10px;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="c">
-      <h1>Access has been restricted</h1>
-      <p>You have triggered a rate limit.<br><br>
-         Please wait a few minutes before you try again;<br>
-         in some cases this may take up to an hour.
-      </p>
-      <div id="s">
-        <a href="https://support.github.com">Contact Support</a> &mdash;
-        <a href="https://githubstatus.com">GitHub Status</a> &mdash;
-        <a href="https://twitter.com/githubstatus">@githubstatus</a>
-      </div>
-    </div>
-  </body>
-</html>
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
 
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 

--- a/projects/kubernetes/autoscaler/1-31/ATTRIBUTION.txt
+++ b/projects/kubernetes/autoscaler/1-31/ATTRIBUTION.txt
@@ -812,7 +812,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ------
 
 ** github.com/imdario/mergo; version v0.3.15 --
-https://github.com/imdario/mergo
+https://github.com/darccio/mergo
 
 Copyright (c) 2013 Dario Castañé. All rights reserved.
 Copyright (c) 2012 The Go Authors. All rights reserved.
@@ -952,51 +952,33 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ** golang.org/go; version go1.24.13 --
 https://github.com/golang/go
 
+Copyright 2009 The Go Authors.
 
-<html>
-  <head>
-    <meta content="origin" name="referrer">
-    <title>Rate limit &middot; GitHub</title>
-    <meta name="viewport" content="width=device-width">
-    <style type="text/css" media="screen">
-      body {
-        background-color: #f6f8fa;
-        color: rgba(0, 0, 0, 0.5);
-        font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
-        font-size: 14px;
-        line-height: 1.5;
-      }
-      .c { margin: 50px auto; max-width: 600px; text-align: center; padding: 0 24px; }
-      a { text-decoration: none; }
-      a:hover { text-decoration: underline; }
-      h1 { color: #24292e; line-height: 60px; font-size: 48px; font-weight: 300; margin: 0px; }
-      p { margin: 20px 0 40px; }
-      #s { margin-top: 35px; }
-      #s a {
-        color: #666666;
-        font-weight: 200;
-        font-size: 14px;
-        margin: 0 10px;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="c">
-      <h1>Access has been restricted</h1>
-      <p>You have triggered a rate limit.<br><br>
-         Please wait a few minutes before you try again;<br>
-         in some cases this may take up to an hour.
-      </p>
-      <div id="s">
-        <a href="https://support.github.com">Contact Support</a> &mdash;
-        <a href="https://githubstatus.com">GitHub Status</a> &mdash;
-        <a href="https://twitter.com/githubstatus">@githubstatus</a>
-      </div>
-    </div>
-  </body>
-</html>
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
 
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 

--- a/projects/kubernetes/autoscaler/1-34/ATTRIBUTION.txt
+++ b/projects/kubernetes/autoscaler/1-34/ATTRIBUTION.txt
@@ -873,54 +873,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ** golang.org/go; version go1.24.13 --
 https://github.com/golang/go
 
-
-<html>
-  <head>
-    <meta content="origin" name="referrer">
-    <title>Rate limit &middot; GitHub</title>
-    <meta name="viewport" content="width=device-width">
-    <style type="text/css" media="screen">
-      body {
-        background-color: #f6f8fa;
-        color: rgba(0, 0, 0, 0.5);
-        font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
-        font-size: 14px;
-        line-height: 1.5;
-      }
-      .c { margin: 50px auto; max-width: 600px; text-align: center; padding: 0 24px; }
-      a { text-decoration: none; }
-      a:hover { text-decoration: underline; }
-      h1 { color: #24292e; line-height: 60px; font-size: 48px; font-weight: 300; margin: 0px; }
-      p { margin: 20px 0 40px; }
-      #s { margin-top: 35px; }
-      #s a {
-        color: #666666;
-        font-weight: 200;
-        font-size: 14px;
-        margin: 0 10px;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="c">
-      <h1>Access has been restricted</h1>
-      <p>You have triggered a rate limit.<br><br>
-         Please wait a few minutes before you try again;<br>
-         in some cases this may take up to an hour.
-      </p>
-      <div id="s">
-        <a href="https://support.github.com">Contact Support</a> &mdash;
-        <a href="https://githubstatus.com">GitHub Status</a> &mdash;
-        <a href="https://twitter.com/githubstatus">@githubstatus</a>
-      </div>
-    </div>
-  </body>
-</html>
-
-
-
-------
-
 ** golang.org/x/exp; version v0.0.0-20240719175910-8a7402abbf56 --
 https://golang.org/x/exp
 

--- a/projects/kubernetes/autoscaler/1-35/ATTRIBUTION.txt
+++ b/projects/kubernetes/autoscaler/1-35/ATTRIBUTION.txt
@@ -810,7 +810,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/go; version go1.25.8 --
+** golang.org/go; version go1.25.9 --
 https://github.com/golang/go
 
 ** golang.org/x/exp/slices; version v0.0.0-20250819193227-8b4c13bb791b --

--- a/projects/kubernetes/cloud-provider-aws/1-35/ATTRIBUTION.txt
+++ b/projects/kubernetes/cloud-provider-aws/1-35/ATTRIBUTION.txt
@@ -591,7 +591,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/go; version go1.25.8 --
+** golang.org/go; version go1.25.9 --
 https://github.com/golang/go
 
 ** golang.org/x/net; version v0.47.0 --

--- a/projects/kubernetes/cloud-provider-vsphere/1-35/ATTRIBUTION.txt
+++ b/projects/kubernetes/cloud-provider-vsphere/1-35/ATTRIBUTION.txt
@@ -1103,7 +1103,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/go; version go1.25.8 --
+** golang.org/go; version go1.25.9 --
 https://github.com/golang/go
 
 ** golang.org/x/crypto; version v0.46.0 --

--- a/projects/rancher/local-path-provisioner/ATTRIBUTION.txt
+++ b/projects/rancher/local-path-provisioner/ATTRIBUTION.txt
@@ -715,7 +715,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/go; version go1.26.1 --
+** golang.org/go; version go1.26.2 --
 https://github.com/golang/go
 
 ** golang.org/x/net; version v0.38.0 --

--- a/projects/replicatedhq/troubleshoot/ATTRIBUTION.txt
+++ b/projects/replicatedhq/troubleshoot/ATTRIBUTION.txt
@@ -1781,7 +1781,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------
 
-** golang.org/go; version go1.25.8 --
+** golang.org/go; version go1.25.9 --
 https://github.com/golang/go
 
 ** golang.org/x/crypto; version v0.47.0 --


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Update attribution files on release-0.25 branch after bumping builder base tag

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
