### PR TITLE
fix(image-builder): Add EPEL config surface for RHEL builds

### DIFF
--- a/projects/aws/image-builder/builder/config.go
+++ b/projects/aws/image-builder/builder/config.go
@@ -1,0 +1,71 @@
+package builder
+
+import (
+	"encoding/json"
+	"log"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// WarnOnUnknownConfigKeys logs a warning for every top-level key in the raw
+// config that the given config type has no field for. Those keys are dropped by
+// json.Unmarshal and never reach Packer, so without this they fail silently.
+//
+// This warns rather than errors on purpose. Unknown keys have always been
+// accepted, so rejecting them now would break configs that build today.
+func WarnOnUnknownConfigKeys(rawConfig []byte, config interface{}, configFlag string) {
+	var provided map[string]json.RawMessage
+	if err := json.Unmarshal(rawConfig, &provided); err != nil {
+		// The typed unmarshal reports malformed JSON with a better message.
+		return
+	}
+
+	known := knownJSONKeys(reflect.TypeOf(config))
+
+	var unknown []string
+	for key := range provided {
+		if _, ok := known[key]; !ok {
+			unknown = append(unknown, key)
+		}
+	}
+	if len(unknown) == 0 {
+		return
+	}
+	sort.Strings(unknown)
+
+	log.Printf("Warning: ignoring unrecognized key(s) in %s: %s. "+
+		"These values are dropped and will not be passed to Packer.",
+		configFlag, strings.Join(unknown, ", "))
+}
+
+// knownJSONKeys collects the json tag names of t, descending into embedded
+// structs because the hypervisor configs compose their fields that way.
+func knownJSONKeys(t reflect.Type) map[string]struct{} {
+	keys := make(map[string]struct{})
+	collectJSONKeys(t, keys)
+	return keys
+}
+
+func collectJSONKeys(t reflect.Type, keys map[string]struct{}) {
+	for t != nil && (t.Kind() == reflect.Ptr || t.Kind() == reflect.Interface) {
+		t = t.Elem()
+	}
+	if t == nil || t.Kind() != reflect.Struct {
+		return
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		if field.Anonymous {
+			collectJSONKeys(field.Type, keys)
+			continue
+		}
+
+		name, _, _ := strings.Cut(field.Tag.Get("json"), ",")
+		if name == "" || name == "-" {
+			continue
+		}
+		keys[name] = struct{}{}
+	}
+}

--- a/projects/aws/image-builder/builder/config_test.go
+++ b/projects/aws/image-builder/builder/config_test.go
@@ -1,0 +1,176 @@
+package builder
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The EPEL keys have to survive the unmarshal/re-marshal the CLI does before it
+// hands the config to Packer as a var file. An explicit empty value is what
+// disables EPEL, so it has to reach Packer; a config that never mentions EPEL
+// must not gain the keys, or every existing RHEL build would lose EPEL.
+func TestBaremetalConfigEpelRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want map[string]interface{}
+	}{
+		{
+			name: "explicit empty values are preserved to disable EPEL",
+			in:   `{"disk_size":"20480","redhat_epel_rpm":"","epel_rpm_gpg_key":""}`,
+			want: map[string]interface{}{
+				"redhat_epel_rpm":  "",
+				"epel_rpm_gpg_key": "",
+			},
+		},
+		{
+			name: "custom mirrors are preserved",
+			in:   `{"redhat_epel_rpm":"https://mirror.internal/epel-release-latest-9.noarch.rpm","epel_rpm_gpg_key":"https://mirror.internal/RPM-GPG-KEY-EPEL-9"}`,
+			want: map[string]interface{}{
+				"redhat_epel_rpm":  "https://mirror.internal/epel-release-latest-9.noarch.rpm",
+				"epel_rpm_gpg_key": "https://mirror.internal/RPM-GPG-KEY-EPEL-9",
+			},
+		},
+		{
+			name: "only one key set leaves the other to the upstream default",
+			in:   `{"redhat_epel_rpm":""}`,
+			want: map[string]interface{}{
+				"redhat_epel_rpm": "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var config BaremetalConfig
+			assert.NoError(t, json.Unmarshal([]byte(tt.in), &config))
+
+			out, err := json.Marshal(config)
+			assert.NoError(t, err)
+
+			var got map[string]interface{}
+			assert.NoError(t, json.Unmarshal(out, &got))
+
+			for key, want := range tt.want {
+				value, present := got[key]
+				assert.Truef(t, present, "%s must reach Packer", key)
+				assert.Equal(t, want, value)
+			}
+		})
+	}
+}
+
+// Guards the regression that a non-pointer field would cause: configs that say
+// nothing about EPEL must not emit the keys at all, otherwise the empty value
+// would disable EPEL for builds that never asked.
+func TestConfigsOmitEpelWhenUnset(t *testing.T) {
+	tests := []struct {
+		name   string
+		config interface{}
+	}{
+		{name: "baremetal", config: &BaremetalConfig{}},
+		{name: "vsphere", config: &VsphereConfig{}},
+		{name: "cloudstack", config: &CloudstackConfig{}},
+		{name: "nutanix", config: &NutanixConfig{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NoError(t, json.Unmarshal([]byte(`{}`), tt.config))
+
+			out, err := json.Marshal(tt.config)
+			assert.NoError(t, err)
+
+			var got map[string]interface{}
+			assert.NoError(t, json.Unmarshal(out, &got))
+
+			assert.NotContains(t, got, "redhat_epel_rpm")
+			assert.NotContains(t, got, "epel_rpm_gpg_key")
+		})
+	}
+}
+
+// Every hypervisor config that embeds RhelConfig has the same defect, so the
+// fix has to cover all of them.
+func TestEpelConfigurableOnAllRhelHypervisors(t *testing.T) {
+	in := []byte(`{"redhat_epel_rpm":"","epel_rpm_gpg_key":""}`)
+
+	assertDisabled := func(t *testing.T, config interface{}) {
+		t.Helper()
+		assert.NoError(t, json.Unmarshal(in, config))
+
+		out, err := json.Marshal(config)
+		assert.NoError(t, err)
+
+		var got map[string]interface{}
+		assert.NoError(t, json.Unmarshal(out, &got))
+		assert.Equal(t, "", got["redhat_epel_rpm"])
+		assert.Equal(t, "", got["epel_rpm_gpg_key"])
+	}
+
+	t.Run("baremetal", func(t *testing.T) { assertDisabled(t, &BaremetalConfig{}) })
+	t.Run("vsphere", func(t *testing.T) { assertDisabled(t, &VsphereConfig{}) })
+	t.Run("cloudstack", func(t *testing.T) { assertDisabled(t, &CloudstackConfig{}) })
+	t.Run("nutanix", func(t *testing.T) { assertDisabled(t, &NutanixConfig{}) })
+}
+
+func TestKnownJSONKeysIncludesEmbeddedFields(t *testing.T) {
+	keys := knownJSONKeys(reflect.TypeOf(&BaremetalConfig{}))
+
+	// Directly declared, and reached through RhelConfig -> EpelConfig and
+	// RhelConfig -> RhsmConfig.
+	for _, key := range []string{"disk_size", "rhel_username", "redhat_epel_rpm", "epel_rpm_gpg_key", "rhsm_org_id", "iso_url", "http_proxy", "extra_rpms"} {
+		assert.Containsf(t, keys, key, "%s should be recognized", key)
+	}
+
+	assert.NotContains(t, keys, "not_a_real_key")
+}
+
+func TestWarnOnUnknownConfigKeys(t *testing.T) {
+	tests := []struct {
+		name       string
+		in         string
+		wantLogged []string
+		wantQuiet  bool
+	}{
+		{
+			name:       "unknown keys are reported",
+			in:         `{"disk_size":"20480","typo_size":"1","another_bogus_key":""}`,
+			wantLogged: []string{"another_bogus_key", "typo_size", "baremetal-config"},
+		},
+		{
+			name:      "recognized keys stay quiet",
+			in:        `{"disk_size":"20480","redhat_epel_rpm":"","rhel_username":"u","rhsm_org_id":"1"}`,
+			wantQuiet: true,
+		},
+		{
+			name:      "malformed json defers to the typed unmarshal error",
+			in:        `{"disk_size":`,
+			wantQuiet: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logged bytes.Buffer
+			log.SetOutput(&logged)
+			defer log.SetOutput(os.Stderr)
+
+			WarnOnUnknownConfigKeys([]byte(tt.in), &BaremetalConfig{}, "baremetal-config")
+
+			if tt.wantQuiet {
+				assert.Empty(t, logged.String())
+				return
+			}
+			for _, want := range tt.wantLogged {
+				assert.Contains(t, logged.String(), want)
+			}
+		})
+	}
+}

