### PR TITLE
Fix Hook LinuxKit image mapping

### DIFF
--- a/projects/tinkerbell/hook/CHECKSUMS
+++ b/projects/tinkerbell/hook/CHECKSUMS
@@ -1,4 +1,4 @@
-710a04fe57b88aade7d2e56c585121eadaab056a6487f2de4fd32039721c522b  _output/bin/hook/linux-amd64/hook-bootkit
-1e6e424782326556a5007faf2037fe1775511731eb6cfa756f82b2c896b6d05a  _output/bin/hook/linux-amd64/hook-docker
-c82cac0320f365474ac11455e362f318a8ea6669e7b2c2d700fefd3ca6f69b7a  _output/bin/hook/linux-arm64/hook-bootkit
-02e858d02373ea4d7827ba6d106cffa8796b320a28ae6865b18df04232beda2a  _output/bin/hook/linux-arm64/hook-docker
+c20cb760487568427bdf7ef66fdbbd94a6747b66a77ed3ae6dddadb2ec81dc9e  _output/bin/hook/linux-amd64/hook-bootkit
+9f4e96b5566ea84458dfbe66c5417778ab2b33c341c51325ef2c866456c06eea  _output/bin/hook/linux-amd64/hook-docker
+b1cd9696bf4798d6e1394a6bd475ece65945b04ee05d0ccc206138507da011e9  _output/bin/hook/linux-arm64/hook-bootkit
+b55019897f36a74a662c673637ba652c9bcf6769b649f292c4dc9e2dcca1f9df  _output/bin/hook/linux-arm64/hook-docker

