### PR TITLE
Fix prometheus.namespace template to honor targetNamespace

### DIFF
--- a/projects/prometheus/prometheus/helm/patches/0004-Add-namespace-to-charts.patch
+++ b/projects/prometheus/prometheus/helm/patches/0004-Add-namespace-to-charts.patch
@@ -1,4 +1,4 @@
-From 527d2b4838d03206894b7d93fc7c2cdd3b1cce8e Mon Sep 17 00:00:00 2001
+From 080e2e03173ebbaf4c0d25c83ae3584c15232c75 Mon Sep 17 00:00:00 2001
 From: Prow Bot <prow@amazonaws.com>
 Date: Wed, 17 Dec 2025 21:57:05 -0800
 Subject: [PATCH 4/6] Add namespace to charts
@@ -9,7 +9,7 @@ Subject: [PATCH 4/6] Add namespace to charts
  2 files changed, 8 insertions(+), 2 deletions(-)
 
 diff --git a/charts/prometheus/templates/_helpers.tpl b/charts/prometheus/templates/_helpers.tpl
-index fc0b0cbf..62e6bb0c 100644
+index fc0b0cbf..5fe3440a 100644
 --- a/charts/prometheus/templates/_helpers.tpl
 +++ b/charts/prometheus/templates/_helpers.tpl
 @@ -170,8 +170,12 @@ Create the name of the service account to use for the server component
@@ -19,9 +19,9 @@ index fc0b0cbf..62e6bb0c 100644
 -  {{- default .Release.Namespace .Values.forceNamespace -}}
 -{{- end }}
 +  {{- if .Values.forceNamespace -}}
-+    {{- default .Values.forceNamespace .Values.defaultNamespace -}}
++    {{- .Values.forceNamespace -}}
 +  {{- else -}}
-+    {{- default .Release.Namespace .Values.defaultNamespace -}}
++    {{- default .Values.defaultNamespace .Release.Namespace -}}
 +  {{- end -}}
 +{{- end -}}
  


### PR DESCRIPTION
Fix prometheus.namespace template to honor targetNamespace

*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3891

*Description of changes:*
Fix the `prometheus.namespace` helm template so that a package's
`spec.targetNamespace` (.Release.Namespace) is honored.

The template misused Helm's `default` function. `default A B` returns B
if non-empty, otherwise A. The previous code was:

    {{- if .Values.forceNamespace -}}
        {{- default .Values.forceNamespace .Values.defaultNamespace -}}
    {{- else -}}
        {{- default .Release.Namespace .Values.defaultNamespace -}}
    {{- end -}}

Since `defaultNamespace: "observability"` is always non-empty, both
branches always returned "observability", so `.Release.Namespace`
(the user-specified targetNamespace) was always ignored.

Fixed to:

    {{- if .Values.forceNamespace -}}
        {{- .Values.forceNamespace -}}
    {{- else -}}
        {{- default .Values.defaultNamespace .Release.Namespace -}}
    {{- end -}}

Precedence is now: forceNamespace > .Release.Namespace (targetNamespace)
> defaultNamespace ("observability" fallback).

Implemented in:
  projects/prometheus/prometheus/helm/patches/0004-Add-namespace-to-charts.patch

*Testing*
Built and tested on a vSphere EKS-A cluster (Kubernetes 1.33):
- `make release` succeeded for prometheus + node-exporter; images and
  helm chart pushed to ECR; validate-checksums OK
- Installed the chart into a custom namespace:
    helm install prometheus oci://<registry>/prometheus/charts/prometheus \
      --version 3.8.0-... --set sourceRegistry=<registry> \
      --namespace my-custom-ns
- Confirmed all resources are created in `my-custom-ns` (not forced into
  "observability"):
    $ kubectl get pods,svc,cm -n my-custom-ns | grep prometheus
    pod/prometheus-server-...               Running
    pod/prometheus-node-exporter-...        Running
    service/prometheus-server               ...
    service/prometheus-node-exporter        ...
    configmap/prometheus-server             ...
- NOTES shows prometheus-server.my-custom-ns.svc.cluster.local

**Additional testing via Package CR (kubectl apply):**
- Overrode PackageBundleController defaultRegistry to point to personal ECR with patched chart
- Applied Package CR with `spec.targetNamespace: prom-cr-test`
- Package reached STATE=installed; all prometheus resources (server, node-exporter) created in `prom-cr-test` namespace
- Confirms the full controller path (helmdriver.go install.Namespace) honors targetNamespace correctly


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<img width="1367" height="783" alt="Screenshot 2026-06-03 at 3 02 11 PM" src="https://github.com/user-attachments/assets/43b7513a-074f-4aea-848a-e63cb21a376b" />
<img width="1185" height="502" alt="Screenshot 2026-06-05 at 5 24 31 PM" src="https://github.com/user-attachments/assets/0f615e93-a96e-440b-a739-2238dc997157" />

