### PR TITLE
update EKSD_LATEST_RELEASES to 1-30

### DIFF
--- a/EKSD_LATEST_RELEASES
+++ b/EKSD_LATEST_RELEASES
@@ -1,4 +1,4 @@
-latest: 1-29
+latest: 1-30
 releases:
 - branch: 1-18
   kubeVersion: v1.18.20


### PR DESCRIPTION
The latest field on EKSD_LATEST_RELEASES should ideally be maintained at least on par with the minimum Kubernetes version supported for the release as that will help us in maintaining a reasonably decent version skew with the max K8s version supported in the release. Thus update the value to 1-30


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
