### PR TITLE
Allow certBundles field mutable in kcp kubeadmSpec

### DIFF
--- a/projects/kubernetes-sigs/cluster-api/patches/0001-Support-core-dns-1.13.2-for-eks-1-33-25.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0001-Support-core-dns-1.13.2-for-eks-1-33-25.patch
@@ -1,14 +1,12 @@
-From 89330ec1e614331e9f6c9f8a7a9bcc9ae7efdbc3 Mon Sep 17 00:00:00 2001
+From b5c1ba5c5065c627fdefa0cbfd1d29d62be34705 Mon Sep 17 00:00:00 2001
 From: Amelia Lu <63176721+peirulu@users.noreply.github.com>
 Date: Tue, 17 Mar 2026 15:38:55 -0700
 Subject: [PATCH 01/37] support core dns 1.13.2 for eks-1-33-25
-
 
 EKS-D 1.33-25 ships with coredns 1.13.2.  The corefile-migration package
 with release version 1.0.31 supports 1.11.3.  Temporarily ovewriting the version
 to point to the latest release 1.0.31. The patch can be removed once the package has been
 bumped in upstream capi.
-
 ---
  go.mod | 2 +-
  go.sum | 4 ++--
@@ -43,5 +41,5 @@ index b40f4a16d..2d1a640fe 100644
  github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
  github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
 -- 
-2.48.1
+2.50.1 (Apple Git-155)
 

--- a/projects/kubernetes-sigs/cluster-api/patches/0002-Adding-capi-support-for-Bottlerocket.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0002-Adding-capi-support-for-Bottlerocket.patch
@@ -1,4 +1,4 @@
-From e662675c5e9b92492fd92c456aa0a637a621f2ed Mon Sep 17 00:00:00 2001
+From 8856acdda405f82c7f0d545ddd458cb3315ce806 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Fri, 11 Jun 2021 10:43:09 -0700
 Subject: [PATCH 02/37] Adding capi support for Bottlerocket

--- a/projects/kubernetes-sigs/cluster-api/patches/0003-Add-unstacked-etcd-support.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0003-Add-unstacked-etcd-support.patch
@@ -1,4 +1,4 @@
-From 1780cfc7760add9bbbb674b8f33a32f1ed67bdf1 Mon Sep 17 00:00:00 2001
+From fb2d4e8160eb8bdcde2331f72da858eac0949aab Mon Sep 17 00:00:00 2001
 From: Rajashree Mandaogane <mandaor@amazon.com>
 Date: Mon, 28 Jun 2021 13:44:50 -0700
 Subject: [PATCH 03/37] Add unstacked etcd support
