### PR TITLE
fix(aquasecurity/trivy): Update CHECKSUMS after CVE dep bump

### DIFF
--- a/projects/aquasecurity/trivy/CHECKSUMS
+++ b/projects/aquasecurity/trivy/CHECKSUMS
@@ -1,2 +1,2 @@
-a57c541f11a57b2e61781e57920ce53c620e0161780e63dff3403a95a3c6ee87  _output/bin/trivy/linux-amd64/trivy
-9350d79d4fe67c0d7f496d08e10296d18bf0c4582d2b9390ba9990772419a58b  _output/bin/trivy/linux-arm64/trivy
+e1f722bacbc60efcc1df59207181c3e5ddce9d2896d41ff8350196843ce6d521  _output/bin/trivy/linux-amd64/trivy
+e2d1b5a6bb4f77f20320f064ae7ada1c36f300df25489b07049c7577589a3043  _output/bin/trivy/linux-arm64/trivy


### PR DESCRIPTION
Issue #, if available:
N/A (follow-up to #5588)

Description of changes:
Update aquasecurity/trivy CHECKSUMS to match CodeBuild output after #5588 (Go dep CVE bump).


```
Checksums do not match!
--
The correct checksums are printed below
Please only update if changing GIT_TAG or build flags.
*************** CHECKSUMS ***************
e1f722bacbc60efcc1df59207181c3e5ddce9d2896d41ff8350196843ce6d521  _output/bin/trivy/linux-amd64/trivy
e2d1b5a6bb4f77f20320f064ae7ada1c36f300df25489b07049c7577589a3043  _output/bin/trivy/linux-arm64/trivy
*****************************************

```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.