### PR TITLE
fix(image-builder): match retryable packer errors case-insensitively

### DIFF
--- a/projects/kubernetes-sigs/image-builder/build/build_image.sh
+++ b/projects/kubernetes-sigs/image-builder/build/build_image.sh
@@ -76,7 +76,9 @@ function retry_image_builder() {
       local retry="false"
       local message=""
       for key in "${!retryable_messages[@]}"; do
-        if grep -q "$key" "$log_file"; then
+        # -i: packer's casing varies between versions and builders, e.g. it emits
+        # "timeout waiting for IP address" while the key below reads "Timeout waiting for IP."
+        if grep -qi "$key" "$log_file"; then
           message="${retryable_messages[$key]}"
           retry="true"
           break


### PR DESCRIPTION
## Problem

`retry_image_builder` never retries on the most common transient vSphere failure.

Packer emits lowercase:

```
Build 'vsphere-iso.vsphere' errored after 31 minutes 13 seconds: timeout waiting for IP address
```

but the retryable key is `"Timeout waiting for IP."` and the match uses `grep -q`, which is case-sensitive. So the pattern never fires, `retry` stays `false`, and the build exits immediately:

```
The command has failed after 1 attempts.
```

Reproduced locally against that exact packer line:

```
grep -q  'Timeout waiting for IP.'  -> no match   (current behaviour, no retry)
grep -qi 'Timeout waiting for IP.'  -> MATCH      (with this fix, retries)
```


## Fix

`grep -q` -> `grep -qi`. One-line, applies to all seven patterns, none of which need case sensitivity to stay correct.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
