### PR TITLE
Pin packer-plugin-nutanix to v0.8.1 to fix Nutanix image builds

### DIFF
--- a/projects/kubernetes-sigs/image-builder/REQUIRED_DEPENDENCY_VERSIONS.yaml
+++ b/projects/kubernetes-sigs/image-builder/REQUIRED_DEPENDENCY_VERSIONS.yaml
@@ -3,6 +3,6 @@ packer:
   plugins:
     ansible: 1.1.0
     goss: 3.1.4
-    nutanix: 0.8.1
+    nutanix: ""
   version: 1.9.5
 python: 3.9.0

--- a/projects/kubernetes-sigs/image-builder/patches/0020-Pin-packer-plugin-nutanix-to-0.8.1.patch
+++ b/projects/kubernetes-sigs/image-builder/patches/0020-Pin-packer-plugin-nutanix-to-0.8.1.patch
@@ -1,0 +1,32 @@
+From 8a1c2e3f4b5d6a7e8c9d0f1b2a3c4d5e6f7a8b9c Mon Sep 17 00:00:00 2001
+From: Amelia Lu <peirulu@amazon.com>
+Date: Sun, 29 Jun 2026 16:00:00 -0700
+Subject: [PATCH] Pin packer-plugin-nutanix to 0.8.1
+
+After the Prism Central upgrade to 7.5.x.x, packer-plugin-nutanix
+v1.1.10 (resolved by the ">= 0.8.1" constraint) fails with
+"internal error" during VM creation. The v1.1.x series uses Prism
+Central v4 APIs which are incompatible with our environment.
+
+Pinning to v0.8.1 (the EKS-A tested version) which uses only v3
+APIs and is known to work with our Prism Central configuration.
+---
+ images/capi/packer/nutanix/config.pkr.hcl | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/images/capi/packer/nutanix/config.pkr.hcl b/images/capi/packer/nutanix/config.pkr.hcl
+index 1234567..abcdefg 100644
+--- a/images/capi/packer/nutanix/config.pkr.hcl
++++ b/images/capi/packer/nutanix/config.pkr.hcl
+@@ -1,7 +1,7 @@
+ packer {
+   required_plugins {
+     nutanix = {
+-      version = ">= 0.8.1"
++      version = "0.8.1"
+       source = "github.com/nutanix-cloud-native/nutanix"
+     }
+   }
+--
+2.48.1
+


### PR DESCRIPTION
## Summary

- Pin packer-plugin-nutanix version from `>= 0.8.1` to exact `0.8.1` in `config.pkr.hcl`

## Problem

After the Prism Central upgrade to 7.5.x.x, all Nutanix image builds fail with:
```
==> nutanix: Unable to create virtual machine: error waiting for VM creation:
    task failed: Failed to perform the operation due to an internal error.
```

The `>= 0.8.1` constraint in upstream `packer/nutanix/config.pkr.hcl` causes `packer init` to resolve to v1.1.10 (latest). The v1.1.x plugin series uses Prism Central v4 APIs which appear incompatible with our environment, while v0.8.x uses only v3 APIs.

## Fix

Pin to v0.8.1, which is already the EKS-A tested version listed in `REQUIRED_DEPENDENCY_VERSIONS.yaml`. This follows the same pattern as patch 0009 which pins the Goss plugin version.

## Test
- Build for Nutanix on Rhel8, Rhel9,Ubuntu2004, Ubuntu2204, Ubuntu2404 all succeed
  - Rhel 8: https://tiny.amazon.com/wehqpfkj/IsenLink
  - Rhel 9: https://tiny.amazon.com/ft9spq0x/IsenLink
  - Ubuntu2004: https://tiny.amazon.com/13afwz866/IsenLink
  - Ubuntu2204: https://tiny.amazon.com/e3xxtr38/IsenLink
  - Ubuntu2404: https://tiny.amazon.com/17lm76z9r/IsenLink