### PR TITLE
feat(autoscaler): Bump cluster-autoscaler 1-36 to v1.36.0

### DIFF
--- a/UPSTREAM_PROJECTS.yaml
+++ b/UPSTREAM_PROJECTS.yaml
@@ -171,7 +171,7 @@ projects:
             go_version: "1.24"
           - tag: cluster-autoscaler-1.35.0
             go_version: "1.25"
-          - tag: cluster-autoscaler-1.35.0
+          - tag: cluster-autoscaler-1.36.0
             go_version: "1.25"
       - name: cloud-provider-aws
         versions:

--- a/projects/kubernetes/autoscaler/1-36/GIT_TAG
+++ b/projects/kubernetes/autoscaler/1-36/GIT_TAG
@@ -1,1 +1,1 @@
-cluster-autoscaler-1.35.0
+cluster-autoscaler-1.36.0

--- a/projects/kubernetes/autoscaler/README.md
+++ b/projects/kubernetes/autoscaler/README.md
@@ -6,8 +6,8 @@
 ![1.32 Version](https://img.shields.io/badge/1--32%20version-cluster--autoscaler--1.32.4-blue)
 ![1.33 Version](https://img.shields.io/badge/1--33%20version-cluster--autoscaler--1.33.3-blue)
 ![1.34 Version](https://img.shields.io/badge/1--34%20version-cluster--autoscaler--1.34.2-blue)
-![1.35 Version](https://img.shields.io/badge/1--35%20version-cluster--autoscaler--1.35.0-blue)
-![1.36 Version](https://img.shields.io/badge/1--36%20version-cluster--autoscaler--1.35.0-blue)
+![1.35 Version](https://img.shields.io/badge/1--35%20version-cluster--autoscaler--1.36.0-blue)
+![1.36 Version](https://img.shields.io/badge/1--36%20version-cluster--autoscaler--1.36.0-blue)
 ![Build Status](https://codebuild.us-west-2.amazonaws.com/badges?uuid=eyJlbmNyeXB0ZWREYXRhIjoiL0tWckptdkxsZEd1cXNiNTBncjRNVU5oekpZRlBkTDNBcFVvZkFOVHZwbTBKUm91QkR6RVN4QlhJWk42cXF3L29FMmdnTXUrVndiay8zVUQ0YjJsc21vPSIsIml2UGFyYW1ldGVyU3BlYyI6Ik1Gd2UwbmRXVWxSRTMvUHQiLCJtYXRlcmlhbFNldFNlcmlhbCI6MX0%3D&branch=main)
 
 [Autoscaler](https://github.com/kubernetes/autoscaler) defines the cluster autoscaler.


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Bump cluster-autoscaler 1-36 GIT_TAG from v1.35.0 to v1.36.0.

Note: CHECKSUMS will be updated in a follow-up PR after CodeBuild produces the correct values for the new binary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.