### PR TITLE
Bump metrics-server to v0.8.1-eksbuild.11

### DIFF
--- a/projects/kubernetes-sigs/metrics-server/EKS_ADDON_IMAGE_TAG
+++ b/projects/kubernetes-sigs/metrics-server/EKS_ADDON_IMAGE_TAG
@@ -1,1 +1,1 @@
-v0.8.1-eksbuild.2
+v0.8.1-eksbuild.11


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Bump metrics-server EKS addon image tag from v0.8.1-eksbuild.2 to v0.8.1-eksbuild.11 to address Go dependency CVEs (golang.org/x/crypto, golang.org/x/net, google.golang.org/grpc).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
