### PR TITLE
Bump Bottlerocket to v1.64.0 for 1-33 through 1-36

### DIFF
--- a/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
+++ b/projects/kubernetes-sigs/image-builder/BOTTLEROCKET_RELEASES
@@ -15,14 +15,14 @@
   ami-release-version: v1.62.0
   ova-release-version: v1.62.0
 1-33:
-  ami-release-version: v1.62.0
-  ova-release-version: v1.62.0
+  ami-release-version: v1.64.0
+  ova-release-version: v1.64.0
 1-34:
-  ami-release-version: v1.62.0
-  ova-release-version: v1.62.0
+  ami-release-version: v1.64.0
+  ova-release-version: v1.64.0
 1-35:
-  ami-release-version: v1.62.0
-  ova-release-version: v1.62.0
+  ami-release-version: v1.64.0
+  ova-release-version: v1.64.0
 1-36:
-  ami-release-version: v1.62.0
-  ova-release-version: v1.62.0
+  ami-release-version: v1.64.0
+  ova-release-version: v1.64.0


### PR DESCRIPTION
Bumps Bottlerocket `ami-release-version` and `ova-release-version` from v1.62.0 to v1.64.0 for Kubernetes 1-33 through 1-36.

## Why

Picks up a registry mirror regression fix, confirmed by the Bottlerocket team to be included in [v1.64.0](https://github.com/bottlerocket-os/bottlerocket/releases/tag/v1.64.0). The fix ships via the `bottlerocket-core-kit` 14.8.0 -> 15.0.0 bump in that release rather than being called out in the top-level release notes.

## Scope

The regression is specific to containerd v2, so only the affected Kubernetes versions are bumped:

| k8s | before | after |
|---|---|---|
| 1-33 | v1.62.0 | **v1.64.0** |
| 1-34 | v1.62.0 | **v1.64.0** |
| 1-35 | v1.62.0 | **v1.64.0** |
| 1-36 | v1.62.0 | **v1.64.0** |