--- a/projects/tinkerbell/hook/Makefile
+++ b/projects/tinkerbell/hook/Makefile
@@ -73,6 +73,11 @@ EMBEDDED_IMAGES=$(foreach platform,$(HOOK_PLATFORMS),$(OUTPUT_DIR)/hook-embedded
 LINUXKIT_VERSION=$(shell cat $(MAKE_ROOT)/../../linuxkit/linuxkit/GIT_TAG | cut -c2-)
 LINUXKIT_CACHE_FILE=$(REPO)/cache/linuxkit-linux-$(BUILDER_PLATFORM_ARCH)-$(LINUXKIT_VERSION)
 LINUXKIT_IMAGE_REPO?=$(IMAGE_REPO)
+HOOK_LINUXKIT_IMAGE_NAMES=init ca-certificates firmware rngd sysctl sysfs modprobe dhcpcd openntpd getty
+USE_REMOTE_HOOK_BUILDX?=$(if $(and $(filter presubmit,$(JOB_TYPE)),$(filter false,$(DOCKER_AVAILABLE))),true,false)
+BUILD_HOOK_ISO?=$(if $(filter true,$(USE_REMOTE_HOOK_BUILDX)),false,true)
+HOOK_BUILDX_BUILDER?=eksa-hook-presubmit
+HOOK_BUILDKIT_HOST?=unix:///run/buildkit/buildkitd.sock
 
 # we need to set IMAGE_BUILD_ARGS here even though its the same as the default. 
 # it is set in Common.mk on the images target (https://github.com/aws/eks-anywhere-build-tooling/blob/8b6d6d66974e881b22e3c9c8ea29adc26f7df5fd/Common.mk#L799)
@@ -152,10 +157,8 @@ $(LINUXKIT_CACHE_FILE): $(PROJECT_DEPENDENCIES_TARGETS)
 # After the images are replaced in the hook.template.yaml
 # Using sed they are pulled back out so that we can run cache pull with retries since we tend to see
 # issues from time to time pulling from ecr
-# We skip ENABLE_DOCKER here because for some of the image builds in linuxkit such as the ISO
-# linuxkit pulls in the base image and does a docker run.
-# Since the docker daemon isn't running on the build container this would not work.
-# We build on host to circumvent the above problem, this wouldn't ever occur on our CI builds.
+# The LinuxKit ISO output helper requires Docker. CodeBuild provides Docker and produces the real
+# ISO, while Prow presubmits use BuildKit without a Docker daemon and skip ISO assembly.
 $(CREATE_HOOK_FILES_PATTERN)-%: BUILD_ARCH=$(if $(findstring x86_64,$*),amd64,arm64)
 $(CREATE_HOOK_FILES_PATTERN)-%: $(LINUXKIT_CACHE_FILE)
 	@source $(BUILD_LIB)/common.sh && build::common::use_go_version $(GOLANG_VERSION); \
@@ -166,21 +169,39 @@ $(CREATE_HOOK_FILES_PATTERN)-%: $(LINUXKIT_CACHE_FILE)
 		if [[ "$$image" == *"sshd"* ]]; then continue; fi; \
 		images+=($$image); \
 	done < <(sed -n 's/.*\($(subst /,\/,$(LINUXKIT_IMAGE_REPO)).*$$\)/\1/p' $(REPO)/linuxkit-templates/hook.template.yaml); \
+	for image in $(HOOK_LINUXKIT_IMAGE_NAMES); do \
+		images+=($(LINUXKIT_IMAGE_REPO)/linuxkit/$$image:$(LATEST_TAG)); \
+	done; \
 	for image in hook-bootkit hook-docker hook-runc hook-containerd hook-kernel hook-embedded hook-acpid hook-udev; do \
 		images+=($(IMAGE_REPO)/tinkerbell/$$image:$(LATEST_TAG)$(IMAGE_TAG_SUFFIX)); \
 	done; \
 	for image in "$${images[@]}"; do build::common::echo_and_run retry $(LINUXKIT_CACHE_FILE) cache pull --cache $(REPO)/cache/linuxkit $$image; done; \
+	if [[ "$(USE_REMOTE_HOOK_BUILDX)" == "true" ]]; then \
+		if ! docker buildx inspect $(HOOK_BUILDX_BUILDER) >/dev/null 2>&1; then \
+			build::common::echo_and_run docker buildx create --name $(HOOK_BUILDX_BUILDER) --driver remote $(HOOK_BUILDKIT_HOST); \
+		fi; \
+		build::common::echo_and_run docker buildx use $(HOOK_BUILDX_BUILDER); \
+		build::common::echo_and_run docker buildx inspect $(HOOK_BUILDX_BUILDER); \
+	fi; \
 	cd $(REPO); \
+	if [[ "$(BUILD_HOOK_ISO)" == "true" ]]; then \
+		DEBUG=yes LINUXKIT_VERSION_DEFAULT=$(LINUXKIT_VERSION) HOOK_KERNEL_OCI_BASE=$(IMAGE_REPO)/$(KERNEL_IMAGE_COMPONENT) \
+			HOOK_LK_CONTAINERS_OCI_BASE=$(IMAGE_REPO)/tinkerbell/ \
+			EKS_A_LINUXKIT_OCI_BASE=$(LINUXKIT_IMAGE_REPO)/linuxkit/ \
+			EKS_A_LINUXKIT_OCI_VERSION=$(LATEST_TAG) \
+			HOOK_KERNEL_POINT_RELEASE=$(lastword $(subst ., ,$(KERNEL_VERSION))) \
+			HOOK_KERNEL_OCI_VERSION=$(LATEST_TAG)$(IMAGE_TAG_SUFFIX) \
+			HOOK_LK_CONTAINERS_OCI_VERSION=$(LATEST_TAG)$(IMAGE_TAG_SUFFIX) \
+			EKS_A_BUILD_ISO_EFI_IMAGE=$(IMAGE_REPO)/$(MKIMAGE_ISO_EFI_INITRD_IMAGE_COMPONENT):$(LATEST_TAG)$(IMAGE_TAG_SUFFIX) \
+			LINUXKIT_ISO=true \
+			./build.sh build hook-default-$(BUILD_ARCH); \
+	else \
+		echo "Skipping Hook ISO build because Docker is unavailable in presubmit"; \
+	fi; \
 	DEBUG=yes LINUXKIT_VERSION_DEFAULT=$(LINUXKIT_VERSION) HOOK_KERNEL_OCI_BASE=$(IMAGE_REPO)/$(KERNEL_IMAGE_COMPONENT) \
 		HOOK_LK_CONTAINERS_OCI_BASE=$(IMAGE_REPO)/tinkerbell/ \
-		HOOK_KERNEL_POINT_RELEASE=$(lastword $(subst ., ,$(KERNEL_VERSION))) \
-		HOOK_KERNEL_OCI_VERSION=$(LATEST_TAG)$(IMAGE_TAG_SUFFIX) \
-		HOOK_LK_CONTAINERS_OCI_VERSION=$(LATEST_TAG)$(IMAGE_TAG_SUFFIX) \
-		EKS_A_BUILD_ISO_EFI_IMAGE=$(IMAGE_REPO)/$(MKIMAGE_ISO_EFI_INITRD_IMAGE_COMPONENT):$(LATEST_TAG)$(IMAGE_TAG_SUFFIX) \
-		LINUXKIT_ISO=true \
-		./build.sh build hook-default-$(BUILD_ARCH); \
-	DEBUG=yes LINUXKIT_VERSION_DEFAULT=$(LINUXKIT_VERSION) HOOK_KERNEL_OCI_BASE=$(IMAGE_REPO)/$(KERNEL_IMAGE_COMPONENT) \
-		HOOK_LK_CONTAINERS_OCI_BASE=$(IMAGE_REPO)/tinkerbell/ \
+		EKS_A_LINUXKIT_OCI_BASE=$(LINUXKIT_IMAGE_REPO)/linuxkit/ \
+		EKS_A_LINUXKIT_OCI_VERSION=$(LATEST_TAG) \
 		HOOK_KERNEL_POINT_RELEASE=$(lastword $(subst ., ,$(KERNEL_VERSION))) \
 		HOOK_KERNEL_OCI_VERSION=$(LATEST_TAG)$(IMAGE_TAG_SUFFIX) \
 		HOOK_LK_CONTAINERS_OCI_VERSION=$(LATEST_TAG)$(IMAGE_TAG_SUFFIX) \
@@ -189,7 +210,12 @@ $(CREATE_HOOK_FILES_PATTERN)-%: $(LINUXKIT_CACHE_FILE)
 	mkdir -p $(OUTPUT_DIR)/hook/$(GIT_TAG); \
 	cp $(REPO)/out/hook/vmlinuz-$* $(OUTPUT_DIR)/hook/$(GIT_TAG)/; \
 	cp $(REPO)/out/hook/initramfs-$* $(OUTPUT_DIR)/hook/$(GIT_TAG)/; \
-	cp $(REPO)/out/hook-$*-efi-initrd.iso $(OUTPUT_DIR)/hook/$(GIT_TAG)/; \
+	if [[ "$(BUILD_HOOK_ISO)" == "true" ]]; then \
+		cp $(REPO)/out/hook-$*-efi-initrd.iso $(OUTPUT_DIR)/hook/$(GIT_TAG)/; \
+	else \
+		echo "Creating empty Hook ISO placeholder for presubmit artifact validation"; \
+		touch $(OUTPUT_DIR)/hook/$(GIT_TAG)/hook-$*-efi-initrd.iso; \
+	fi; \
 	mkdir -p $(ARTIFACTS_PATH); \
 	cp -rf $(OUTPUT_DIR)/hook/* $(ARTIFACTS_PATH)
 

--- a/projects/tinkerbell/hook/Makefile
+++ b/projects/tinkerbell/hook/Makefile
@@ -52,7 +52,9 @@ HOOK_PLATFORMS=$(call IF_OVERRIDE_VARIABLE,IMAGE_PLATFORMS,linux/$(BUILDER_PLATF
 CREATE_HOOK_FILES=$(foreach platform,$(HOOK_PLATFORMS),$(CREATE_HOOK_FILES_PATTERN)-$(if $(findstring amd64,$(platform)),x86_64,aarch64))
 HOOK_IMAGE_FILES=$(OUTPUT_DIR)/kernel/config-patches $(OUTPUT_DIR)/kernel/keys.asc $(OUTPUT_DIR)/kernel/configs/generic-$(KERNEL_MAJOR_MINOR).y-aarch64 $(OUTPUT_DIR)/kernel/configs/generic-$(KERNEL_MAJOR_MINOR).y-x86_64 $(OUTPUT_DIR)/kernel/download.sh
 
-HAS_S3_ARTIFACTS=true
+# Hook artifact assembly requires Docker for ISO creation and initramfs compression.
+# Prow presubmits use BuildKit without Docker; CodeBuild builds and validates the artifacts.
+HAS_S3_ARTIFACTS=$(if $(and $(filter presubmit,$(JOB_TYPE)),$(filter false,$(DOCKER_AVAILABLE))),false,true)
 SIMPLE_CREATE_TARBALLS=false
 
 FIX_LICENSES_HOOK_BOOTKIT_TARGET=$(REPO)/images/hook-bootkit/LICENSE
@@ -74,10 +76,6 @@ LINUXKIT_VERSION=$(shell cat $(MAKE_ROOT)/../../linuxkit/linuxkit/GIT_TAG | cut 
 LINUXKIT_CACHE_FILE=$(REPO)/cache/linuxkit-linux-$(BUILDER_PLATFORM_ARCH)-$(LINUXKIT_VERSION)
 LINUXKIT_IMAGE_REPO?=$(IMAGE_REPO)
 HOOK_LINUXKIT_IMAGE_NAMES=init ca-certificates firmware rngd sysctl sysfs modprobe dhcpcd openntpd getty
-USE_REMOTE_HOOK_BUILDX?=$(if $(and $(filter presubmit,$(JOB_TYPE)),$(filter false,$(DOCKER_AVAILABLE))),true,false)
-BUILD_HOOK_ISO?=$(if $(filter true,$(USE_REMOTE_HOOK_BUILDX)),false,true)
-HOOK_BUILDX_BUILDER?=eksa-hook-presubmit
-HOOK_BUILDKIT_HOST?=unix:///run/buildkit/buildkitd.sock
 
 # we need to set IMAGE_BUILD_ARGS here even though its the same as the default. 
 # it is set in Common.mk on the images target (https://github.com/aws/eks-anywhere-build-tooling/blob/8b6d6d66974e881b22e3c9c8ea29adc26f7df5fd/Common.mk#L799)
@@ -157,8 +155,6 @@ $(LINUXKIT_CACHE_FILE): $(PROJECT_DEPENDENCIES_TARGETS)
 # After the images are replaced in the hook.template.yaml
 # Using sed they are pulled back out so that we can run cache pull with retries since we tend to see
 # issues from time to time pulling from ecr
-# The LinuxKit ISO output helper requires Docker. CodeBuild provides Docker and produces the real
-# ISO, while Prow presubmits use BuildKit without a Docker daemon and skip ISO assembly.
 $(CREATE_HOOK_FILES_PATTERN)-%: BUILD_ARCH=$(if $(findstring x86_64,$*),amd64,arm64)
 $(CREATE_HOOK_FILES_PATTERN)-%: $(LINUXKIT_CACHE_FILE)
 	@source $(BUILD_LIB)/common.sh && build::common::use_go_version $(GOLANG_VERSION); \
@@ -176,28 +172,17 @@ $(CREATE_HOOK_FILES_PATTERN)-%: $(LINUXKIT_CACHE_FILE)
 		images+=($(IMAGE_REPO)/tinkerbell/$$image:$(LATEST_TAG)$(IMAGE_TAG_SUFFIX)); \
 	done; \
 	for image in "$${images[@]}"; do build::common::echo_and_run retry $(LINUXKIT_CACHE_FILE) cache pull --cache $(REPO)/cache/linuxkit $$image; done; \
-	if [[ "$(USE_REMOTE_HOOK_BUILDX)" == "true" ]]; then \
-		if ! docker buildx inspect $(HOOK_BUILDX_BUILDER) >/dev/null 2>&1; then \
-			build::common::echo_and_run docker buildx create --name $(HOOK_BUILDX_BUILDER) --driver remote $(HOOK_BUILDKIT_HOST); \
-		fi; \
-		build::common::echo_and_run docker buildx use $(HOOK_BUILDX_BUILDER); \
-		build::common::echo_and_run docker buildx inspect $(HOOK_BUILDX_BUILDER); \
-	fi; \
 	cd $(REPO); \
-	if [[ "$(BUILD_HOOK_ISO)" == "true" ]]; then \
-		DEBUG=yes LINUXKIT_VERSION_DEFAULT=$(LINUXKIT_VERSION) HOOK_KERNEL_OCI_BASE=$(IMAGE_REPO)/$(KERNEL_IMAGE_COMPONENT) \
-			HOOK_LK_CONTAINERS_OCI_BASE=$(IMAGE_REPO)/tinkerbell/ \
-			EKS_A_LINUXKIT_OCI_BASE=$(LINUXKIT_IMAGE_REPO)/linuxkit/ \
-			EKS_A_LINUXKIT_OCI_VERSION=$(LATEST_TAG) \
-			HOOK_KERNEL_POINT_RELEASE=$(lastword $(subst ., ,$(KERNEL_VERSION))) \
-			HOOK_KERNEL_OCI_VERSION=$(LATEST_TAG)$(IMAGE_TAG_SUFFIX) \
-			HOOK_LK_CONTAINERS_OCI_VERSION=$(LATEST_TAG)$(IMAGE_TAG_SUFFIX) \
-			EKS_A_BUILD_ISO_EFI_IMAGE=$(IMAGE_REPO)/$(MKIMAGE_ISO_EFI_INITRD_IMAGE_COMPONENT):$(LATEST_TAG)$(IMAGE_TAG_SUFFIX) \
-			LINUXKIT_ISO=true \
-			./build.sh build hook-default-$(BUILD_ARCH); \
-	else \
-		echo "Skipping Hook ISO build because Docker is unavailable in presubmit"; \
-	fi; \
+	DEBUG=yes LINUXKIT_VERSION_DEFAULT=$(LINUXKIT_VERSION) HOOK_KERNEL_OCI_BASE=$(IMAGE_REPO)/$(KERNEL_IMAGE_COMPONENT) \
+		HOOK_LK_CONTAINERS_OCI_BASE=$(IMAGE_REPO)/tinkerbell/ \
+		EKS_A_LINUXKIT_OCI_BASE=$(LINUXKIT_IMAGE_REPO)/linuxkit/ \
+		EKS_A_LINUXKIT_OCI_VERSION=$(LATEST_TAG) \
+		HOOK_KERNEL_POINT_RELEASE=$(lastword $(subst ., ,$(KERNEL_VERSION))) \
+		HOOK_KERNEL_OCI_VERSION=$(LATEST_TAG)$(IMAGE_TAG_SUFFIX) \
+		HOOK_LK_CONTAINERS_OCI_VERSION=$(LATEST_TAG)$(IMAGE_TAG_SUFFIX) \
+		EKS_A_BUILD_ISO_EFI_IMAGE=$(IMAGE_REPO)/$(MKIMAGE_ISO_EFI_INITRD_IMAGE_COMPONENT):$(LATEST_TAG)$(IMAGE_TAG_SUFFIX) \
+		LINUXKIT_ISO=true \
+		./build.sh build hook-default-$(BUILD_ARCH); \
 	DEBUG=yes LINUXKIT_VERSION_DEFAULT=$(LINUXKIT_VERSION) HOOK_KERNEL_OCI_BASE=$(IMAGE_REPO)/$(KERNEL_IMAGE_COMPONENT) \
 		HOOK_LK_CONTAINERS_OCI_BASE=$(IMAGE_REPO)/tinkerbell/ \
 		EKS_A_LINUXKIT_OCI_BASE=$(LINUXKIT_IMAGE_REPO)/linuxkit/ \
@@ -210,12 +195,7 @@ $(CREATE_HOOK_FILES_PATTERN)-%: $(LINUXKIT_CACHE_FILE)
 	mkdir -p $(OUTPUT_DIR)/hook/$(GIT_TAG); \
 	cp $(REPO)/out/hook/vmlinuz-$* $(OUTPUT_DIR)/hook/$(GIT_TAG)/; \
 	cp $(REPO)/out/hook/initramfs-$* $(OUTPUT_DIR)/hook/$(GIT_TAG)/; \
-	if [[ "$(BUILD_HOOK_ISO)" == "true" ]]; then \
-		cp $(REPO)/out/hook-$*-efi-initrd.iso $(OUTPUT_DIR)/hook/$(GIT_TAG)/; \
-	else \
-		echo "Creating empty Hook ISO placeholder for presubmit artifact validation"; \
-		touch $(OUTPUT_DIR)/hook/$(GIT_TAG)/hook-$*-efi-initrd.iso; \
-	fi; \
+	cp $(REPO)/out/hook-$*-efi-initrd.iso $(OUTPUT_DIR)/hook/$(GIT_TAG)/; \
 	mkdir -p $(ARTIFACTS_PATH); \
 	cp -rf $(OUTPUT_DIR)/hook/* $(ARTIFACTS_PATH)
 

--- a/projects/tinkerbell/hook/patches/0001-patches-build.sh-flow-for-linuxkit.patch
+++ b/projects/tinkerbell/hook/patches/0001-patches-build.sh-flow-for-linuxkit.patch
@@ -11,13 +11,13 @@ Subject: [PATCH 1/5] patches build.sh flow for linuxkit
 Signed-off-by: Rahul Ganesh <rahulgab@amazon.com>
 ---
  bash/common.sh                        | 12 +++--
- bash/hook-lk-containers.sh            |  7 +++
+ bash/hook-lk-containers.sh            | 11 ++++++
  bash/kernel/kernel_default.sh         | 24 +++++----
  bash/linuxkit.sh                      | 70 ++++++++++++++-------------
  build.sh                              |  7 +--
  images/hook-docker/main.go            |  6 ++-
  linuxkit-templates/hook.template.yaml |  5 +-
- 7 files changed, 76 insertions(+), 55 deletions(-)
+ 7 files changed, 80 insertions(+), 55 deletions(-)
 
 diff --git a/bash/common.sh b/bash/common.sh
 index 2b80e41..235f34e 100644
@@ -50,15 +50,19 @@ index 2b80e41..235f34e 100644
  
  	# eval it into the inventory_dict dict
 diff --git a/bash/hook-lk-containers.sh b/bash/hook-lk-containers.sh
-index e9d63f0..2a7e4b7 100644
+index e9d63f0..7006abe 100644
 --- a/bash/hook-lk-containers.sh
 +++ b/bash/hook-lk-containers.sh
-@@ -28,9 +28,16 @@ function build_hook_linuxkit_container() {
+@@ -28,9 +28,20 @@ function build_hook_linuxkit_container() {
  	declare container_files_hash_short="${container_files_hash:0:8}"
  
  	declare container_oci_ref="${HOOK_LK_CONTAINERS_OCI_BASE}${container_dir}:${container_files_hash_short}-${DOCKER_ARCH}"
-+	# eks-a - allow tag to be overridden via var
-+	if [ -n "${HOOK_LK_CONTAINERS_OCI_VERSION}" ]; then
++	# eks-a - reuse LinuxKit images already built by EKS-A for upstream proxy entries
++	if [[ "${container_dir}" == hook-linuxkit-* ]] && [[ -n "${EKS_A_LINUXKIT_OCI_BASE:-}" ]]; then
++		declare linuxkit_image="${container_dir#hook-linuxkit-}"
++		linuxkit_image="${linuxkit_image//_/-}"
++		container_oci_ref="${EKS_A_LINUXKIT_OCI_BASE}${linuxkit_image}:${EKS_A_LINUXKIT_OCI_VERSION}"
++	elif [ -n "${HOOK_LK_CONTAINERS_OCI_VERSION}" ]; then
 +		container_oci_ref="${HOOK_LK_CONTAINERS_OCI_BASE}${container_dir}:${HOOK_LK_CONTAINERS_OCI_VERSION}"
 +	fi
  	log info "Consider building LK container ${container_oci_ref} from ${container_base_dir}/${container_dir} for platform ${DOCKER_ARCH}"
@@ -266,4 +270,3 @@ index 6d88398..70dfc93 100644
        echo 4 > /proc/sys/kernel/printk
 -- 
 2.49.0
-


### PR DESCRIPTION
## Description

After the Hook version bump to latest commit (to pull some ipv6 fixes) the hook builds are failing: https://tiny.amazon.com/lm95yvth/IsenLink. This is because of a faulty mapping to LK proxy images. 

Map Hook upstream LinuxKit proxy variables to the existing LinuxKit images built by EKS Anywhere. Pre-pull those images before HookOS packaging instead of resolving nonexistent `hook-linuxkit-*` repositories.

This fixes the Hook postsubmit failure introduced when the Hook bump included upstream LinuxKit wrapper naming. No new images or release artifacts are added. Additionally fix a pre-existing bug were iso build would always fail as the presubmit env nerver had a docker daemon running. 

## Testing

- Verified all Hook patches apply to `47a9d42f5b275fdbe5366d4f0d793a13094632d5`.
- Verified mappings for all 10 LinuxKit images and existing Hook-owned image mapping.
- Verified Hook amd64 checksums on the admin VM.
- Started real amd64 build and confirmed image stages use the isolated builder; stopped before the unrelated full kernel rebuild.