@@ -167,7 +167,7 @@ index 8e36313c7..a0568c262 100644
  const (
  	// TopologyReconciledCondition provides evidence about the reconciliation of a Cluster topology into
 diff --git a/api/core/v1beta1/machine_types.go b/api/core/v1beta1/machine_types.go
-index 9665953dd..8cf242133 100644
+index 5a37f7542..b630efc60 100644
 --- a/api/core/v1beta1/machine_types.go
 +++ b/api/core/v1beta1/machine_types.go
 @@ -51,6 +51,8 @@ const (
@@ -333,7 +333,7 @@ index 23abc6c2b..fa7bda307 100644
 +	EtcdHealthCheckFailedReason = "EtcdMemberHealthCheckFailed"
 +)
 diff --git a/api/core/v1beta2/machine_types.go b/api/core/v1beta2/machine_types.go
-index 399d3971c..e480f0773 100644
+index 16f4bf07a..8069c99e1 100644
 --- a/api/core/v1beta2/machine_types.go
 +++ b/api/core/v1beta2/machine_types.go
 @@ -30,6 +30,9 @@ const (

--- a/projects/kubernetes-sigs/cluster-api/patches/0004-Unstacked-etcd-and-controlplane-upgrade.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0004-Unstacked-etcd-and-controlplane-upgrade.patch
@@ -1,4 +1,4 @@
-From d2e210e242a661f714f9f614bc17c4d15f29f251 Mon Sep 17 00:00:00 2001
+From bf0266da88407c4bc95a7caca351179a934817d0 Mon Sep 17 00:00:00 2001
 From: Rajashree Mandaogane <mandaor@amazon.com>
 Date: Fri, 6 Aug 2021 17:16:39 -0700
 Subject: [PATCH 04/37] Unstacked etcd and controlplane upgrade

--- a/projects/kubernetes-sigs/cluster-api/patches/0005-Patch-config-path-in-kubevip-manifest-for-kubeadm-co.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0005-Patch-config-path-in-kubevip-manifest-for-kubeadm-co.patch
@@ -1,4 +1,4 @@
-From e69029ee1662158db0c10595d417ce7b72e40ad6 Mon Sep 17 00:00:00 2001
+From dd5a8f705f88ac529543cf4ac1b048b7fdda9660 Mon Sep 17 00:00:00 2001
 From: Guillermo Gaston <gaslor@amazon.com>
 Date: Thu, 19 Aug 2021 21:52:52 +0000
 Subject: [PATCH 05/37] Patch config path in kubevip manifest for kubeadm

--- a/projects/kubernetes-sigs/cluster-api/patches/0006-Make-pause-and-bottlerocket-bootstrap-images-updatab.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0006-Make-pause-and-bottlerocket-bootstrap-images-updatab.patch
@@ -1,4 +1,4 @@
-From fa300ba98d0415223af9119cc8f4e9907fbb15a4 Mon Sep 17 00:00:00 2001
+From 0adc6a830e61dfed80498b9f268bdcb1f4964923 Mon Sep 17 00:00:00 2001
 From: Guillermo Gaston <gaslor@amazon.com>
 Date: Tue, 31 Aug 2021 15:56:28 +0000
 Subject: [PATCH 06/37] Make pause and bottlerocket bootstrap images updatable

--- a/projects/kubernetes-sigs/cluster-api/patches/0007-Fix-proxy-template-for-bottlerocket-bootstrap.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0007-Fix-proxy-template-for-bottlerocket-bootstrap.patch
@@ -1,4 +1,4 @@
-From 79847e4399066411ee688c387a277b6c24cdd218 Mon Sep 17 00:00:00 2001
+From 96b55a742748279233d15aee30fb315ca9cc1ca9 Mon Sep 17 00:00:00 2001
 From: Rajashree Mandaogane <mandaor@amazon.com>
 Date: Thu, 30 Sep 2021 14:04:36 -0700
 Subject: [PATCH 07/37] Fix proxy template for bottlerocket bootstrap

--- a/projects/kubernetes-sigs/cluster-api/patches/0008-Add-bottlerocket-changes-to-capbk-v1alpha4-api.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0008-Add-bottlerocket-changes-to-capbk-v1alpha4-api.patch
@@ -1,4 +1,4 @@
-From 2e6f9a956c1e41ed0a12b0e665b70c6dbe965036 Mon Sep 17 00:00:00 2001
+From 238e5f86998003855475ee1602de770b40643c17 Mon Sep 17 00:00:00 2001
 From: Rajashree Mandaogane <mandaor@amazon.com>
 Date: Sun, 21 Nov 2021 20:59:58 -0800
 Subject: [PATCH 08/37] Add bottlerocket changes to capbk v1alpha4 api

--- a/projects/kubernetes-sigs/cluster-api/patches/0009-Add-status.version-to-list-of-fields-to-ignore-for-u.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0009-Add-status.version-to-list-of-fields-to-ignore-for-u.patch
@@ -1,4 +1,4 @@
-From 104a850fe73b32bce53ae20cf77893ec6681ee64 Mon Sep 17 00:00:00 2001
+From bb135cb2e470518c7afd425fb2acd73ad02cbd16 Mon Sep 17 00:00:00 2001
 From: Vivek Koppuru <koppv@amazon.com>
 Date: Wed, 12 Jan 2022 19:04:15 -0800
 Subject: [PATCH 09/37] Add status.version to list of fields to ignore for

--- a/projects/kubernetes-sigs/cluster-api/patches/0010-Add-node-labels-support-for-bottlerocket.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0010-Add-node-labels-support-for-bottlerocket.patch
@@ -1,4 +1,4 @@
-From e5354bec3e248e0a4992c28706538c28816933b8 Mon Sep 17 00:00:00 2001
+From e44f9e6954d64f7cb88420473a589c32710d77cb Mon Sep 17 00:00:00 2001
 From: Vivek Koppuru <koppv@amazon.com>
 Date: Mon, 24 Jan 2022 00:46:44 -0800
 Subject: [PATCH 10/37] Add node labels support for bottlerocket

--- a/projects/kubernetes-sigs/cluster-api/patches/0011-Support-worker-node-taints.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0011-Support-worker-node-taints.patch
@@ -1,4 +1,4 @@
-From 850eff69817cc9fc20f8916259b44d22c71dcd2a Mon Sep 17 00:00:00 2001
+From a4cfa2cc33921bd73a0da4c168cfd8762ae1492c Mon Sep 17 00:00:00 2001
 From: Daniel Budris <budris@amazon.com>
 Date: Fri, 17 Dec 2021 13:38:39 -0800
 Subject: [PATCH 11/37] Support worker node taints

--- a/projects/kubernetes-sigs/cluster-api/patches/0012-support-bottle-rocket-control-plane-taints.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0012-support-bottle-rocket-control-plane-taints.patch
@@ -1,4 +1,4 @@
-From c765ea7e00043b761e99bb03b69eee27f408ce93 Mon Sep 17 00:00:00 2001
+From e85ed73862bec729ecf4b19b89c512e6e2a9283c Mon Sep 17 00:00:00 2001
 From: danbudris <budris@amazon.com>
 Date: Fri, 18 Feb 2022 09:24:32 -0500
 Subject: [PATCH 12/37] support bottle rocket control plane taints
@@ -1411,7 +1411,7 @@ index c041e914c..8153b3cc4 100644
  				`),
  		},
 diff --git a/controlplane/kubeadm/internal/workload_cluster_test.go b/controlplane/kubeadm/internal/workload_cluster_test.go
-index 4d4bfdae5..400bb0358 100644
+index 9cb59c2b1..94a9b50a0 100644
 --- a/controlplane/kubeadm/internal/workload_cluster_test.go
 +++ b/controlplane/kubeadm/internal/workload_cluster_test.go
 @@ -317,12 +317,17 @@ func TestUpdateUpdateClusterConfigurationInKubeadmConfigMap(t *testing.T) {

--- a/projects/kubernetes-sigs/cluster-api/patches/0013-Change-format-for-storing-etcd-machine-address.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0013-Change-format-for-storing-etcd-machine-address.patch
@@ -1,4 +1,4 @@
-From 429f353c201b10f75b0441618e6f87edefd90fb5 Mon Sep 17 00:00:00 2001
+From 1f3d24853e7e952a14019286890f6cd1c32ec97e Mon Sep 17 00:00:00 2001
 From: Rajashree Mandaogane <mandaor@amazon.com>
 Date: Thu, 3 Mar 2022 15:01:35 -0800
 Subject: [PATCH 13/37] Change format for storing etcd machine address

--- a/projects/kubernetes-sigs/cluster-api/patches/0014-Parse-provider-id-from-kubelet-extra-args.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0014-Parse-provider-id-from-kubelet-extra-args.patch
@@ -1,4 +1,4 @@
-From 88078c959ba7a801ec15f06cc69f17b71f556616 Mon Sep 17 00:00:00 2001
+From d94ed47401af028e244ed6b5094c14dbd20cad07 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Wed, 8 Jun 2022 10:27:26 -0700
 Subject: [PATCH 14/37] Parse provider-id from kubelet extra args

--- a/projects/kubernetes-sigs/cluster-api/patches/0015-Support-configuring-bottlerocket-admin-container-ima.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0015-Support-configuring-bottlerocket-admin-container-ima.patch
@@ -1,4 +1,4 @@
-From aa4bc5ea621a0cbd80b595f667147535cae44606 Mon Sep 17 00:00:00 2001
+From 246cfe3db6047d0c14fc74da333307963c67dfaf Mon Sep 17 00:00:00 2001
 From: Jiayi Wang <jiayiwang7@yahoo.com>
 Date: Wed, 23 Nov 2022 09:26:28 -0500
 Subject: [PATCH 15/37] Support configuring bottlerocket admin container image

--- a/projects/kubernetes-sigs/cluster-api/patches/0016-Make-bottlerocket-admin-control-custom-bootstrap-con.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0016-Make-bottlerocket-admin-control-custom-bootstrap-con.patch
@@ -1,4 +1,4 @@
-From efac986221a77a0d7eb396b7a3dbee8e37edf65a Mon Sep 17 00:00:00 2001
+From e2e57ef711eaf5c68e7f6d357b3bd53ba50c06a2 Mon Sep 17 00:00:00 2001
 From: Jiayi Wang <jiayiwang7@yahoo.com>
 Date: Thu, 5 Jan 2023 14:56:09 -0500
 Subject: [PATCH 16/37] Make bottlerocket admin, control, custom bootstrap

--- a/projects/kubernetes-sigs/cluster-api/patches/0017-Mark-etcd-machine-status-to-running-after-etcd-contr.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0017-Mark-etcd-machine-status-to-running-after-etcd-contr.patch
@@ -1,4 +1,4 @@
-From bd6f6d61478fd1d12e82ef9b4f8947e5c7ca990a Mon Sep 17 00:00:00 2001
+From 1eb1c7cc7bdcfe75c4631c77e84937caacf13931 Mon Sep 17 00:00:00 2001
 From: Jiayi Wang <jiayiwang7@yahoo.com>
 Date: Mon, 9 Jan 2023 15:41:05 -0500
 Subject: [PATCH 17/37] Mark etcd machine status to running after etcd
@@ -12,7 +12,7 @@ Subject: [PATCH 17/37] Mark etcd machine status to running after etcd
  4 files changed, 11 insertions(+), 4 deletions(-)
 
 diff --git a/api/core/v1beta1/machine_types.go b/api/core/v1beta1/machine_types.go
-index 8cf242133..bdd481382 100644
+index b630efc60..af0327459 100644
 --- a/api/core/v1beta1/machine_types.go
 +++ b/api/core/v1beta1/machine_types.go
 @@ -51,8 +51,12 @@ const (
@@ -30,7 +30,7 @@ index 8cf242133..bdd481382 100644
  	// search each annotation for during the pre-drain.delete lifecycle hook
  	// to pause reconciliation of deletion. These hooks will prevent removal of
 diff --git a/api/core/v1beta2/machine_types.go b/api/core/v1beta2/machine_types.go
-index e480f0773..cff104875 100644
+index 8069c99e1..61c79e2b5 100644
 --- a/api/core/v1beta2/machine_types.go
 +++ b/api/core/v1beta2/machine_types.go
 @@ -30,9 +30,12 @@ const (

--- a/projects/kubernetes-sigs/cluster-api/patches/0018-add-support-for-registry-credentials.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0018-add-support-for-registry-credentials.patch
@@ -1,4 +1,4 @@
-From 5d4e80ba599c40014da9efee59f3188aeeaa72d3 Mon Sep 17 00:00:00 2001
+From 1e29f1ccb19b07743ee1f1e7844162e54629a573 Mon Sep 17 00:00:00 2001
 From: Ahree Hong <ahreeh@amazon.com>
 Date: Wed, 14 Dec 2022 12:47:42 -0800
 Subject: [PATCH 18/37] add support for registry credentials

--- a/projects/kubernetes-sigs/cluster-api/patches/0019-Add-support-for-configuring-NTP-servers-on-bottleroc.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0019-Add-support-for-configuring-NTP-servers-on-bottleroc.patch
@@ -1,4 +1,4 @@
-From 2ac34465415f7e1cec05fef7676c4dc36536fc1d Mon Sep 17 00:00:00 2001
+From be1284c6b3e9975d734eec9c97d587f8f83170a7 Mon Sep 17 00:00:00 2001
 From: Abhinav <abhinavmpandey08@gmail.com>
 Date: Wed, 1 Feb 2023 16:34:23 -0800
 Subject: [PATCH 19/37] Add support for configuring NTP servers on bottlerocket

--- a/projects/kubernetes-sigs/cluster-api/patches/0020-set-hostname-for-BR-nodes.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0020-set-hostname-for-BR-nodes.patch
@@ -1,4 +1,4 @@
-From 925364ed7986f91f2835be83ff4e99b2437d9081 Mon Sep 17 00:00:00 2001
+From 8d03f753f536a9ce1fe7463ad8665c84f90a842b Mon Sep 17 00:00:00 2001
 From: Ahree Hong <ahreeh@amazon.com>
 Date: Tue, 7 Feb 2023 14:26:36 -0800
 Subject: [PATCH 20/37] set hostname for BR nodes
@@ -2091,7 +2091,7 @@ index 758ae1b6c..b50a2c895 100644
                                  description: |-
                                    BottlerocketAdmin holds the image source for admin container
 diff --git a/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplane.go b/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplane.go
-index f90c29c4e..922dddcf4 100644
+index f90c29c4e..8fd519242 100644
 --- a/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplane.go
 +++ b/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplane.go
 @@ -145,6 +145,7 @@ func (webhook *KubeadmControlPlane) ValidateUpdate(_ context.Context, oldObj, ne

--- a/projects/kubernetes-sigs/cluster-api/patches/0021-add-br-kernel.sysctl-settings.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0021-add-br-kernel.sysctl-settings.patch
@@ -1,4 +1,4 @@
-From b30e80f6fcd3772796810879c60107f345f838fa Mon Sep 17 00:00:00 2001
+From 0a65a957eb334935411c4e4c0b3aa96e60ff7601 Mon Sep 17 00:00:00 2001
 From: Ahree Hong <ahreeh@amazon.com>
 Date: Tue, 7 Mar 2023 14:01:39 -0800
 Subject: [PATCH 21/37] add br kernel.sysctl settings

--- a/projects/kubernetes-sigs/cluster-api/patches/0022-add-boot-kernel-settings-for-BR.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0022-add-boot-kernel-settings-for-BR.patch
@@ -1,4 +1,4 @@
-From 6b9b2d949d9bc57c61316c0164a31adf34c4b7a4 Mon Sep 17 00:00:00 2001
+From fd6ad432347101bee4147a57f75a4c97cd800fdd Mon Sep 17 00:00:00 2001
 From: Ahree Hong <ahreeh@amazon.com>
 Date: Thu, 23 Mar 2023 01:51:16 -0700
 Subject: [PATCH 22/37] add boot kernel settings for BR

--- a/projects/kubernetes-sigs/cluster-api/patches/0023-Patch-haproxy-maxconn-value-to-avoid-ulimit-issue.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0023-Patch-haproxy-maxconn-value-to-avoid-ulimit-issue.patch
@@ -1,4 +1,4 @@
-From fb54bca3df74e1d1784a10a5965a4088e8df2180 Mon Sep 17 00:00:00 2001
+From 8a5867d0bf243cf0f5f64303ca677afe04476efe Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Sat, 6 May 2023 14:08:17 -0500
 Subject: [PATCH 23/37] Patch haproxy maxconn value to avoid ulimit issue

--- a/projects/kubernetes-sigs/cluster-api/patches/0024-CAPI-Move-Cluster-Filter.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0024-CAPI-Move-Cluster-Filter.patch
@@ -1,4 +1,4 @@
-From 7c587777e18a5bdaddda0f604c615a65a41a530a Mon Sep 17 00:00:00 2001
+From 76dcfde62cf7585c7265286c0fced2ffa648640b Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 16 May 2023 11:03:09 -0500
 Subject: [PATCH 24/37] CAPI Move Cluster Filter

--- a/projects/kubernetes-sigs/cluster-api/patches/0025-Move-objects-with-force-move-label-and-no-cluster-te.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0025-Move-objects-with-force-move-label-and-no-cluster-te.patch
@@ -1,4 +1,4 @@
-From 17b299932ea9cb341ba18f23be295729a299a986 Mon Sep 17 00:00:00 2001
+From 26d788124d2aebe969e1b53440fb23e33c53fda3 Mon Sep 17 00:00:00 2001
 From: Vignesh Goutham Ganesh <vgg@amazon.com>
 Date: Tue, 30 May 2023 10:14:31 -0500
 Subject: [PATCH 25/37] Move objects with force move label and no cluster

--- a/projects/kubernetes-sigs/cluster-api/patches/0026-allow-registry-mirror-configurations-to-be-mutable-f.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0026-allow-registry-mirror-configurations-to-be-mutable-f.patch
@@ -1,31 +1,35 @@
-From d062573e34aea1f0f41d2f2e2796094d60fc4bde Mon Sep 17 00:00:00 2001
+From 7a3a195bf0955ac09a72c61275c78917b9b34185 Mon Sep 17 00:00:00 2001
 From: Cavaughn Browne <cxbrowne@amazon.com>
 Date: Thu, 20 Jul 2023 11:05:49 -0500
 Subject: [PATCH 26/37] allow registry mirror configurations to be mutable for
  BR
 
 ---
- .../internal/webhooks/kubeadmcontrolplane.go  |  2 +
+ .../internal/webhooks/kubeadmcontrolplane.go  |  6 +++
  .../webhooks/kubeadmcontrolplane_test.go      | 45 +++++++++++++++++++
- 2 files changed, 47 insertions(+)
+ 2 files changed, 51 insertions(+)
 
 diff --git a/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplane.go b/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplane.go
-index 922dddcf4..9c8c27bc1 100644
+index 8fd519242..a44da7d07 100644
 --- a/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplane.go
 +++ b/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplane.go
-@@ -163,6 +163,7 @@ func (webhook *KubeadmControlPlane) ValidateUpdate(_ context.Context, oldObj, ne
+@@ -163,6 +163,9 @@ func (webhook *KubeadmControlPlane) ValidateUpdate(_ context.Context, oldObj, ne
  		{spec, kubeadmConfigSpec, clusterConfiguration, controllerManager, "*"},
  		{spec, kubeadmConfigSpec, clusterConfiguration, scheduler},
  		{spec, kubeadmConfigSpec, clusterConfiguration, scheduler, "*"},
 +		{spec, kubeadmConfigSpec, clusterConfiguration, "registryMirror", "*"},
++		{spec, kubeadmConfigSpec, clusterConfiguration, "certBundles"},
++		{spec, kubeadmConfigSpec, clusterConfiguration, "certBundles", "*"},
  		{spec, kubeadmConfigSpec, clusterConfiguration, "certificateValidityPeriodDays"},
  		{spec, kubeadmConfigSpec, clusterConfiguration, "encryptionAlgorithm"},
  		// spec.kubeadmConfigSpec.initConfiguration
-@@ -182,6 +183,7 @@ func (webhook *KubeadmControlPlane) ValidateUpdate(_ context.Context, oldObj, ne
+@@ -182,6 +185,9 @@ func (webhook *KubeadmControlPlane) ValidateUpdate(_ context.Context, oldObj, ne
  		{spec, kubeadmConfigSpec, joinConfiguration, "bottlerocketControl", "*"},
  		{spec, kubeadmConfigSpec, joinConfiguration, "bottlerocketCustomBootstrapContainers"},
  		{spec, kubeadmConfigSpec, joinConfiguration, "bottlerocket", "*"},
 +		{spec, kubeadmConfigSpec, joinConfiguration, "registryMirror", "*"},
++		{spec, kubeadmConfigSpec, joinConfiguration, "certBundles"},
++		{spec, kubeadmConfigSpec, joinConfiguration, "certBundles", "*"},
  		{spec, kubeadmConfigSpec, joinConfiguration, "pause", "*"},
  		{spec, kubeadmConfigSpec, joinConfiguration, nodeRegistration},
  		{spec, kubeadmConfigSpec, joinConfiguration, nodeRegistration, "*"},

--- a/projects/kubernetes-sigs/cluster-api/patches/0027-Add-support-for-external-etcd-machines-in-Kind-mappe.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0027-Add-support-for-external-etcd-machines-in-Kind-mappe.patch
@@ -1,4 +1,4 @@
-From ae4c6ff0da9accb47916056eafecc2aa2874ae7e Mon Sep 17 00:00:00 2001
+From 08c927995f8edf6962e6e2af69fc7bce7989bc26 Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
 Date: Wed, 16 Aug 2023 19:58:01 -0700
 Subject: [PATCH 27/37] Add support for external etcd machines in Kind mapper

--- a/projects/kubernetes-sigs/cluster-api/patches/0028-disable-cgroupns-private-to-fix-AL2.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0028-disable-cgroupns-private-to-fix-AL2.patch
@@ -1,4 +1,4 @@
-From 7965ab7efc90f0721cdd9270d253e493f62360bc Mon Sep 17 00:00:00 2001
+From 95e3789421829098bd7566556f05d4adbff20a9e Mon Sep 17 00:00:00 2001
 From: Jackson West <jgw@amazon.com>
 Date: Sat, 19 Aug 2023 09:35:39 -0500
 Subject: [PATCH 28/37] disable cgroupns=private to fix AL2

--- a/projects/kubernetes-sigs/cluster-api/patches/0029-Add-support-for-in-place-upgrade.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0029-Add-support-for-in-place-upgrade.patch
@@ -1,4 +1,4 @@
-From 6b3c6d7fbb56a346a7cbfedbdcc4ff01426047c0 Mon Sep 17 00:00:00 2001
+From 1d0fdd1180ad2e973bb7d6ab0dfd98044730ee94 Mon Sep 17 00:00:00 2001
 From: Abhinav Pandey <abhinavmpandey08@gmail.com>
 Date: Wed, 17 Jan 2024 09:28:18 -0800
 Subject: [PATCH 29/37] Add support for in-place upgrade
@@ -356,10 +356,10 @@ index d84fd5d9c..0984c24e7 100644
  	}
  }
 diff --git a/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplane.go b/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplane.go
-index 9c8c27bc1..3023fa3af 100644
+index a44da7d07..5b09f0cdf 100644
 --- a/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplane.go
 +++ b/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplane.go
-@@ -376,12 +376,12 @@ func validateRolloutAndCertValidityFields(rolloutSpec controlplanev1.KubeadmCont
+@@ -380,12 +380,12 @@ func validateRolloutAndCertValidityFields(rolloutSpec controlplanev1.KubeadmCont
  		return nil
  	}
  

--- a/projects/kubernetes-sigs/cluster-api/patches/0030-Adding-support-for-multiple-registry-mirrors-in-bott.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0030-Adding-support-for-multiple-registry-mirrors-in-bott.patch
@@ -1,4 +1,4 @@
-From df7f6a471507a0176c0313dc0f3a63cab76e1964 Mon Sep 17 00:00:00 2001
+From 339b3f1d88d0651ba801ae78ad7bda8c8748edcf Mon Sep 17 00:00:00 2001
 From: Aravind Ramalingam <ramaliar@amazon.com>
 Date: Mon, 22 Jan 2024 12:47:26 -0800
 Subject: [PATCH 30/37] Adding support for multiple registry mirrors in

--- a/projects/kubernetes-sigs/cluster-api/patches/0031-Add-Bottlerocket-kubernetes-settings-for-kubelet-con.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0031-Add-Bottlerocket-kubernetes-settings-for-kubelet-con.patch
@@ -1,4 +1,4 @@
-From 92e8fde9c4469c39ec1012c06ad56bf951d94d38 Mon Sep 17 00:00:00 2001
+From 2c077521cae0c3bff960b93e6a651cc09b12c28c Mon Sep 17 00:00:00 2001
 From: Mitali Paygude <mitalipaygude@gmail.com>
 Date: Fri, 31 May 2024 02:10:39 -0700
 Subject: [PATCH 31/37] Add Bottlerocket kubernetes settings for kubelet

--- a/projects/kubernetes-sigs/cluster-api/patches/0032-Add-changes-to-support-kubeadm-v1beta4-types.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0032-Add-changes-to-support-kubeadm-v1beta4-types.patch
@@ -1,4 +1,4 @@
-From 0bb3f8712e5d99a73a64758e10b4e9ae33b0268b Mon Sep 17 00:00:00 2001
+From 0f6fbd7768804ab89dd04dde1d871df7ba977814 Mon Sep 17 00:00:00 2001
 From: Tanvir Tatla <tatlat@amazon.com>
 Date: Tue, 17 Sep 2024 16:45:06 -0700
 Subject: [PATCH 32/37] Add changes to support kubeadm v1beta4 types

--- a/projects/kubernetes-sigs/cluster-api/patches/0033-Disable-MachineSetPreflightChecks-Beta-feature.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0033-Disable-MachineSetPreflightChecks-Beta-feature.patch
@@ -1,4 +1,4 @@
-From ecdb59bd71b7406d85fbf5c955921c96b255201b Mon Sep 17 00:00:00 2001
+From cc35ae1984f98adc101cd7cd1a18989499c1e7fc Mon Sep 17 00:00:00 2001
 From: Shizhao Liu <lshizhao@amazon.com>
 Date: Thu, 27 Feb 2025 14:26:37 -0800
 Subject: [PATCH 33/37] Disable MachineSetPreflightChecks Beta feature

--- a/projects/kubernetes-sigs/cluster-api/patches/0034-Update-conversion-files-for-upstreamv1beta3-and-upst.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0034-Update-conversion-files-for-upstreamv1beta3-and-upst.patch
@@ -1,4 +1,4 @@
-From f411c53802b57f91b5c88412658777230122c89d Mon Sep 17 00:00:00 2001
+From 58af180309802e6f492e611832df351658b7937c Mon Sep 17 00:00:00 2001
 From: Pankti <shah.pankti2609@gmail.com>
 Date: Tue, 7 Oct 2025 14:21:01 -0700
 Subject: [PATCH 34/37] Update conversion files for upstreamv1beta3 and

--- a/projects/kubernetes-sigs/cluster-api/patches/0035-Make-ManagedExternalEtcdRef-a-pointer-field-in-v1bet.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0035-Make-ManagedExternalEtcdRef-a-pointer-field-in-v1bet.patch
@@ -1,4 +1,4 @@
-From 89e64102edc2ffc853aa5ba2480a30a64094e013 Mon Sep 17 00:00:00 2001
+From 76de0e2c1f8dd536bf252409b4a1fc32a69cfb5f Mon Sep 17 00:00:00 2001
 From: Pankti <shah.pankti2609@gmail.com>
 Date: Tue, 14 Oct 2025 12:11:10 -0700
 Subject: [PATCH 35/37] Make ManagedExternalEtcdRef a pointer field in v1beta2

--- a/projects/kubernetes-sigs/cluster-api/patches/0036-Fix-missing-registryMirror.mirrors-field-in-kcp-conv.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0036-Fix-missing-registryMirror.mirrors-field-in-kcp-conv.patch
@@ -1,4 +1,4 @@
-From b7be2e65c1d43dc1b570a4ba13013a397e0e10c0 Mon Sep 17 00:00:00 2001
+From 9d522f6e9aac953a3098f5c7497d5df0007cbdc7 Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
 Date: Mon, 27 Oct 2025 16:14:56 -0700
 Subject: [PATCH 36/37] Fix missing registryMirror.mirrors field in kcp

--- a/projects/kubernetes-sigs/cluster-api/patches/0037-Fix-KubeadmControlPlane-webhook-to-properly-default-.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0037-Fix-KubeadmControlPlane-webhook-to-properly-default-.patch
@@ -1,4 +1,4 @@
-From 21f1d930ec22d4fbe1f427aef9f0c0c0f5bedd65 Mon Sep 17 00:00:00 2001
+From 0c33078ebdb8393ce7fc549cac7523d0e57a9e60 Mon Sep 17 00:00:00 2001
 From: rajeshvenkata <rajesh.venkat.p@gmail.com>
 Date: Thu, 30 Oct 2025 14:51:59 -0700
 Subject: [PATCH 37/37] Fix KubeadmControlPlane webhook to properly default
@@ -9,7 +9,7 @@ Subject: [PATCH 37/37] Fix KubeadmControlPlane webhook to properly default
  1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplane.go b/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplane.go
-index 3023fa3af..609786a30 100644
+index 5b09f0cdf..ad2495e4b 100644
 --- a/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplane.go
 +++ b/controlplane/kubeadm/internal/webhooks/kubeadmcontrolplane.go
 @@ -85,8 +85,12 @@ func defaultKubeadmControlPlaneSpec(s *controlplanev1.KubeadmControlPlaneSpec) {


### PR DESCRIPTION
*Description of changes:*

Allow setting bottlerocket certBundles via upgrade workflow. Without this, kcp controller validation fails with error
````
- spec.kubeadmConfigSpec.clusterConfiguration.certBundles: Forbidden: cannot be modified
  - spec.kubeadmConfigSpec.joinConfiguration.certBundles: Forbidden: cannot be modified
  ```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
