### PR TITLE
Scanner-trivy (#5561 follow-up):

### DIFF
--- a/projects/goharbor/harbor-scanner-trivy/CHECKSUMS
+++ b/projects/goharbor/harbor-scanner-trivy/CHECKSUMS
@@ -1,2 +1,2 @@
-3b542ee72eb8a9f9449e541b4c55bbf43461300adc5d4103b2b089a22be30516  _output/bin/harbor-scanner-trivy/linux-amd64/scanner-trivy
-5d5e7285376e729f7764acf498df55a7dea128a0e78cea533a4825e51d6f77e8  _output/bin/harbor-scanner-trivy/linux-arm64/scanner-trivy
+93fad3f7a01560ba257d02b1d8f4344f5eb4e8dccffdad153732693ffbdd9001  _output/bin/harbor-scanner-trivy/linux-amd64/scanner-trivy
+e7368b1c9180a9e4eccf18035388837a8cde94f903c914e9b41bffa85d37b81b  _output/bin/harbor-scanner-trivy/linux-arm64/scanner-trivy


### PR DESCRIPTION
Issue #, if available:
N/A (follow-up to #5561)

Description of changes:
Update harbor-scanner-trivy CHECKSUMS to match CodeBuild output after #5561 (Go dep CVE bump).


```
Checksums do not match!
--
The correct checksums are printed below
Please only update if changing GIT_TAG or build flags.
*************** CHECKSUMS ***************
93fad3f7a01560ba257d02b1d8f4344f5eb4e8dccffdad153732693ffbdd9001  _output/bin/harbor-scanner-trivy/linux-amd64/scanner-trivy
e7368b1c9180a9e4eccf18035388837a8cde94f903c914e9b41bffa85d37b81b  _output/bin/harbor-scanner-trivy/linux-arm64/scanner-trivy
*****************************************


```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.