--- a/projects/aws/image-builder/builder/types.go
+++ b/projects/aws/image-builder/builder/types.go
@@ -119,6 +119,23 @@ type RhelConfig struct {
 	RhelPassword string `json:"rhel_password"`
 
 	RhsmConfig
+	EpelConfig
+}
+
+// EpelConfig controls the EPEL repository used during RHEL image builds.
+//
+// These are pointers so that "not set" can be told apart from an explicit empty
+// string. An empty string disables EPEL: the upstream RHEL setup tasks skip the
+// gpg key import and the epel-release install when either value is empty, which
+// is what builds in networks that cannot reach the Fedora EPEL mirrors need.
+//
+// A plain string with omitempty would drop that explicit empty value and leave
+// the upstream default in effect, and a plain string without omitempty would
+// emit an empty value for every build that never mentioned EPEL at all,
+// disabling it fleet-wide.
+type EpelConfig struct {
+	RedhatEpelRpm *string `json:"redhat_epel_rpm,omitempty"`
+	EpelRpmGpgKey *string `json:"epel_rpm_gpg_key,omitempty"`
 }
 
 type NutanixConfig struct {

--- a/projects/aws/image-builder/cmd/build.go
+++ b/projects/aws/image-builder/cmd/build.go
@@ -186,6 +186,7 @@ func ValidateInputs(bo *builder.BuildOptions) error {
 			if err = json.Unmarshal(config, &bo.VsphereConfig); err != nil {
 				return err
 			}
+			builder.WarnOnUnknownConfigKeys(config, bo.VsphereConfig, "vsphere-config")
 			if bo.Os == builder.RedHat {
 				isoUrl := bo.VsphereConfig.IsoUrl
 				if bo.BuilderType == builder.BuilderTypeClone {
@@ -213,6 +214,7 @@ func ValidateInputs(bo *builder.BuildOptions) error {
 			if err = json.Unmarshal(config, &bo.BaremetalConfig); err != nil {
 				return err
 			}
+			builder.WarnOnUnknownConfigKeys(config, bo.BaremetalConfig, "baremetal-config")
 			if bo.Os == builder.RedHat {
 				if err = validateRedhat(&bo.BaremetalConfig.RhelConfig, bo.BaremetalConfig.IsoUrl); err != nil {
 					return err
@@ -241,6 +243,7 @@ func ValidateInputs(bo *builder.BuildOptions) error {
 			if err = json.Unmarshal(config, &bo.NutanixConfig); err != nil {
 				return err
 			}
+			builder.WarnOnUnknownConfigKeys(config, bo.NutanixConfig, "nutanix-config")
 
 			if bo.Os == builder.RedHat {
 				if err = validateRedhat(&bo.NutanixConfig.RhelConfig, "Don't check IsoUrl Param"); err != nil {
@@ -273,6 +276,7 @@ func ValidateInputs(bo *builder.BuildOptions) error {
 			if err = json.Unmarshal(config, &bo.CloudstackConfig); err != nil {
 				return err
 			}
+			builder.WarnOnUnknownConfigKeys(config, bo.CloudstackConfig, "cloudstack-config")
 			if bo.Os == builder.RedHat {
 				if err = validateRedhat(&bo.CloudstackConfig.RhelConfig, bo.CloudstackConfig.IsoUrl); err != nil {
 					return err
@@ -313,6 +317,7 @@ func ValidateInputs(bo *builder.BuildOptions) error {
 			if err = json.Unmarshal(config, amiConfig); err != nil {
 				return err
 			}
+			builder.WarnOnUnknownConfigKeys(config, amiConfig, "ami-config")
 
 			bo.AMIConfig = amiConfig
 			bo.FilesConfig = &builder.AdditionalFilesConfig{


### PR DESCRIPTION
BaremetalConfig and the other hypervisor configs that embed RhelConfig had no fields for redhat_epel_rpm/epel_rpm_gpg_key, so Go's typed unmarshal silently dropped these keys before Packer ever saw them. Customers in firewall-restricted networks had no supported way to disable EPEL for RHEL builds.

Add EpelConfig with pointer-typed fields so an explicit empty string (disable EPEL) can be told apart from an unset field (inherit the upstream default). A plain string with omitempty would drop the explicit empty value; a plain string without omitempty would disable EPEL for every build that never mentions it.

Also add WarnOnUnknownConfigKeys, which logs (not errors) unrecognized keys in a hypervisor config so future typos or gaps like this one are visible instead of silently dropped.

sim: https://t.corp.amazon.com/D500679852

*Issue #, if available:*

*Description of changes:*

Adds `EpelConfig` (pointer-typed `RedhatEpelRpm`, `EpelRpmGpgKey`) embedded in `RhelConfig`, so it's picked up by every hypervisor config that supports RHEL (`BaremetalConfig`, `VsphereConfig`, `CloudstackConfig`, `NutanixConfig`). Also adds `WarnOnUnknownConfigKeys` in `builder/config.go`, called from `cmd/build.go` after each hypervisor config's `json.Unmarshal`, to log any top-level JSON key that has no matching field -- warning only, not erroring, so existing configs with typos or extra keys keep building.

**Tested:**
- `gofmt -l`, `go build ./...`, `go vet ./...` all clean
- Unit tests (`builder/config_test.go`, 14 subtests): explicit `""` survives unmarshal→marshal round trip, unset fields stay omitted, all 4 hypervisor configs covered, unknown-key warning fires/stays quiet as expected. All pass (`go test ./...` full suite, no regressions)
- End-to-end on a c5.metal EC2 (Ubuntu 24.04): ran the built CLI against a baremetal config with explicit empty EPEL values + one bogus key. Confirmed via the generated `packer/config/baremetal.json`:
  ```
  {"disk_size":"6656",...,"rhel_username":"test","rhel_password":"test","redhat_epel_rpm":"","epel_rpm_gpg_key":""}
  ```
  Both keys reach Packer as explicit empty strings -- before the fix neither key appeared at all. The unknown-key warning correctly flagged all 5 non-field keys in the test config.
- Confirmed the fix can't turn a silent drop into a build failure: upstream `kubernetes-sigs/image-builder` already declares both keys in `packer/config/common.json` (loaded before our var file per Makefile:54, so our value overrides the default), and `ansible/roles/setup/{tasks/redhat.yml,defaults/main.yml}` consume them to install/skip EPEL.
- Not able to run a full RHEL build locally (no RHEL 9.8 ISO / RHSM subscription / EPEL-blocked network available here) -- validated at the config/unmarshal/marshal + Packer var-file layer, not the booted-node EPEL behavior.

Tradeoff for reviewers: `EpelConfig` is embedded in `RhelConfig` rather than added individually to each hypervisor config, so all 4 configs get the fields at once -- including `NutanixConfig`, which is wider than the baremetal scenario the customer reported. The defect is in `RhelConfig` itself (shared across all 4), so this seemed like the right scope. Narrowing to baremetal-only would mean moving the embed point out of `RhelConfig` into each struct individually, at the cost of duplicating the fields 4 times.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.