### PR TITLE
Distribution (#5560 follow-up)

### DIFF
--- a/projects/goharbor/distribution/CHECKSUMS
+++ b/projects/goharbor/distribution/CHECKSUMS
@@ -1,2 +1,2 @@
-364daa8e41fdf1b4a6c7f4130fda21f75958e708f9686707daf18b234c7b8972  _output/bin/distribution/linux-amd64/registry
-7444a897cc88391ebc9d6de88e5390e5c47202be4dee1c1af0e6a17a4ae5fccd  _output/bin/distribution/linux-arm64/registry
+177c06c6e68bd75be31150ed730f6402ad4af4e3fa76b22cca3fa29ada13f789  _output/bin/distribution/linux-amd64/registry
+edf1fc4a03b6fd5c554317ee8033a31d5d48ace8b25e0075ef5dc96a5e8ed1ca  _output/bin/distribution/linux-arm64/registry


### PR DESCRIPTION
Issue #, if available:
N/A (follow-up to #5560)

Description of changes:
Update goharbor/distribution CHECKSUMS to match CodeBuild output after #5560 (Go dep CVE bump).


```
sha256sum: WARNING: 2 computed checksums did NOT match
--
Checksums do not match!
The correct checksums are printed below
Please only update if changing GIT_TAG or build flags.
*************** CHECKSUMS ***************
177c06c6e68bd75be31150ed730f6402ad4af4e3fa76b22cca3fa29ada13f789  _output/bin/distribution/linux-amd64/registry
edf1fc4a03b6fd5c554317ee8033a31d5d48ace8b25e0075ef5dc96a5e8ed1ca  _output/bin/distribution/linux-arm64/registry
*****************************************


```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.