### PR TITLE
Add nutanix_cluster_uuid to fix image build cluster resolution

### DIFF
--- a/projects/aws/image-builder/builder/types.go
+++ b/projects/aws/image-builder/builder/types.go
@@ -123,6 +123,7 @@ type RhelConfig struct {
 
 type NutanixConfig struct {
 	ClusterName       string `json:"nutanix_cluster_name"`
+	ClusterUUID       string `json:"nutanix_cluster_uuid,omitempty"`
 	ImageName         string `json:"image_name"`
 	ImageSizeGb       string `json:"image_size_gb,omitempty"`
 	ImageUrl          string `json:"image_url,omitempty"`

--- a/projects/kubernetes-sigs/image-builder/packer/nutanix/nutanix.json
+++ b/projects/kubernetes-sigs/image-builder/packer/nutanix/nutanix.json
@@ -1,6 +1,7 @@
 {
     "nutanix_endpoint": "nutanix_endpoint",
     "nutanix_cluster_name": "cluster_name",
+    "nutanix_cluster_uuid": "",
     "nutanix_password": "nutanix_password",
     "nutanix_username": "nutanix_username",
     "nutanix_subnet_name": "nutanix_subnet_name"

--- a/projects/kubernetes-sigs/image-builder/patches/0019-Add-Nutanix-cluster-UUID-support.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0019-Add-Nutanix-cluster-UUID-support.patch
@@ -28,7 +28,7 @@ index 0353122c8..7efd0dd52 100644
      "machine_id_mode": "444",
      "memory": "2048",
      "nutanix_cluster_name": "{{env `NUTANIX_CLUSTER_NAME`}}",
-+    "nutanix_cluster_uuid": "",
++    "nutanix_cluster_uuid": "{{env `NUTANIX_CLUSTER_UUID`}}",
      "nutanix_endpoint": "{{env `NUTANIX_ENDPOINT`}}",
      "nutanix_insecure": "{{env `NUTANIX_INSECURE`}}",
      "nutanix_password": "{{env `NUTANIX_PASSWORD`}}",

--- a/projects/kubernetes-sigs/image-builder/patches/0019-Add-Nutanix-cluster-UUID-support.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0019-Add-Nutanix-cluster-UUID-support.patch
@@ -1,0 +1,37 @@
+From fc2315f1adf6718a450f1ffd22ec9e3c28f28603 Mon Sep 17 00:00:00 2001
+From: Amelia Lu <peirulu@amazon.com>
+Date: Mon, 29 Jun 2026 00:31:52 -0700
+Subject: [PATCH] Add Nutanix cluster UUID support
+
+When multiple clusters share the same name (e.g. Prism Central and
+Prism Element both named "nutanix-ci-cluster"), the Packer Nutanix
+plugin may resolve to the wrong cluster. Adding cluster_uuid allows
+unambiguous cluster targeting. The plugin gives cluster_uuid precedence
+over cluster_name when both are set.
+---
+ images/capi/packer/nutanix/packer.json.tmpl | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/images/capi/packer/nutanix/packer.json.tmpl b/images/capi/packer/nutanix/packer.json.tmpl
+index 0353122c8..7efd0dd52 100644
+--- a/images/capi/packer/nutanix/packer.json.tmpl
++++ b/images/capi/packer/nutanix/packer.json.tmpl
+@@ -3,6 +3,7 @@
+     {
+       "boot_type": "{{user `boot_type`}}",
+       "cluster_name": "{{user `nutanix_cluster_name`}}",
++      "cluster_uuid": "{{user `nutanix_cluster_uuid`}}",
+       "cpu": "{{user `cpus`}}",
+       "force_deregister": "{{user `force_deregister`}}",
+       "image_delete": "{{user `image_delete`}}",
+@@ -154,6 +155,7 @@
+     "machine_id_mode": "444",
+     "memory": "2048",
+     "nutanix_cluster_name": "{{env `NUTANIX_CLUSTER_NAME`}}",
++    "nutanix_cluster_uuid": "",
+     "nutanix_endpoint": "{{env `NUTANIX_ENDPOINT`}}",
+     "nutanix_insecure": "{{env `NUTANIX_INSECURE`}}",
+     "nutanix_password": "{{env `NUTANIX_PASSWORD`}}",
+-- 
+2.48.1
+


### PR DESCRIPTION
## Summary

- Add `nutanix_cluster_uuid` field to `NutanixConfig` struct in image-builder CLI
- Add `nutanix_cluster_uuid` variable to `packer/nutanix/nutanix.json` template
- Add patch to upstream packer template adding `cluster_uuid` builder field

## Problem

All Nutanix image builds are failing with:
```
==> nutanix: Unable to create virtual machine: error waiting for VM creation: 
    task failed: Failed to perform the operation due to an internal error.
```

Root cause: Two clusters in Prism Central share the name `nutanix-ci-cluster`:
- `7887b68c...` — **Prism Central** (cannot run VMs) on `10.70.2.0/24`
- `000628ec...` — **AHV Compute** (4 hypervisor nodes) on `10.70.128.0/24`

Packer resolves `nutanix_cluster_name: "nutanix-ci-cluster"` to Prism Central, which rejects VM creation.

## Fix

The Packer Nutanix plugin supports `cluster_uuid` ([reference](https://github.com/nutanix-cloud-native/packer-plugin-nutanix/blob/main/builder/nutanix/config.go#L126)) which takes precedence over `cluster_name`. This PR adds the plumbing so that when `nutanix_cluster_uuid` is set in the config, it flows through to the Packer template.
