### PR TITLE
[release-0.26] Bump capx controller-tools to v0.17.0

### DIFF
--- a/projects/nutanix-cloud-native/cluster-api-provider-nutanix/CHECKSUMS
+++ b/projects/nutanix-cloud-native/cluster-api-provider-nutanix/CHECKSUMS
@@ -1,2 +1,2 @@
-7562e08f9e8f750d09d438c8e5ff8660ded2dc211b6bbb95c278bd0480e2dc0d  _output/bin/cluster-api-provider-nutanix/linux-amd64/manager
-ea944d0a2084d61a2b167637be34bb64357faa4c4e4072ac2a940c02cb57340f  _output/bin/cluster-api-provider-nutanix/linux-arm64/manager
+c3a7bcdc6fc63d375eab557270f5713668012cecba5806fd1b663cbed2963e9a  _output/bin/cluster-api-provider-nutanix/linux-amd64/manager
+c06ca6bf495136241157655fe043477e31d3ae4dd9e3d46828e4cc844d734065  _output/bin/cluster-api-provider-nutanix/linux-arm64/manager

--- a/projects/nutanix-cloud-native/cluster-api-provider-nutanix/Makefile
+++ b/projects/nutanix-cloud-native/cluster-api-provider-nutanix/Makefile
@@ -34,7 +34,7 @@ $(TOOLS_BIN_DIR):
 	@mkdir -p $(TOOLS_BIN_DIR)
 
 $(CONTROLLER_GEN): $(TOOLS_BIN_DIR)
-	GOBIN=$(TOOLS_BIN_DIR) $(GO) install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0
+	GOBIN=$(TOOLS_BIN_DIR) $(GO) install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.17.0
 
 .PHONY: create-manifests
 create-manifests: export PATH:=$(TOOLS_BIN_DIR):$(MAKE_ROOT)/$(OUTPUT_DIR):$(PATH)


### PR DESCRIPTION
*Description of changes:*

controller-gen fails to build in the staging bundle and in the cluster-api-provider-nutanix presubmit:

 ``` 
golang.org/x/tools@v0.16.1/internal/tokeninternal/tokeninternal.go:78:9:
 invalid array length -delta * delta (constant -256 of type int64)
```

controller-tools v0.14.0 pins golang.org/x/tools v0.16.1, which does not compile under Go 1.25. The project declares GOLANG_VERSION 1.23, but builder-base standard-ec39a22a692a667411d582405edec7f191486e52.2 no longer ships Go SDKs below 1.25, so the build silently falls back to go1.25.12.

v0.17.0 is the closest release that clears this: it declares go 1.23.0 and pulls x/tools v0.28.0.

This target is reached from `make release` via
RELEASE_TARGETS -> upload-artifacts -> s3-artifacts -> create-manifests, so it blocks the staging bundle build, not just the presubmit.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

<!-- If this is a security issue, please do not discuss on GitHub. Please report any suspected or confirmed security issues to AWS Security https://aws.amazon.com/security/vulnerability-reporting/ -->
