### PR TITLE
fix(cluster-api): Use registryHost for registry mirror credential host

### DIFF
--- a/projects/kubernetes-sigs/cluster-api/patches/0017-add-support-for-registry-credentials.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0017-add-support-for-registry-credentials.patch
@@ -29,7 +29,7 @@ index 04fb96221..5e8573f09 100644
 +username = "{{.RegistryMirrorUsername}}"
 +password = "{{.RegistryMirrorPassword}}"
 +[[settings.container-registry.credentials]]
-+registry = "{{.RegistryMirrorEndpoint}}"
++registry = "{{.RegistryMirrorCredentialHost}}"
 +username = "{{.RegistryMirrorUsername}}"
 +password = "{{.RegistryMirrorPassword}}"
 +{{- end -}}
@@ -59,16 +59,17 @@ index bf484f182..096b47ffc 100644
  }
  
  type BottlerocketSettingsInput struct {
-@@ -45,6 +46,8 @@ type BottlerocketSettingsInput struct {
+@@ -45,6 +46,9 @@ type BottlerocketSettingsInput struct {
  	NoProxyEndpoints           []string
  	RegistryMirrorEndpoint     string
  	RegistryMirrorCACert       string
 +	RegistryMirrorUsername     string
 +	RegistryMirrorPassword     string
++	RegistryMirrorCredentialHost string
  	NodeLabels                 string
  	Taints                     string
  	ProviderId                 string
-@@ -57,6 +60,11 @@ type HostPath struct {
+@@ -57,6 +61,20 @@ type HostPath struct {
  	Type string
  }
  
@@ -77,10 +78,19 @@ index bf484f182..096b47ffc 100644
 +	Password string
 +}
 +
++// registryHost strips the path from a registry endpoint, returning only the host:port.
++// For example, "192.168.1.1:443/v2" becomes "192.168.1.1:443".
++func registryHost(endpoint string) string {
++	if idx := strings.Index(endpoint, "/"); idx != -1 {
++		return endpoint[:idx]
++	}
++	return endpoint
++}
++
  func generateBootstrapContainerUserData(kind string, tpl string, data interface{}) ([]byte, error) {
  	tm := template.New(kind).Funcs(defaultTemplateFuncMap)
  	if _, err := tm.Parse(filesTemplate); err != nil {
-@@ -128,6 +136,9 @@ func generateNodeUserData(kind string, tpl string, data interface{}) ([]byte, er
+@@ -128,6 +146,9 @@ func generateNodeUserData(kind string, tpl string, data interface{}) ([]byte, er
  	if _, err := tm.Parse(registryMirrorCACertTemplate); err != nil {
  		return nil, errors.Wrapf(err, "failed to parse registry mirror ca cert %s template", kind)
  	}
@@ -90,13 +100,14 @@ index bf484f182..096b47ffc 100644
  	if _, err := tm.Parse(nodeLabelsTemplate); err != nil {
  		return nil, errors.Wrapf(err, "failed to parse node labels %s template", kind)
  	}
-@@ -212,6 +223,11 @@ func getBottlerocketNodeUserData(bootstrapContainerUserData []byte, users []boot
+@@ -212,6 +233,12 @@ func getBottlerocketNodeUserData(bootstrapContainerUserData []byte, users []boot
  		bottlerocketInput.RegistryMirrorCACert = base64.StdEncoding.EncodeToString([]byte(config.RegistryMirrorConfiguration.CACert))
  	}
  
 +	if config.RegistryMirrorCredentials.Username != "" && config.RegistryMirrorCredentials.Password != "" {
 +		bottlerocketInput.RegistryMirrorUsername = config.RegistryMirrorCredentials.Username
 +		bottlerocketInput.RegistryMirrorPassword = config.RegistryMirrorCredentials.Password
++		bottlerocketInput.RegistryMirrorCredentialHost = registryHost(config.RegistryMirrorConfiguration.Endpoint)
 +	}
 +
  	bottlerocketNodeUserData, err := generateNodeUserData("InitBottlerocketNode", bottlerocketNodeInitSettingsTemplate, bottlerocketInput)

--- a/projects/kubernetes-sigs/cluster-api/patches/0018-Add-support-for-configuring-NTP-servers-on-bottleroc.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0018-Add-support-for-configuring-NTP-servers-on-bottleroc.patch
@@ -119,9 +119,10 @@ index 096b47ffc..05cd01b8a 100644
  	RegistryMirrorCredentials
  }
  
-@@ -49,6 +50,7 @@ type BottlerocketSettingsInput struct {
+@@ -49,7 +50,8 @@ type BottlerocketSettingsInput struct {
  	RegistryMirrorUsername     string
  	RegistryMirrorPassword     string
+ 	RegistryMirrorCredentialHost string
  	NodeLabels                 string
 +	NTPServers                 []string
  	Taints                     string
@@ -137,14 +138,15 @@ index 096b47ffc..05cd01b8a 100644
  	t, err := tm.Parse(tpl)
  	if err != nil {
  		return nil, errors.Wrapf(err, "failed to parse %s template", kind)
-@@ -222,11 +227,15 @@ func getBottlerocketNodeUserData(bootstrapContainerUserData []byte, users []boot
+@@ -232,12 +237,17 @@ func getBottlerocketNodeUserData(bootstrapContainerUserData []byte, users []boot
  	if config.RegistryMirrorConfiguration.CACert != "" {
  		bottlerocketInput.RegistryMirrorCACert = base64.StdEncoding.EncodeToString([]byte(config.RegistryMirrorConfiguration.CACert))
  	}
--
+ 
  	if config.RegistryMirrorCredentials.Username != "" && config.RegistryMirrorCredentials.Password != "" {
  		bottlerocketInput.RegistryMirrorUsername = config.RegistryMirrorCredentials.Username
  		bottlerocketInput.RegistryMirrorPassword = config.RegistryMirrorCredentials.Password
+ 		bottlerocketInput.RegistryMirrorCredentialHost = registryHost(config.RegistryMirrorConfiguration.Endpoint)
  	}
 +	if len(config.NTPServers) > 0 {
 +		for _, ntp := range config.NTPServers {

--- a/projects/kubernetes-sigs/cluster-api/patches/0029-Adding-support-for-multiple-registry-mirrors-in-bott.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0029-Adding-support-for-multiple-registry-mirrors-in-bott.patch
@@ -562,7 +562,7 @@ index b3cf9a03f..9e88da034 100644
 +{{- end }}
 +{{- end }}
  [[settings.container-registry.credentials]]
- registry = "{{.RegistryMirrorEndpoint}}"
+ registry = "{{.RegistryMirrorCredentialHost}}"
  username = "{{.RegistryMirrorUsername}}"
  password = "{{.RegistryMirrorPassword}}"
  {{- end -}}
@@ -712,7 +712,7 @@ index 6a2243f5c..15d60df6f 100644
  		NodeLabels:               parseNodeLabels(getArgValue(config.KubeletExtraArgs, "node-labels")), // empty string if it does not exist
  		Taints:                   parseTaints(config.Taints),                                           //empty string if it does not exist
  		ProviderID:               getArgValue(config.KubeletExtraArgs, "provider-id"),
-@@ -251,6 +252,31 @@ func getBottlerocketNodeUserData(bootstrapContainerUserData []byte, users []boot
+@@ -251,6 +252,33 @@ func getBottlerocketNodeUserData(bootstrapContainerUserData []byte, users []boot
  			bottlerocketInput.NoProxyEndpoints = append(bottlerocketInput.NoProxyEndpoints, strconv.Quote(noProxy))
  		}
  	}
@@ -728,6 +728,7 @@ index 6a2243f5c..15d60df6f 100644
 +		if endpoint := endpointRegex.FindStringSubmatch(config.RegistryMirrorConfiguration.Endpoint); endpoint != nil {
 +			bottlerocketInput.RegistryMirrorEndpoint = endpoint[0]
 +		}
++		bottlerocketInput.RegistryMirrorCredentialHost = registryHost(config.RegistryMirrorConfiguration.Endpoint)
 +	} else if len(config.RegistryMirrorConfiguration.Mirrors) > 0 {
 +		for _, mirror := range config.RegistryMirrorConfiguration.Mirrors {
 +			for _, endpoint := range mirror.Endpoints {
@@ -739,6 +740,7 @@ index 6a2243f5c..15d60df6f 100644
 +		if endpoint := endpointRegex.FindStringSubmatch(config.RegistryMirrorConfiguration.Mirrors[0].Endpoints[0]); endpoint != nil {
 +			bottlerocketInput.RegistryMirrorEndpoint = endpoint[0]
 +		}
++		bottlerocketInput.RegistryMirrorCredentialHost = registryHost(config.RegistryMirrorConfiguration.Mirrors[0].Endpoints[0])
 +	}
 +
  	if config.RegistryMirrorConfiguration.CACert != "" {

--- a/projects/kubernetes-sigs/cluster-api/patches/0030-Add-Bottlerocket-kubernetes-settings-for-kubelet-con.patch
+++ b/projects/kubernetes-sigs/cluster-api/patches/0030-Add-Bottlerocket-kubernetes-settings-for-kubelet-con.patch
@@ -2043,7 +2043,7 @@ diff --git a/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go b/bootstrap
 index 15d60df6f..ece510d9d 100644
 --- a/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go
 +++ b/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go
-@@ -43,32 +43,59 @@ type BottlerocketConfig struct {
+@@ -43,33 +43,60 @@ type BottlerocketConfig struct {
  }
  
  // BottlerocketSettingsInput is the input for the Bottlerocket settings template.
@@ -2059,6 +2059,7 @@ index 15d60df6f..ece510d9d 100644
 -	RegistryMirrorCACert       string
 -	RegistryMirrorUsername     string
 -	RegistryMirrorPassword     string
+-	RegistryMirrorCredentialHost string
 -	NodeLabels                 string
 -	NTPServers                 []string
 -	Taints                     string
@@ -2085,6 +2086,7 @@ index 15d60df6f..ece510d9d 100644
 +	RegistryMirrorCACert            string
 +	RegistryMirrorUsername          string
 +	RegistryMirrorPassword          string
++	RegistryMirrorCredentialHost    string
 +	NodeLabels                      string
 +	NTPServers                      []string
 +	Taints                          string


### PR DESCRIPTION
Add RegistryMirrorCredentialHost field and registryHost helper to strip paths from registry endpoints when configuring container-registry credentials in Bottlerocket. This ensures the credential registry field uses only host:port rather than the full endpoint path.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
