### PR TITLE
[autoscaler] Revert 1-35 CHECKSUMS to original values

### DIFF
--- a/projects/kubernetes/autoscaler/1-35/CHECKSUMS
+++ b/projects/kubernetes/autoscaler/1-35/CHECKSUMS
@@ -1,2 +1,2 @@
-86aaccae7db3f62c9a99218c46b94fdf7963895f59c0601c1cfcf7abd947f58f  _output/1-35/bin/autoscaler/linux-amd64/cluster-autoscaler
-6ef2f978d521bbf3b02d913ca50c693173f4bd80d5549d7b45787d1af9f2738f  _output/1-35/bin/autoscaler/linux-arm64/cluster-autoscaler
+40645f5759f6f82f9c2c65aabaa62d683d2f1a60fb272757d44a01f3eef81878  _output/1-35/bin/autoscaler/linux-amd64/cluster-autoscaler
+d8ed1d11412b9f87be73777e195819e83d0d559e6d7c0846036834fc3ced1102  _output/1-35/bin/autoscaler/linux-arm64/cluster-autoscaler


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/3907

*Description of changes:*
Revert the cluster-autoscaler 1-35 CHECKSUMS that #5595 changed to 86aaccae/6ef2f978.

#5595 updated 1-35/CHECKSUMS based on an anomalous CodeBuild run, but a clean full pipeline run builds the 1-35 binary to the original 40645f57/d8ed1d11 values (unchanged since #5480). 1-35's inputs (GIT_TAG cluster-autoscaler-1.35.0, GOLANG_VERSION 1.25, builder-base) did not change in #5595, so its checksum should not have changed. The 86aaccae value now on main causes autoscaler-1-35 validate-checksums to FAIL, which blocks the build before it reaches 1-36. This restores the correct committed values.

CodeBuild output from the clean run:
```
40645f5759f6f82f9c2c65aabaa62d683d2f1a60fb272757d44a01f3eef81878  _output/1-35/bin/autoscaler/linux-amd64/cluster-autoscaler
d8ed1d11412b9f87be73777e195819e83d0d559e6d7c0846036834fc3ced1102  _output/1-35/bin/autoscaler/linux-arm64/cluster-autoscaler
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.